### PR TITLE
Modernize roadmap, type cvdump parser

### DIFF
--- a/reccmp/isledecomp/cvdump/parser.py
+++ b/reccmp/isledecomp/cvdump/parser.py
@@ -1,6 +1,5 @@
 import re
-from typing import Iterable, Tuple
-from collections import namedtuple
+from typing import Iterable, NamedTuple, Tuple
 from .types import CvdumpTypesParser
 from .symbols import CvdumpSymbolsParser
 
@@ -40,21 +39,52 @@ _gdata32_regex = re.compile(
 # e.g. 0004 "C:\work\lego-island\isle\3rdparty\smartheap\SHLW32MT.LIB" "check.obj"
 _module_regex = re.compile(r"(?P<id>\w{4})(?: \"(?P<lib>.+?)\")?(?: \"(?P<obj>.+?)\")")
 
-# User functions only
-LinesEntry = namedtuple("LinesEntry", "filename line_no section offset")
 
-# Strings, vtables, functions
-# superset of everything else
-# only place you can find the C symbols (library functions, smacker, etc)
-PublicsEntry = namedtuple("PublicsEntry", "type section offset flags name")
+class LinesEntry(NamedTuple):
+    """User functions only"""
 
-# (Estimated) size of any symbol
-SizeRefEntry = namedtuple("SizeRefEntry", "module section offset size")
+    filename: str
+    line_no: int
+    section: int
+    offset: int
 
-# global variables
-GdataEntry = namedtuple("GdataEntry", "section offset type name")
 
-ModuleEntry = namedtuple("ModuleEntry", "id lib obj")
+class PublicsEntry(NamedTuple):
+    """
+    - Strings, vtables, functions
+    - superset of everything else
+    - only place you can find the C symbols (library functions, smacker, etc)
+    """
+
+    type: str
+    section: int
+    offset: int
+    flags: int
+    name: str
+
+
+class SizeRefEntry(NamedTuple):
+    """(Estimated) size of any symbol"""
+
+    module: int
+    section: int
+    offset: int
+    size: int
+
+
+class GdataEntry(NamedTuple):
+    """global variables"""
+
+    section: int
+    offset: int
+    type: str
+    name: str
+
+
+class ModuleEntry(NamedTuple):
+    id: int
+    lib: str
+    obj: str
 
 
 class CvdumpParser:
@@ -64,10 +94,10 @@ class CvdumpParser:
         self._lines_function: Tuple[str, int] = ("", 0)
 
         self.lines = {}
-        self.publics = []
-        self.sizerefs = []
-        self.globals = []
-        self.modules = []
+        self.publics: list[PublicsEntry] = []
+        self.sizerefs: list[SizeRefEntry] = []
+        self.globals: list[GdataEntry] = []
+        self.modules: list[ModuleEntry] = []
 
         self.types = CvdumpTypesParser()
         self.symbols_parser = CvdumpSymbolsParser()

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -9,19 +9,26 @@ in the original binary.
 import os
 import argparse
 import logging
+from pathlib import Path
 import statistics
 import bisect
 from typing import Iterator, List, Optional, Tuple
 from collections import namedtuple
 import reccmp
 from reccmp.isledecomp import Bin as IsleBin
-from reccmp.isledecomp.bin import InvalidVirtualAddressError
+from reccmp.isledecomp.bin import Bin, InvalidVirtualAddressError
+from reccmp.isledecomp.compare.db import MatchInfo
 from reccmp.isledecomp.cvdump import Cvdump
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.types import SymbolType
+from reccmp.project.detect import (
+    argparse_add_built_project_target_args,
+    argparse_parse_built_project_target,
+)
+from reccmp.project.error import RecCmpProjectException
+from reccmp.project.logging import argparse_add_logging_args, argparse_parse_logging
 
-# Ignore all compare-db messages.
-logging.getLogger("isledecomp.compare").addHandler(logging.NullHandler())
+logger = logging.getLogger(__name__)
 
 
 def or_blank(value) -> str:
@@ -33,9 +40,11 @@ class ModuleMap:
     """Load a subset of sections from the pdb to allow you to look up the
     module number based on the recomp address."""
 
-    def __init__(self, pdb, binfile) -> None:
-        cvdump = Cvdump(pdb).section_contributions().modules().run()
-        self.module_lookup = {m.id: (m.lib, m.obj) for m in cvdump.modules}
+    def __init__(self, pdb: Path, binfile: Bin) -> None:
+        cvdump = Cvdump(str(pdb)).section_contributions().modules().run()
+        self.module_lookup: dict[int, tuple[str, str]] = {
+            m.id: (m.lib, m.obj) for m in cvdump.modules
+        }
         self.library_lookup = {m.obj: m.lib for m in cvdump.modules}
         self.section_contrib = [
             (
@@ -96,12 +105,12 @@ def print_sections(sections):
 ALLOWED_TYPE_ABBREVIATIONS = ["fun", "dat", "poi", "str", "vta", "flo"]
 
 
-def match_type_abbreviation(mtype: Optional[SymbolType]) -> str:
+def match_type_abbreviation(mtype: Optional[int]) -> str:
     """Return abbreviation of the given SymbolType name"""
     if mtype is None:
         return ""
 
-    return mtype.name.lower()[:3]
+    return SymbolType(mtype).name.lower()[:3]
 
 
 def get_cmakefiles_prefix(module: str) -> str:
@@ -344,23 +353,14 @@ def export_to_csv(csv_file: str, results: List[RoadmapRow]):
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Show all addresses from original and recomp."
+        allow_abbrev=False,
+        description="Recompilation Compare: compare an original EXE with a recompiled EXE + PDB.",
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {reccmp.VERSION}"
     )
-    parser.add_argument(
-        "original", metavar="original-binary", help="The original binary"
-    )
-    parser.add_argument(
-        "recompiled", metavar="recompiled-binary", help="The recompiled binary"
-    )
-    parser.add_argument(
-        "pdb", metavar="recompiled-pdb", help="The PDB of the recompiled binary"
-    )
-    parser.add_argument(
-        "decomp_dir", metavar="decomp-dir", help="The decompiled source tree"
-    )
+    argparse_add_built_project_target_args(parser)
+
     parser.add_argument("--csv", metavar="<file>", help="If set, export to CSV")
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Show recomp addresses in output"
@@ -373,32 +373,35 @@ def parse_args() -> argparse.Namespace:
         help="Show suggested order of modules (using the specified symbol type)",
     )
 
-    (args, _) = parser.parse_known_args()
-
-    if not os.path.isfile(args.original):
-        parser.error(f"Original binary {args.original} does not exist")
-
-    if not os.path.isfile(args.recompiled):
-        parser.error(f"Recompiled binary {args.recompiled} does not exist")
-
-    if not os.path.isfile(args.pdb):
-        parser.error(f"Symbols PDB {args.pdb} does not exist")
-
-    if not os.path.isdir(args.decomp_dir):
-        parser.error(f"Source directory {args.decomp_dir} does not exist")
+    argparse_add_logging_args(parser)
+    args = parser.parse_args()
+    argparse_parse_logging(args=args)
+    if args.loglevel != logging.DEBUG:
+        # Mute logger events from compare engine
+        logging.getLogger("isledecomp.compare.core").setLevel(logging.CRITICAL)
+        logging.getLogger("isledecomp.compare.db").setLevel(logging.CRITICAL)
+        logging.getLogger("isledecomp.compare.lines").setLevel(logging.CRITICAL)
 
     return args
 
 
-def main():
+def main() -> int:
     args = parse_args()
 
-    with IsleBin(args.original, find_str=True) as orig_bin, IsleBin(
-        args.recompiled
-    ) as recomp_bin:
-        engine = IsleCompare(orig_bin, recomp_bin, args.pdb, args.decomp_dir)
+    try:
+        target = argparse_parse_built_project_target(args=args)
+    except RecCmpProjectException as e:
+        logger.error(e.args[0])
+        return 1
 
-        module_map = ModuleMap(args.pdb, recomp_bin)
+    with IsleBin(target.original_path, find_str=True) as orig_bin, IsleBin(
+        target.recompiled_path
+    ) as recomp_bin:
+        engine = IsleCompare(
+            orig_bin, recomp_bin, target.recompiled_pdb, target.source_root
+        )
+
+        module_map = ModuleMap(target.recompiled_pdb, recomp_bin)
 
         def is_same_section(orig: int, recomp: int) -> bool:
             """Compare the section name instead of the index.
@@ -411,7 +414,7 @@ def main():
             except IndexError:
                 return False
 
-        def to_roadmap_row(match):
+        def to_roadmap_row(match: MatchInfo):
             orig_sect = None
             orig_ofs = None
             orig_sect_ofs = None
@@ -453,6 +456,8 @@ def main():
                 and recomp_sect is not None
                 and is_same_section(orig_sect, recomp_sect)
             ):
+                assert recomp_ofs is not None
+                assert orig_ofs is not None
                 displacement = recomp_ofs - orig_ofs
 
             return RoadmapRow(
@@ -480,7 +485,7 @@ def main():
 
         if args.order is not None:
             suggest_order(results, module_map, args.order)
-            return
+            return 0
 
         if args.csv is None:
             if args.verbose:
@@ -496,6 +501,8 @@ def main():
 
         if args.csv is not None:
             export_to_csv(args.csv, results)
+
+        return 0
 
 
 if __name__ == "__main__":

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -16,7 +16,7 @@ from typing import Iterator, List, Optional, Tuple
 from collections import namedtuple
 import reccmp
 from reccmp.isledecomp import Bin as IsleBin
-from reccmp.isledecomp.bin import Bin, InvalidVirtualAddressError
+from reccmp.isledecomp.bin import InvalidVirtualAddressError
 from reccmp.isledecomp.compare.db import MatchInfo
 from reccmp.isledecomp.cvdump import Cvdump
 from reccmp.isledecomp.compare import Compare as IsleCompare
@@ -40,7 +40,7 @@ class ModuleMap:
     """Load a subset of sections from the pdb to allow you to look up the
     module number based on the recomp address."""
 
-    def __init__(self, pdb: Path, binfile: Bin) -> None:
+    def __init__(self, pdb: Path, binfile: IsleBin) -> None:
         cvdump = Cvdump(str(pdb)).section_contributions().modules().run()
         self.module_lookup: dict[int, tuple[str, str]] = {
             m.id: (m.lib, m.obj) for m in cvdump.modules


### PR DESCRIPTION
* `roadmap` now uses the project config like all other scripts. Closes #10.
* `roadmap` was broken on master due to a regression, which I also fixed. Tests would probably be a good idea, but I'm not sure where to start and if it would be worth it.
* I typed parts of the code and the parsing code of `cvdump`.
* When trying to type the code I noticed that some of the `--order`-specfic code might be broken. I am not really sure how it is supposed to be used anyway. Input would be appreciated.