### PR TITLE
Build yml should use .pdb extension

### DIFF
--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -433,7 +433,7 @@ def detect_project(
                     logger.info("Found %s -> %s", target_id, pdb)
                     build_data.setdefault("targets", {}).setdefault(
                         target_id, {}
-                    ).setdefault("pdb", str(p))
+                    ).setdefault("pdb", str(pdb))
                     break
             else:
                 logger.warning("Could not find %s", filename)


### PR DESCRIPTION
Minor bugfix for `reccmp-project` generating the reccmp-build.yml file. The "pdb" key used the same filename as the "path" key, as in:

```yaml
  LEGO1:
    path: C:\path\to\build-dir\LEGO1.DLL
    pdb: C:\path\to\build-dir\LEGO1.DLL
```

This worked anyway because cvdump grabs the pdb if it is in the same directory as the binary. If we ever change that dependency then the filename will matter.