### PR TITLE
Fix bug with `--paths` command line option

### DIFF
--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -23,14 +23,30 @@ class GhidraConfig(BaseModel):
 
 @dataclass
 class RecCmpTarget:
-    target_id: str
+    """Partial information for a target (binary file) in the decomp project
+    This contains only the static information (same for all users).
+    Saved to project.yml. (See ProjectFileTarget)"""
+
+    # Unique ID for grouping the metadata.
+    # If none is given we will use the base filename minus the file extension.
+    target_id: str | None
+
+    # Base filename (not a path) of the binary for this target.
+    # "reccmp-project detect" uses this to search for the original and recompiled binaries
+    # when creating the user.yml file.
     filename: str
+
+    # Relative (to project root) directory of source code files for this target.
     source_root: Path
+
+    # Ghidra-specific options for this target.
     ghidra_config: GhidraConfig
 
 
 @dataclass
 class RecCmpBuiltTarget(RecCmpTarget):
+    """Full information for a target. Used to load component files for reccmp analysis."""
+
     original_path: Path
     recompiled_path: Path
     recompiled_pdb: Path
@@ -41,6 +57,8 @@ class Hash(BaseModel):
 
 
 class ProjectFileTarget(BaseModel):
+    """Target schema for project.yml"""
+
     filename: str
     source_root: Path = Field(
         validation_alias=AliasChoices("source-root", "source_root")
@@ -50,22 +68,32 @@ class ProjectFileTarget(BaseModel):
 
 
 class ProjectFile(BaseModel):
+    """File schema for project.yml"""
+
     targets: dict[str, ProjectFileTarget]
 
 
 class UserFileTarget(BaseModel):
+    """Target schema for user.yml"""
+
     path: Path
 
 
 class UserFile(BaseModel):
+    """File schema for user.yml"""
+
     targets: dict[str, UserFileTarget]
 
 
 class BuildFileTarget(BaseModel):
+    """Target schema for build.yml"""
+
     path: Path
     pdb: Path
 
 
 class BuildFile(BaseModel):
+    """File schema for build.yml"""
+
     project: Path
     targets: dict[str, BuildFileTarget]

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -37,6 +37,7 @@ def verify_target_names(
     user_targets: dict[str, UserFileTarget],
     build_targets: dict[str, BuildFileTarget],
 ):
+    """Warn if the user or build files have different targets than the canonical list in the project file."""
     project_keys = set(project_targets.keys())
     user_keys = set(user_targets.keys())
     build_keys = set(build_targets.keys())
@@ -117,6 +118,8 @@ class RecCmpProject:
 
 
 class RecCmpBuiltProject:
+    """Combines information from the project, user, and build yml files."""
+
     def __init__(
         self,
         project_config_path: Path,
@@ -130,6 +133,7 @@ class RecCmpBuiltProject:
 
     @classmethod
     def from_directory(cls, directory: Path) -> "RecCmpBuiltProject":
+        # Searching for build.yml
         build_directory = find_filename_recursively(
             directory=directory, filename=RECCMP_BUILD_CONFIG
         )
@@ -139,10 +143,13 @@ class RecCmpBuiltProject:
             )
         build_config = build_directory / RECCMP_BUILD_CONFIG
         logger.debug("Using build config: %s", build_config)
+
+        # Parse build.yml
         yaml_loader = ruamel.yaml.YAML()
         with build_config.open() as buildfile:
             build_data = BuildFile.model_validate(yaml_loader.load(buildfile))
 
+        # Searching for project.yml
         # note that Path.joinpath() will ignore the first path if the second path is absolute
         project_directory = build_directory.joinpath(build_data.project)
         project_config_path = project_directory / RECCMP_PROJECT_CONFIG
@@ -151,15 +158,20 @@ class RecCmpBuiltProject:
                 f"{build_config}: .project is invalid ({project_config_path} does not exist)"
             )
         logger.debug("Using project config: %s", project_config_path)
+
+        # Parse project.yml
         with project_config_path.open() as projectfile:
             project_data = ProjectFile.model_validate(yaml_loader.load(projectfile))
 
+        # Searching for user.yml
         user_config = project_directory / RECCMP_USER_CONFIG
         if not user_config.is_file():
             raise InvalidRecCmpProjectException(
                 f"Missing {RECCMP_USER_CONFIG}. First run 'reccmp-project detect'."
             )
         logger.debug("Using user config: %s", user_config)
+
+        # Parse user.yml
         with user_config.open() as userfile:
             user_data = UserFile.model_validate(yaml_loader.load(userfile))
 
@@ -174,10 +186,13 @@ class RecCmpBuiltProject:
             user_config=user_config,
             build_config=build_config,
         )
+
+        # For each target in the project file, combine information from user and build files.
         for target_id, project_target_data in project_data.targets.items():
             user_target_data = user_data.targets.get(target_id, None)
             build_target_data = build_data.targets.get(target_id, None)
 
+            # Skip this target if the build or user files do not have it.
             if not user_target_data:
                 logger.warning(
                     "%s: targets.%s is missing. Target will not be available.",
@@ -232,7 +247,7 @@ class RecCmpBuiltPathsAction(argparse.Action):
     ):
         original, recompiled, pdb, source_root = list(Path(o) for o in values)
         target = RecCmpBuiltTarget(
-            target_id="???",
+            target_id=None,
             filename=original.name,
             original_path=original,
             recompiled_path=recompiled,


### PR DESCRIPTION
Resolves #46. The fix is to set `target-id` to `None` if you used the `--paths` command-line option instead of `--target`. See `argparse_add_built_project_target_args`.

This is important because the target name is used to isolate the code annotations we want to read. If it is `None` we set it in `core.py` using the base filename of the orig binary.

I added some comments to the datatype classes so it's faster to understand which things do what.