### PR TITLE
Cache DB lookups for asm sanitize

### DIFF
--- a/reccmp/isledecomp/compare/asm/parse.py
+++ b/reccmp/isledecomp/compare/asm/parse.py
@@ -52,7 +52,6 @@ class ParseAsm:
         self.relocate_lookup = relocate_lookup
         self.name_lookup = name_lookup
         self.bin_lookup = bin_lookup
-        self.lookup_cache = {}
         self.replacements = {}
         self.number_placeholders = True
 
@@ -69,18 +68,12 @@ class ParseAsm:
         self, addr: int, use_cache: bool = True, exact: bool = False
     ) -> Optional[str]:
         """Return a replacement name for this address if we find one."""
-        if use_cache:
-            if addr in self.lookup_cache:
-                self.replacements[addr] = self.lookup_cache[addr]
-                return self.replacements[addr]
-
-            if addr in self.replacements:
-                return self.replacements[addr]
+        if use_cache and addr in self.replacements:
+            return self.replacements[addr]
 
         if callable(self.name_lookup):
             if (name := self.name_lookup(addr, exact)) is not None:
                 if use_cache:
-                    self.lookup_cache[addr] = name
                     self.replacements[addr] = name
 
                 return name

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -4,6 +4,7 @@ import difflib
 from pathlib import Path
 import struct
 import uuid
+from functools import cache
 from dataclasses import dataclass
 from typing import Callable, Iterable, List, Optional
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
@@ -70,6 +71,7 @@ def create_name_lookup(
 ) -> Callable[[int, bool], Optional[str]]:
     """Function generator for name replacement"""
 
+    @cache
     def lookup(addr: int, exact: bool) -> Optional[str]:
         m = db_getter(addr, exact)
         if m is None:


### PR DESCRIPTION
The assembly generate/sanitize/compare process is the last step in the pipeline for `reccmp`. We don't make any changes to the database between comparing each function, so it's no problem to cache the address -> string lookups across the entire session. This gets us about a 5% performance boost. I diffed the full asm output before and after (using `--debug`) and the result is the same.

I also consolidated the "name lookup" function to use a generator, as with the "binary read" and "check relocation table" functions. I have some ideas to improve this area coming soon.


