### PR TITLE
Emulated virtual address space for `PEImage` reads

### DIFF
--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -66,7 +66,9 @@ def test_unusual_reads(binfile: PEImage):
         binfile.read(0xFFFFFFFF, 1)
 
     # Uninitialized part of .data
-    assert binfile.read(0x1010A600, 4) is None
+    # Older versions of reccmp would return None for uninitialized data.
+    # We now return zeroes to emulate the behavior of the real program.
+    assert binfile.read(0x1010A600, 4) == b"\x00\x00\x00\x00"
 
     # Past the end of virtual size in .text
     assert binfile.read(0x100D3A70, 4) == b"\x00\x00\x00\x00"


### PR DESCRIPTION
This changes `PEImage` to create a `memoryview` that contains the virtual address space. We copy the initialized data from the file for each section, leaving zeroes for the uninitialized data.

Currently, the `read()` method returns `None` when you try to read uninitialized data. This required an expensive (in the aggregate) lookup to get the section for your virtual address. I think it's more intuitive (and faster) to just return zeroes here. As we've discovered, MSVC can place variable structs initialized to zero on the border between initialized and uninitialized data for the section. The result in the actual program is the same (all zeroes) so I don't think we need to be that picky about this.

However, `datacmp` reports when a value _should be_ uninitialized and so we need to retain that feature. I created a cached property `uninitialized_ranges` for checking the address. This also includes sections that have the `IMAGE_SCN_CNT_UNINITIALIZED_DATA` flag set. None in `LEGO1` or `ISLE` have this, but future programs will.

I also have a cached property `vaddr_ranges` for the virtual address range of each section, and we use that in the `get_relative_addr` function. It was tricky to get this function to run quickly when `read()` depended on its output, and I had used the `bisect` module to do a binary search for the section. The real improvement is to just call this function less often.

The exception string from `get_relative_addr` returned the `section` variable in the event that no sections contained the given v-addr. I took this out because it would always show the last section in the list.

Slight performance boost from this change, and more improvements are possible with some refactoring to use `memoryview` instead of `bytes`. Hopefully no typos on the many appearances of the word "initialized". 😉



