### PR TITLE
Improve DB performance and code clarity

### DIFF
--- a/reccmp/isledecomp/types.py
+++ b/reccmp/isledecomp/types.py
@@ -1,9 +1,9 @@
 """Types shared by other modules"""
 
-from enum import Enum
+from enum import IntEnum
 
 
-class SymbolType(Enum):
+class SymbolType(IntEnum):
     """Broadly tells us what kind of comparison is required for this symbol."""
 
     FUNCTION = 1

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -13,7 +13,7 @@ def test_ignore_recomp_collision(db):
     """Duplicate recomp addresses are ignored"""
     db.set_recomp_symbol(0x1234, None, "hello", None, 100)
     db.set_recomp_symbol(0x1234, None, "alias_for_hello", None, 100)
-    syms = db.get_all()
+    syms = [*db.get_all()]
     assert len(syms) == 1
 
 
@@ -52,7 +52,7 @@ def test_duplicate_name(db):
     db.set_recomp_symbol(0x200, None, "_Construct", None, 100)
     db.set_recomp_symbol(0x300, None, "_Construct", None, 100)
     db.match_function(0x5555, "_Construct")
-    matches = db.get_matches()
+    matches = [*db.get_matches()]
     # We aren't testing _which_ one would be matched, just that only one _was_ matched
     assert len(matches) == 1
 


### PR DESCRIPTION
Some tweaks to the database before rolling out a new feature (dynamic metadata) I've been working on. The goal here is to optimize the current design and then evaluate the performance shift of the upcoming changes.

- Bulk inserts of data. The biggest users of `set_recomp_symbol` are `load_cvdump` and `match_array_elements`, and both now run the `INSERT` statement using `executemany` instead of calling `execute` repeatedly. It seems cleaner to do it this way when possible, and I think we are cutting at least some overhead by directly reusing the prepared SQL statement instead of relying on the statement cache.

- Unique indices on `orig_addr` and `recomp_addr`. I remember testing this way back and found that performance dropped, so my conclusion was that it was just faster to test each row before inserting. The real problem is that the main search query checking `WHERE orig_addr IS NULL` now prefers the unique index on `orig_addr`, which is a full table scan if all are NULL. It should use the better index on the name field. If you nudge the optimizer to avoid `orig_addr` then it runs fine.

- Some methods return `cur.fetchall()` when returning a generator with `yield from` works better. I had the wrong type annotations in some of these places too.

- SymbolType enum is now an `enum.IntEnum`. This eliminates the call to the SymbolType constructor when fetching out of the database, along with some other code to set up query parameters. We can still do equality checks and test types using `mypy`. When converting the compare_type to its string representation in `match_name`, it is faster to just use a lookup. Maybe this means we should really have `enum.StrEnum` instead with the names of these types.

- `match_vtable` and `match_static_variable` were a little confusing to read. Both look better now.