### PR TITLE
Name of target binary is not always identical to the annotation id

### DIFF
--- a/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -300,7 +300,11 @@ def main():
         raise ValueError
 
     isle_compare = IsleCompare(
-        origfile, recompfile, target.recompiled_pdb, target.source_root
+        origfile,
+        recompfile,
+        target.recompiled_pdb,
+        target.source_root,
+        target_id=target.target_id,
     )
 
     logger.info("Comparison complete.")

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -237,7 +237,11 @@ def main():
         logging.getLogger("isledecomp.compare.lines").setLevel(logging.CRITICAL)
 
     isle_compare = IsleCompare(
-        origfile, recompfile, target.recompiled_pdb, target.source_root
+        origfile,
+        recompfile,
+        target.recompiled_pdb,
+        target.source_root,
+        target_id=target.target_id,
     )
 
     if args.loglevel == logging.DEBUG:

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -157,6 +157,7 @@ def do_the_comparison(target: RecCmpBuiltTarget) -> Iterable[ComparisonItem]:
         recompfile,
         target.recompiled_pdb,
         target.source_root,
+        target_id=target.target_id,
     )
 
     # TODO: We don't currently retain the type information of each variable

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -401,7 +401,11 @@ def main() -> int:
     assert isinstance(recomp_bin, PEImage)
 
     engine = IsleCompare(
-        orig_bin, recomp_bin, target.recompiled_pdb, target.source_root
+        orig_bin,
+        recomp_bin,
+        target.recompiled_pdb,
+        target.source_root,
+        target_id=target.target_id,
     )
 
     module_map = ModuleMap(target.recompiled_pdb, recomp_bin)

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -325,7 +325,11 @@ def main():
         raise ValueError(f"{target.recompiled_path} is not a PE executable")
 
     isle_compare = IsleCompare(
-        origfile, recompfile, target.recompiled_pdb, target.source_root
+        origfile,
+        recompfile,
+        target.recompiled_pdb,
+        target.source_root,
+        target_id=target.target_id,
     )
     if args.loglevel == logging.DEBUG:
         isle_compare.debug = True

--- a/reccmp/tools/vtable.py
+++ b/reccmp/tools/vtable.py
@@ -74,7 +74,11 @@ def main():
     recomp_bin = detect_image(target.recompiled_path)
     assert isinstance(recomp_bin, PEImage)
     engine = IsleCompare(
-        orig_bin, recomp_bin, target.recompiled_pdb, target.source_root
+        orig_bin,
+        recomp_bin,
+        target.recompiled_pdb,
+        target.source_root,
+        target_id=target.target_id,
     )
 
     for tbl_match in engine.compare_vtables():


### PR DESCRIPTION
This allows annotations as `// FUNCTION: GAME 0x100998e0` for a `Super Lego Racer.exe` original binary.