### PR TITLE
Alert to ambiguous name match

### DIFF
--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -454,7 +454,7 @@ class CompareDb:
                         "Ambiguous match 0x%x on name '%s' to '%s'",
                         addr,
                         name,
-                        obj.get("symbol", "__no_symbol__"),
+                        obj.get("symbol"),
                     )
 
                 return matched


### PR DESCRIPTION
Resolves #28.

We use the existing `logger` to display the warning, so brace yourself for more messages. Sample:
```
[WARNING] Ambiguous match 0x10058980 on name '_Construct' to '?_Construct@@YAXPAPAVLegoAnimPresenter@@ABQAV1@@Z'
[WARNING] Ambiguous match 0x1004a780 on name '_Construct' to '?_Construct@@YAXPAPAULegoPathCtrlEdge@@ABQAU1@@Z'
[ERROR] Failed to find function symbol with annotation 0x10022360 and name '?_Construct@@YAXPAPAVMxCore@@ABQAV1@@Z'
[WARNING] Ambiguous match 0x10010c00 on name 'Mx3DPointFloat::operator=' to '??4Mx3DPointFloat@@QAEAAV0@ABV0@@Z'
[WARNING] Ambiguous match 0x10064b20 on name 'Mx4DPointFloat::operator=' to '??4Mx4DPointFloat@@QAEAAV0@ABV0@@Z'
[ERROR] Failed to find function symbol with annotation 0x100c7ef0 and name 'list<MxNextActionDataStart *>::insert'
[ERROR] Failed to find function symbol with annotation 0x100c1bc0 and name 'list<MxDSAction *,allocator<MxDSAction *> >::insert'
```

Other notes:
- I dropped the `_find_potential_match` method in favor of two more general purpose search methods (on name/type and symbol). These return `MatchInfo` objects, both matched and unmatched, so it's up to the caller to check before writing to the DB with a call to `set_pair`.
- We now build indices at the moment they are needed in the two aforementioned methods. This should improve performance (but perhaps only slightly)
- We could very easily create a generic search function that would take any combination of keywords. The problem I found in testing is that SQLite will not engage the indices if you parameterize the key extracted from the JSON string. For example:
    ```sql
    SELECT cols FROM symbols WHERE json_extract(kvstore,?) = ?
    ```
    The workaround is to use string concat instead of a parameter, but this of course leads to the dreaded SQL injection problem. We probably don't need to worry about this too much considering the lifespan and purpose of the data. I'll add this in a separate PR later when we need it.