### PR TITLE
Dynamic metadata for program database

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -168,10 +168,13 @@ class Compare:
                     decoded_string = raw.decode("latin1")
                     rstrip_string = decoded_string.rstrip("\x00")
 
-                    if decoded_string != "" and rstrip_string != "":
-                        sym.friendly_name = rstrip_string
-                    else:
-                        sym.friendly_name = decoded_string
+                    # TODO: Hack to exclude a string that contains \x00 bytes
+                    # The proper solution is to escape the text for JSON or use
+                    # base64 encoding for comparing binary values.
+                    # Kicking the can down the road for now.
+                    if "\x00" in decoded_string and rstrip_string == "":
+                        continue
+                    sym.friendly_name = rstrip_string
 
                 except UnicodeDecodeError:
                     pass
@@ -184,9 +187,7 @@ class Compare:
             }
 
         # Convert dict of dicts (keyed by addr) to list of dicts (that contains the addr)
-        self._db.bulk_cvdump_insert(
-            ({"addr": key, **values} for key, values in dataset.items())
-        )
+        self._db.bulk_recomp_insert(dataset.items())
 
         for (section, offset), (
             filename,
@@ -324,8 +325,13 @@ class Compare:
                                 recomp_element_base_addr + member.offset,
                             )
 
-        self._db.bulk_array_insert(
-            ({"recomp": key, **values} for key, values in dataset.items())
+        # Upsert here to update the starting address of variables already in the db.
+        self._db.bulk_recomp_insert(
+            ((addr, {"name": values["name"]}) for addr, values in dataset.items()),
+            upsert=True,
+        )
+        self._db.bulk_match(
+            ((values["orig"], addr) for addr, values in dataset.items())
         )
 
     def _find_original_strings(self):
@@ -367,13 +373,13 @@ class Compare:
             for addr, string in self.orig_bin.iter_string("latin1"):
                 if is_real_string(string):
                     self._db.set_orig_symbol(
-                        addr, SymbolType.STRING, string, len(string)
+                        addr, type=SymbolType.STRING, name=string, size=len(string)
                     )
 
             for addr, string in self.recomp_bin.iter_string("latin1"):
                 if is_real_string(string):
                     self._db.set_recomp_symbol(
-                        addr, SymbolType.STRING, string, None, len(string)
+                        addr, type=SymbolType.STRING, name=string, size=len(string)
                     )
 
     def _find_float_const(self):
@@ -381,11 +387,13 @@ class Compare:
         We are not matching anything right now because these values are not
         deduped like strings."""
         for addr, size, float_value in self.orig_bin.find_float_consts():
-            self._db.set_orig_symbol(addr, SymbolType.FLOAT, str(float_value), size)
+            self._db.set_orig_symbol(
+                addr, type=SymbolType.FLOAT, name=str(float_value), size=size
+            )
 
         for addr, size, float_value in self.recomp_bin.find_float_consts():
             self._db.set_recomp_symbol(
-                addr, SymbolType.FLOAT, str(float_value), None, size
+                addr, type=SymbolType.FLOAT, name=str(float_value), size=size
             )
 
     def _match_imports(self):
@@ -435,7 +443,7 @@ class Compare:
             (dll_name, func_name) = orig_byaddr[orig]
             fullname = dll_name + ":" + func_name
             self._db.set_recomp_symbol(
-                recomp_rva, SymbolType.FUNCTION, fullname, None, 4
+                recomp_rva, type=SymbolType.FUNCTION, name=fullname, size=4
             )
             self._db.set_pair(orig_rva, recomp_rva, SymbolType.FUNCTION)
             self._db.skip_compare(orig_rva)

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -11,15 +11,15 @@ def fixture_db():
 
 def test_ignore_recomp_collision(db):
     """Duplicate recomp addresses are ignored"""
-    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
-    db.set_recomp_symbol(0x1234, None, "alias_for_hello", None, 100)
+    db.set_recomp_symbol(0x1234, name="hello", size=100)
+    db.set_recomp_symbol(0x1234, name="alias_for_hello", size=100)
     syms = [*db.get_all()]
     assert len(syms) == 1
 
 
 def test_orig_collision(db):
     """Don't match if the original address is not unique"""
-    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
+    db.set_recomp_symbol(0x1234, name="hello", size=100)
     assert db.match_function(0x5555, "hello") is True
 
     # Second run on same address fails
@@ -30,7 +30,7 @@ def test_orig_collision(db):
 
 
 def test_name_match(db):
-    db.set_recomp_symbol(0x1234, None, "hello", None, 100)
+    db.set_recomp_symbol(0x1234, name="hello", size=100)
     assert db.match_function(0x5555, "hello") is True
 
     match = db.get_by_orig(0x5555)
@@ -40,7 +40,7 @@ def test_name_match(db):
 
 def test_match_decorated(db):
     """Should match using decorated name even though regular name is null"""
-    db.set_recomp_symbol(0x1234, None, None, "?_hello", 100)
+    db.set_recomp_symbol(0x1234, symbol="?_hello", size=100)
     assert db.match_function(0x5555, "?_hello") is True
     match = db.get_by_orig(0x5555)
     assert match is not None
@@ -48,9 +48,9 @@ def test_match_decorated(db):
 
 def test_duplicate_name(db):
     """If recomp name is not unique, match only one row"""
-    db.set_recomp_symbol(0x100, None, "_Construct", None, 100)
-    db.set_recomp_symbol(0x200, None, "_Construct", None, 100)
-    db.set_recomp_symbol(0x300, None, "_Construct", None, 100)
+    db.set_recomp_symbol(0x100, name="_Construct", size=100)
+    db.set_recomp_symbol(0x200, name="_Construct", size=100)
+    db.set_recomp_symbol(0x300, name="_Construct", size=100)
     db.match_function(0x5555, "_Construct")
     matches = [*db.get_matches()]
     # We aren't testing _which_ one would be matched, just that only one _was_ matched
@@ -61,12 +61,14 @@ def test_static_variable_match(db):
     """Set up a situation where we can match a static function variable, then match it."""
 
     # We need a matched function to start with.
-    db.set_recomp_symbol(0x1234, None, "Isle::Tick", "?Tick@IsleApp@@QAEXH@Z", 100)
+    db.set_recomp_symbol(
+        0x1234, name="Isle::Tick", symbol="?Tick@IsleApp@@QAEXH@Z", size=100
+    )
     db.match_function(0x5555, "Isle::Tick")
 
     # Decorated variable name from PDB.
     db.set_recomp_symbol(
-        0x2000, None, None, "?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA", 4
+        0x2000, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA", size=4
     )
 
     # Provide variable name and orig function address from decomp markers
@@ -81,3 +83,14 @@ def test_match_options_bool(db):
 
     db.mark_stub(0x1234)
     assert "stub" in db.get_match_options(0x1234)
+
+
+def test_dynamic_metadata(db):
+    """Using the API we have now"""
+    db.set_recomp_symbol(1234, hello="abcdef", option=True)
+    obj = db.get_by_recomp(1234)
+    assert obj.get("hello") == "abcdef"
+
+    # Should preserve boolean type
+    assert isinstance(obj.get("option"), bool)
+    assert obj.get("option") is True


### PR DESCRIPTION
This refactors the program database to store any kind of metadata, no matter how specific. For example:
- Bool to identify thunk, vtordisp, import functions
- Unique name for functions that look alike. (e.g. free functions like `operator!=`, or const vs non-const operators)
- Separate size for orig/recomp
- Back-reference for items inside a function like unwinds or jump tables

To implement this, we are using a JSON string to store key-value pairs. Any format would do, but [SQLite has a nice API](https://www.sqlite.org/json1.html) for working with JSON. Other options I looked at:
- A bunch of python dicts. Probably the fastest but getting there requires a lot of code to re-implement indices. You also lose atomicity and concurrency that we get for free with SQLite.
- `ALTER TABLE` statements to dynamically add columns. The problem here is that you need to maintain state at the python level to avoid sqlite exceptions, and _all_ your SQL statements need to be dynamic to account for which columns are used. (I may still explore this option, though.)

Not that JSON is without its drawbacks:
- We're doing our serialization/deserialization with the python `json` library, which adds non-trivial but not earth-shattering overhead. Comedy: this is faster than `json.loads` (but not enough to use):
    ```python
    dict(sql.execute("SELECT key, value FROM json_each(?)", (json_string,))
    ```
    There are drop-in replacement JSON modules that are intended to be faster, so maybe we can use one of those.
- On the topic of serialization: a faster way around it is to use a "stage" table to dump all your key/value pairs and then use the aggregate `json_group_object()` to collect them all in a JSON string and set into the listing. The problem here is that SQLite has no boolean type, so your python `True` is converted to a 1 before going into the JSON string. `json.dumps` maintains the bool so we don't need a conversion method.
- LEGO1 and ISLE use an odd string "\x00\x00" in `__crt` functions. The PDB points at its exact location in the recomp. The problem is that JSON does not distinguish between that and the empty string (and who could blame it). I worked around this for now by just dropping this specific string. (Accuracy went up by a tick.) We probably should compare const data (string and floats) by looking at the bytes. This will probably cover us with unicode strings too.

Other stuff:
- `set_orig_symbol` and `set_recomp_symbol` now use key args exclusively. This always should have been the case, but we need it now for the dynamic properties.
- `_match_array_elements` now updates existing entries, meaning that the asm will show `g_roiColorAliases[0].m_name` instead of just `g_roiColorAliases` for the first entry.
- The ORM object can access all the dynamic fields via `get()`. We could extend `__getitem__` so you can use `obj.whatever` instead. I added all the previous fields as `@property` methods for now to not introduce any breaking changes.
- New `bulk_match` method that does what the name indicates. I'm going to look into using this more to get extra performance.

The `match_options` table will get folded into the JSON string in a later update. (The ghidra scripts and main compare code use this and I didn't want to change those here.)