### PR TITLE
Ghidra ignore list, config file pydantic refactor

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,4 +19,5 @@ jobs:
       shell: bash
       run: |
         pylint reccmp
-        black --check reccmp
+        pylint tests
+        black --check .

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -1,0 +1,71 @@
+"""Types for the configuration of a reccmp project"""
+
+from pathlib import Path
+from dataclasses import dataclass
+
+from pydantic import AliasChoices, BaseModel, Field
+
+
+class GhidraConfig(BaseModel):
+    ignore_types: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("ignore-types", "ignore_types"),
+    )
+    ignore_functions: list[int] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("ignore-functions", "ignore_functions"),
+    )
+
+    @classmethod
+    def default(cls) -> "GhidraConfig":
+        return cls(ignore_types=[], ignore_functions=[])
+
+
+@dataclass
+class RecCmpTarget:
+    target_id: str
+    filename: str
+    source_root: Path
+    ghidra_config: GhidraConfig
+
+
+@dataclass
+class RecCmpBuiltTarget(RecCmpTarget):
+    original_path: Path
+    recompiled_path: Path
+    recompiled_pdb: Path
+
+
+class Hash(BaseModel):
+    sha256: str
+
+
+class ProjectFileTarget(BaseModel):
+    filename: str
+    source_root: Path = Field(
+        validation_alias=AliasChoices("source-root", "source_root")
+    )
+    hash: Hash
+    ghidra: GhidraConfig = Field(default_factory=GhidraConfig.default)
+
+
+class ProjectFile(BaseModel):
+    targets: dict[str, ProjectFileTarget]
+
+
+class UserFileTarget(BaseModel):
+    path: Path
+
+
+class UserFile(BaseModel):
+    targets: dict[str, UserFileTarget]
+
+
+class BuildFileTarget(BaseModel):
+    path: Path
+    pdb: Path
+
+
+class BuildFile(BaseModel):
+    project: Path
+    targets: dict[str, BuildFileTarget]

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -4,6 +4,7 @@ import enum
 import logging
 from pathlib import Path
 import typing
+from pydantic import BaseModel, Field
 
 import ruamel.yaml
 
@@ -35,10 +36,45 @@ class RecCmpBuiltTarget(RecCmpTarget):
     recompiled_pdb: Path
 
 
+class Hash(BaseModel):
+    sha256: str
+
+
+class ProjectFileTarget(BaseModel):
+    filename: str  # TODO: change to Path, see if this works
+    source_root: str = Field(
+        validation_alias="source-root"
+    )  # TODO: how to parse with hyphen
+    hash: Hash
+    # ghidra: ... # TODO
+
+
+class ProjectFile(BaseModel):
+    targets: dict[str, ProjectFileTarget]
+
+
+class UserFileTarget(BaseModel):
+    path: str  # TODO: change to path if possible
+
+
+class UserFile(BaseModel):
+    targets: dict[str, UserFileTarget]
+
+
+class BuildFileTarget(BaseModel):
+    path: str  # TODO: change to path if possible
+    pdb: str
+
+
+class BuildFile(BaseModel):
+    project: str
+    targets: dict[str, BuildFileTarget]
+
+
 def verify_target_names(
-    project_targets: dict[str, typing.Any],
-    user_targets: dict[str, typing.Any],
-    build_targets: dict[str, typing.Any],
+    project_targets: dict[str, ProjectFileTarget],
+    user_targets: dict[str, UserFileTarget],
+    build_targets: dict[str, BuildFileTarget],
 ):
     project_keys = set(project_targets.keys())
     user_keys = set(user_targets.keys())

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -6,7 +6,17 @@ import typing
 
 import ruamel.yaml
 
-from .config import BuildFile, BuildFileTarget, GhidraConfig, ProjectFile, ProjectFileTarget, RecCmpBuiltTarget, RecCmpTarget, UserFile, UserFileTarget
+from .config import (
+    BuildFile,
+    BuildFileTarget,
+    GhidraConfig,
+    ProjectFile,
+    ProjectFileTarget,
+    RecCmpBuiltTarget,
+    RecCmpTarget,
+    UserFile,
+    UserFileTarget,
+)
 
 from .common import RECCMP_USER_CONFIG, RECCMP_BUILD_CONFIG, RECCMP_PROJECT_CONFIG
 from .error import (
@@ -20,6 +30,7 @@ from .util import get_path_sha256
 
 
 logger = logging.getLogger(__file__)
+
 
 def verify_target_names(
     project_targets: dict[str, ProjectFileTarget],
@@ -123,7 +134,9 @@ class RecCmpBuiltProject:
             directory=directory, filename=RECCMP_BUILD_CONFIG
         )
         if not build_directory:
-            raise RecCmpProjectNotFoundException(f"Cannot find {RECCMP_BUILD_CONFIG}")
+            raise RecCmpProjectNotFoundException(
+                f"Cannot find {RECCMP_BUILD_CONFIG} under {build_directory}"
+            )
         build_config = build_directory / RECCMP_BUILD_CONFIG
         logger.debug("Using build config: %s", build_config)
         yaml_loader = ruamel.yaml.YAML()
@@ -183,11 +196,6 @@ class RecCmpBuiltProject:
 
             source_root = project_directory / project_target_data.source_root
             filename = project_target_data.filename
-            if not filename:
-                raise InvalidRecCmpProjectException(
-                    f"{project_config_path}: targets.{target_id}.filename is missing"
-                )
-
             original_path = user_target_data.path
 
             recompiled_path = build_directory.joinpath(build_target_data.path)
@@ -391,7 +399,9 @@ def detect_project(
                 logger.info("Found %s -> %s", target_id, p)
                 break
             else:
-                logger.warning("Could not find %s under %s", filename, search_path_folder)
+                logger.warning(
+                    "Could not find %s under %s", filename, search_path_folder
+                )
 
         logger.info("Updating %s", user_config_path)
         with user_config_path.open("w") as f:

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -1,12 +1,12 @@
 import argparse
-import dataclasses
 import enum
 import logging
 from pathlib import Path
 import typing
-from pydantic import BaseModel, Field
 
 import ruamel.yaml
+
+from .config import BuildFile, BuildFileTarget, GhidraConfig, ProjectFile, ProjectFileTarget, RecCmpBuiltTarget, RecCmpTarget, UserFile, UserFileTarget
 
 from .common import RECCMP_USER_CONFIG, RECCMP_BUILD_CONFIG, RECCMP_PROJECT_CONFIG
 from .error import (
@@ -20,68 +20,6 @@ from .util import get_path_sha256
 
 
 logger = logging.getLogger(__file__)
-
-
-class GhidraConfig(BaseModel):
-    ignore_types: list[str] = Field(
-        default_factory=list, validation_alias="ignore-types"
-    )
-    ignore_functions: list[int] = Field(
-        default_factory=list, validation_alias="ignore-functions"
-    )
-
-    @classmethod
-    def default(cls) -> "GhidraConfig":
-        return cls(ignore_types=[], ignore_functions=[])
-
-
-@dataclasses.dataclass
-class RecCmpTarget:
-    target_id: str
-    filename: str
-    source_root: Path
-    ghidra_config: GhidraConfig
-
-
-@dataclasses.dataclass
-class RecCmpBuiltTarget(RecCmpTarget):
-    original_path: Path
-    recompiled_path: Path
-    recompiled_pdb: Path
-
-
-class Hash(BaseModel):
-    sha256: str
-
-
-class ProjectFileTarget(BaseModel):
-    filename: str
-    source_root: Path = Field(validation_alias="source-root")
-    hash: Hash
-    ghidra: GhidraConfig = Field(default_factory=GhidraConfig.default)
-
-
-class ProjectFile(BaseModel):
-    targets: dict[str, ProjectFileTarget]
-
-
-class UserFileTarget(BaseModel):
-    path: Path
-
-
-class UserFile(BaseModel):
-    targets: dict[str, UserFileTarget]
-
-
-class BuildFileTarget(BaseModel):
-    path: Path
-    pdb: Path
-
-
-class BuildFile(BaseModel):
-    project: Path
-    targets: dict[str, BuildFileTarget]
-
 
 def verify_target_names(
     project_targets: dict[str, ProjectFileTarget],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 capstone
 colorama>=0.4.6
 pystache
+pydantic==2.9.2
 ruamel.yaml
 pydemangler @ git+https://github.com/wbenny/pydemangler.git
 # requirement of capstone due to python dropping distutils.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import hashlib
+import pytest
 
 from reccmp.isledecomp.bin import (
     Bin as IsleBin,
 )
-import pytest
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import hashlib
+from typing import Iterator
 import pytest
 
 from reccmp.isledecomp.bin import (
@@ -16,7 +17,7 @@ LEGO1_SHA256 = "14645225bbe81212e9bc1919cd8a692b81b8622abb6561280d99b0fc4151ce17
 
 
 @pytest.fixture(name="binfile", scope="session")
-def fixture_binfile(pytestconfig) -> IsleBin:
+def fixture_binfile(pytestconfig) -> Iterator[IsleBin]:
     filename = pytestconfig.getoption("--lego1")
 
     # Skip this if we have not provided the path to LEGO1.dll.

--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -3,7 +3,6 @@
 2. Provides an interface to read from the DLL or EXE using a virtual address.
 These are some basic smoke tests."""
 
-import hashlib
 from typing import Tuple
 import pytest
 from reccmp.isledecomp.bin import (

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,7 +17,7 @@ def test_project_loading(tmp_path_factory, binfile):
               LEGO1:
                 filename: LEGO1.dll
                 source-root: sources
-                hashes:
+                hash:
                   sha256: {LEGO1_SHA256}
             """
         )
@@ -70,7 +70,7 @@ def test_project_original_detection(tmp_path_factory, binfile):
               LEGO1:
                 filename: LEGO1.dll
                 source-root: sources
-                hashes:
+                hash:
                   sha256: {LEGO1_SHA256}
             """
         )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 import textwrap
 
-from .conftest import LEGO1_SHA256
 from reccmp.project.create import create_project, RecCmpProject
 from reccmp.project.detect import detect_project, DetectWhat, RecCmpBuiltProject
+from .conftest import LEGO1_SHA256
 
 
 def test_project_loading(tmp_path_factory, binfile):
@@ -45,6 +45,7 @@ def test_project_loading(tmp_path_factory, binfile):
         )
     )
     project = RecCmpProject.from_directory(project_root)
+    assert project is not None
     assert len(project.targets) == 1
     assert "LEGO1" in project.targets
     assert project.targets["LEGO1"].target_id == "LEGO1"
@@ -75,12 +76,12 @@ def test_project_original_detection(tmp_path_factory, binfile):
         )
     )
     bin_path = Path(binfile.filename)
-    project = detect_project(
+    detect_project(
         project_directory=project_root,
         search_path=[bin_path.parent],
-        detect_what=DetectWhat.ORIGINAL)
+        detect_what=DetectWhat.ORIGINAL,
+    )
     assert (project_root / "reccmp-user.yml").is_file()
-
 
 
 def test_project_creation(tmp_path_factory, binfile):
@@ -88,7 +89,9 @@ def test_project_creation(tmp_path_factory, binfile):
     bin_path = Path(binfile.filename)
     project_config_path = project_root / "reccmp-project.yml"
     user_config_path = project_root / "reccmp-user.yml"
-    project = create_project(project_directory=project_root, original_paths=[bin_path], scm=True, cmake=True)
+    project = create_project(
+        project_directory=project_root, original_paths=[bin_path], scm=True, cmake=True
+    )
     assert project_config_path.is_file()
     assert user_config_path.is_file()
     target_name = bin_path.stem.upper()


### PR DESCRIPTION
Major changes:

### Pydantic
We now use [pydantic](https://docs.pydantic.dev/latest/) to parse and verify config files, as briefly discussed on Matrix
Note that some missing fields are now hard errors, which previously would (partially) lead to targets being skipped. This can be changed in case you encounter signficant issues, but an *incomplete* target should, in my opinion, raise an error while a missing target can be skipped.

### Ghidra import deny list

Implements one feature of #13 
We can now skip types and functions in the Ghidra import like so:
```yaml
targets:
  BETA10:
    ghidra:
      ignore-types:
        # these classes have been changed by hand to account for changes between LEGO1 and BETA10
        - LegoCarBuild
        - LegoWorld
        - LegoCarBuildAnimPresenter
      ignore-functions: []
        # for potential future use, currently empty
```
I will PR this change on `isle` when this one is merged.

### Linting and formatting for unit tests
The tests are now also covered by `pylint` and `black`. I'm open for discussion in case you don't like it.