### PR TITLE
Unified read function for decomp parser/linter

### DIFF
--- a/reccmp/isledecomp/parser/codebase.py
+++ b/reccmp/isledecomp/parser/codebase.py
@@ -19,7 +19,7 @@ class DecompCodebase:
         for filename in filenames:
             parser.reset()
             with open(filename, "r", encoding="utf-8") as f:
-                parser.read_lines(f)
+                parser.read(f.read())
 
             for sym in parser.iter_symbols(module):
                 sym.filename = filename

--- a/reccmp/isledecomp/parser/linter.py
+++ b/reccmp/isledecomp/parser/linter.py
@@ -115,15 +115,12 @@ class DecompLinter:
                     )
                 )
 
-    def check_lines(self, lines, filename, module=None):
-        """`lines` is a generic iterable to allow for testing with a list of strings.
-        We assume lines has the entire contents of the compilation unit."""
-
+    def read(self, code: str, filename: str, module=None) -> bool:
         self.reset(False)
         self._filename = filename
         self._module = module
 
-        self._parser.read_lines(lines)
+        self._parser.read(code)
 
         self._parser.finish()
         self.alerts = self._parser.alerts[::]
@@ -138,7 +135,7 @@ class DecompLinter:
 
         return len(self.alerts) == 0
 
-    def check_file(self, filename, module=None):
+    def check_file(self, filename: str, module=None):
         """Convenience method for decomplint cli tool"""
         with open(filename, "r", encoding="utf-8") as f:
-            return self.check_lines(f, filename, module)
+            return self.read(f.read(), filename, module)

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -1,6 +1,7 @@
 # C++ file parser
 
-from typing import List, Iterable, Iterator, Optional
+import io
+from typing import List, Iterator, Optional
 from enum import Enum
 from .util import (
     get_class_name,
@@ -545,8 +546,8 @@ class DecompParser:
             if vtable_class is not None:
                 self._vtable_done(class_name=vtable_class)
 
-    def read_lines(self, lines: Iterable):
-        for line in lines:
+    def read(self, text: str):
+        for line in io.StringIO(text, newline=None):
             self.read_line(line)
 
     def finish(self):

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -9,27 +9,27 @@ def fixture_linter():
 
 
 def test_simple_in_order(linter):
-    lines = [
-        "// FUNCTION: TEST 0x1000",
-        "void function1() {}",
-        "// FUNCTION: TEST 0x2000",
-        "void function2() {}",
-        "// FUNCTION: TEST 0x3000",
-        "void function3() {}",
-    ]
-    assert linter.check_lines(lines, "test.cpp", "TEST") is True
+    code = """\
+        // FUNCTION: TEST 0x1000
+        void function1() {}
+        // FUNCTION: TEST 0x2000
+        void function2() {}
+        // FUNCTION: TEST 0x3000
+        void function3() {}
+        """
+    assert linter.read(code, "test.cpp", "TEST") is True
 
 
 def test_simple_not_in_order(linter):
-    lines = [
-        "// FUNCTION: TEST 0x1000",
-        "void function1() {}",
-        "// FUNCTION: TEST 0x3000",
-        "void function3() {}",
-        "// FUNCTION: TEST 0x2000",
-        "void function2() {}",
-    ]
-    assert linter.check_lines(lines, "test.cpp", "TEST") is False
+    code = """\
+        // FUNCTION: TEST 0x1000
+        void function1() {}
+        // FUNCTION: TEST 0x3000
+        void function3() {}
+        // FUNCTION: TEST 0x2000
+        void function2() {}
+        """
+    assert linter.read(code, "test.cpp", "TEST") is False
     assert len(linter.alerts) == 1
 
     assert linter.alerts[0].code == ParserError.FUNCTION_OUT_OF_ORDER
@@ -39,16 +39,16 @@ def test_simple_not_in_order(linter):
 
 def test_byname_ignored(linter):
     """Should ignore lookup-by-name markers when checking order."""
-    lines = [
-        "// FUNCTION: TEST 0x1000",
-        "void function1() {}",
-        "// FUNCTION: TEST 0x3000",
-        "// MyClass::MyMethod",
-        "// FUNCTION: TEST 0x2000",
-        "void function2() {}",
-    ]
+    code = """\
+        // FUNCTION: TEST 0x1000
+        void function1() {}
+        // FUNCTION: TEST 0x3000
+        // MyClass::MyMethod
+        // FUNCTION: TEST 0x2000
+        void function2() {}
+        """
     # This will fail because byname lookup does not belong in the cpp file
-    assert linter.check_lines(lines, "test.cpp", "TEST") is False
+    assert linter.read(code, "test.cpp", "TEST") is False
     # but it should not fail for function order.
     assert all(
         alert.code != ParserError.FUNCTION_OUT_OF_ORDER for alert in linter.alerts
@@ -57,49 +57,49 @@ def test_byname_ignored(linter):
 
 def test_module_isolation(linter):
     """Should check the order of markers from a single module only."""
-    lines = [
-        "// FUNCTION: ALPHA 0x0001",
-        "// FUNCTION: TEST 0x1000",
-        "void function1() {}",
-        "// FUNCTION: ALPHA 0x0002",
-        "// FUNCTION: TEST 0x2000",
-        "void function2() {}",
-        "// FUNCTION: ALPHA 0x0003",
-        "// FUNCTION: TEST 0x3000",
-        "void function3() {}",
-    ]
+    code = """\
+        // FUNCTION: ALPHA 0x0001
+        // FUNCTION: TEST 0x1000
+        void function1() {}
+        // FUNCTION: ALPHA 0x0002
+        // FUNCTION: TEST 0x2000
+        void function2() {}
+        // FUNCTION: ALPHA 0x0003
+        // FUNCTION: TEST 0x3000
+        void function3() {}
+        """
 
-    assert linter.check_lines(lines, "test.cpp", "TEST") is True
+    assert linter.read(code, "test.cpp", "TEST") is True
     linter.reset(True)
-    assert linter.check_lines(lines, "test.cpp", "ALPHA") is True
+    assert linter.read(code, "test.cpp", "ALPHA") is True
 
 
 def test_byname_headers_only(linter):
     """Markers that ar referenced by name with cvdump belong in header files only."""
-    lines = [
-        "// FUNCTION: TEST 0x1000",
-        "// MyClass::~MyClass",
-    ]
+    code = """\
+        // FUNCTION: TEST 0x1000
+        // MyClass::~MyClass
+        """
 
-    assert linter.check_lines(lines, "test.h", "TEST") is True
+    assert linter.read(code, "test.h", "TEST") is True
     linter.reset(True)
-    assert linter.check_lines(lines, "test.cpp", "TEST") is False
+    assert linter.read(code, "test.cpp", "TEST") is False
     assert linter.alerts[0].code == ParserError.BYNAME_FUNCTION_IN_CPP
 
 
 def test_duplicate_offsets(linter):
     """The linter will retain module/offset pairs found until we do a full reset."""
-    lines = [
-        "// FUNCTION: TEST 0x1000",
-        "// FUNCTION: HELLO 0x1000",
-        "// MyClass::~MyClass",
-    ]
+    code = """\
+        // FUNCTION: TEST 0x1000
+        // FUNCTION: HELLO 0x1000
+        // MyClass::~MyClass
+        """
 
     # Should not fail for duplicate offset 0x1000 because the modules are unique.
-    assert linter.check_lines(lines, "test.h", "TEST") is True
+    assert linter.read(code, "test.h", "TEST") is True
 
     # Simulate a failure by reading the same file twice.
-    assert linter.check_lines(lines, "test.h", "TEST") is False
+    assert linter.read(code, "test.h", "TEST") is False
 
     # Two errors because offsets from both modules are duplicated
     assert len(linter.alerts) == 2
@@ -107,38 +107,38 @@ def test_duplicate_offsets(linter):
 
     # Partial reset will retain the list of seen offsets.
     linter.reset(False)
-    assert linter.check_lines(lines, "test.h", "TEST") is False
+    assert linter.read(code, "test.h", "TEST") is False
 
     # Full reset will forget seen offsets.
     linter.reset(True)
-    assert linter.check_lines(lines, "test.h", "TEST") is True
+    assert linter.read(code, "test.h", "TEST") is True
 
 
 def test_duplicate_strings(linter):
     """Duplicate string markers are okay if the string value is the same."""
-    string_lines = [
-        "// STRING: TEST 0x1000",
-        'return "hello world";',
-    ]
+    string_lines = """\
+        // STRING: TEST 0x1000
+        return "hello world";
+        """
 
     # No problem to use this marker twice.
-    assert linter.check_lines(string_lines, "test.h", "TEST") is True
-    assert linter.check_lines(string_lines, "test.h", "TEST") is True
+    assert linter.read(string_lines, "test.h", "TEST") is True
+    assert linter.read(string_lines, "test.h", "TEST") is True
 
-    different_string = [
-        "// STRING: TEST 0x1000",
-        'return "hi there";',
-    ]
+    different_string = """\
+        // STRING: TEST 0x1000
+        return "hi there";
+        """
 
     # Same address but the string is different
-    assert linter.check_lines(different_string, "greeting.h", "TEST") is False
+    assert linter.read(different_string, "greeting.h", "TEST") is False
     assert len(linter.alerts) == 1
     assert linter.alerts[0].code == ParserError.WRONG_STRING
 
-    same_addr_reused = [
-        "// GLOBAL:TEXT 0x1000",
-        "int g_test = 123;",
-    ]
+    same_addr_reused = """\
+        // GLOBAL:TEXT 0x1000
+        int g_test = 123;
+        """
 
     # This will fail like any other offset reuse.
-    assert linter.check_lines(same_addr_reused, "other.h", "TEST") is False
+    assert linter.read(same_addr_reused, "other.h", "TEST") is False

--- a/tests/test_parser_samples.py
+++ b/tests/test_parser_samples.py
@@ -31,7 +31,7 @@ def fixture_parser():
 def test_sanity(parser):
     """Read a very basic file"""
     with sample_file("basic_file.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 3
     assert code_blocks_are_sorted(parser.functions) is True
@@ -45,7 +45,7 @@ def test_oneline(parser):
     """(Assuming clang-format permits this) This sample has a function
     on a single line. This will test the end-of-function detection"""
     with sample_file("oneline_function.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 2
     assert parser.functions[0].line_number == 5
@@ -55,7 +55,7 @@ def test_oneline(parser):
 def test_missing_offset(parser):
     """What if the function doesn't have an offset comment?"""
     with sample_file("missing_offset.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     # TODO: For now, the function without the offset will just be ignored.
     # Would be the same outcome if the comment was present but mangled and
@@ -68,7 +68,7 @@ def test_jumbled_case(parser):
     the downstream tools to do something about a jumbled file.
     Just verify that we are reading it correctly."""
     with sample_file("out_of_order.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 3
     assert code_blocks_are_sorted(parser.functions) is False
@@ -76,7 +76,7 @@ def test_jumbled_case(parser):
 
 def test_bad_file(parser):
     with sample_file("poorly_formatted.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 3
 
@@ -84,7 +84,7 @@ def test_bad_file(parser):
 def test_indented(parser):
     """Offsets for functions inside of a class will probably be indented."""
     with sample_file("basic_class.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     # TODO: We don't properly detect the end of these functions
     # because the closing brace is indented. However... knowing where each
@@ -103,7 +103,7 @@ def test_indented(parser):
 
 def test_inline(parser):
     with sample_file("inline.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 2
     for fun in parser.functions:
@@ -116,7 +116,7 @@ def test_multiple_offsets(parser):
     all but ensure module name (case-insensitive) is distinct.
     Use first module occurrence in case of duplicates."""
     with sample_file("multiple_offsets.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 4
     assert parser.functions[0].module == "TEST"
@@ -135,7 +135,7 @@ def test_multiple_offsets(parser):
 
 def test_variables(parser):
     with sample_file("global_variables.cpp") as f:
-        parser.read_lines(f)
+        parser.read(f.read())
 
     assert len(parser.functions) == 1
     assert len(parser.variables) == 2


### PR DESCRIPTION
As discussed on matrix chat, I've been working on moving us from the current line-based C++ parser to a token-based parser. This will allow other teams to use whatever house style they want and get their annotations loaded without any surprises. It's a big change, so I'm going to add things in stages so it's easier to review.

First up is having just one `read()` method for both the parser and the decomp linter. The token-based parser needs to get the entire file's contents as a string, so file reads and unit tests will now use the same entrypoint.

The unit tests all used a list of strings to represent the code lines. These are now multiline strings, which I suppose is the best amongst the lot of not-aesthetically-pleasing options. I only used `dedent` where needed for the tests to pass -- this is typically due to not detecting the start or end of the function because we require the curly brace to be in a certain spot. The token-based parser won't have this problem so we can take those calls out later.

As expected, we are reading all the annotations exactly the same on the main isle repo before and after this change.