### PR TITLE
Expand line number match to a range of lines

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -250,7 +250,9 @@ class Compare:
         # a lineref, we can match the nameref correctly because the lineref
         # was already removed from consideration.
         for fun in codebase.iter_line_functions():
-            recomp_addr = self._lines_db.search_line(fun.filename, fun.line_number)
+            recomp_addr = self._lines_db.search_line(
+                fun.filename, fun.line_number, fun.end_line
+            )
             if recomp_addr is not None:
                 self._db.set_function_pair(fun.offset, recomp_addr)
                 if fun.should_skip():

--- a/reccmp/isledecomp/compare/lines.py
+++ b/reccmp/isledecomp/compare/lines.py
@@ -75,6 +75,17 @@ class LinesDb:
         if len(possible_functions) == 1:
             return possible_functions[0]
 
+        # The file has been edited since the last compile.
+        if len(possible_functions) > 1:
+            logger.error(
+                "Debug data out of sync with function near: %s:%d",
+                path,
+                line_start,
+            )
+            return None
+
+        # No functions matched. This could mean the file is out of sync, or that
+        # the function was eliminated or inlined by compiler optimizations.
         logger.error(
             "Failed to find function symbol with filename and line: %s:%d",
             path,

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -478,17 +478,18 @@ class DecompParser:
                 # to help parsing.
                 self.function_sig = remove_trailing_comment(line_strip)
 
+                # The range of lines for this function begins when we see a non-blank line.
+                self._function_starts_here()
+
                 # Now check to see if the opening curly bracket is on the
                 # same line. clang-format should prevent this (BraceWrapping)
                 # but it is easy to detect.
                 # If the entire function is on one line, handle that too.
                 if self.function_sig.endswith("{"):
-                    self._function_starts_here()
                     self.state = ReaderState.IN_FUNC
                 elif self.function_sig.endswith("}") or self.function_sig.endswith(
                     "};"
                 ):
-                    self._function_starts_here()
                     self._function_done()
                 elif self.function_sig.endswith(");"):
                     # Detect forward reference or declaration
@@ -499,7 +500,6 @@ class DecompParser:
         elif self.state == ReaderState.WANT_CURLY:
             if line_strip == "{":
                 self.curly_indent_stops = line.index("{")
-                self._function_starts_here()
                 self.state = ReaderState.IN_FUNC
 
         elif self.state == ReaderState.IN_FUNC:

--- a/tests/test_parser_line_number.py
+++ b/tests/test_parser_line_number.py
@@ -1,0 +1,256 @@
+"""Verify that the reported line number of each decomp item matches expectations."""
+from textwrap import dedent  # Indenting is important here.
+import pytest
+from reccmp.isledecomp.parser.parser import DecompParser
+
+
+@pytest.fixture(name="parser")
+def fixture_parser():
+    return DecompParser()
+
+
+def test_function_one_liner(parser):
+    """Entire function on one line"""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        void test() { hello(); world++; }
+        """
+        )
+    )
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 2
+
+
+def test_function_newline_curly(parser):
+    """Allman style: curly braces always on their own line"""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        void test()
+        {
+            hello();
+            world++;
+        }
+        """
+        )
+    )
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 6
+
+
+def test_function_sameline_curly(parser):
+    """K&R or 1TBS style: curly braces never on their own line"""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        void test() {
+            hello();
+            world++;
+        }
+        """
+        )
+    )
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 5
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_function_newline_curly_with_code(parser):
+    """Pico/Lisp style. Same syntax as AFXWIN1.INL"""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        void test()
+        {   hello(); 
+            world++; }
+        """
+        )
+    )
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 4
+
+
+def test_function_with_other_markers(parser):
+    """Correct reporting for function with STRING and GLOBAL markers"""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        const char* test()
+        {
+            // GLOBAL: TEST 0x2000
+            // STRING: TEST 0x3000
+            const char* msg = "Hello";
+
+            // GLOBAL: TEST 0x4000
+            static int g_count = 5;
+
+            // STRING: TEST 0x5000
+            return "Test";
+        }
+        """
+        )
+    )
+
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 13
+
+    # Variable and string on same line
+    assert parser.variables[0].line_number == 6
+    assert parser.strings[0].line_number == 6
+
+    # Variable by itself
+    assert parser.variables[1].line_number == 9
+
+    # String by itself
+    assert parser.strings[1].line_number == 12
+
+
+def test_function_allman_unexpected_function_end(parser):
+    """TODO: This should probably be a syntax error instead.
+    Documenting current behavior of ending the existing function gracefully
+    when a second FUNCTION marker is detected."""
+    parser.read(
+        dedent(
+            """\
+        // FUNCTION: TEST 0x1234
+        void test()
+        {
+            hello();
+            // FUNCTION: TEST 0x5555
+        }
+        """
+        )
+    )
+
+    # Outer function ends at the line before the second FUNCTION mark
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 4
+
+
+@pytest.mark.xfail(
+    reason="Missed function end because closing '}' did not match tab stops of opening '{'"
+)
+def test_function_unequal_curly(parser):
+    """Similar to previous test except that we overshoot the range of the first function."""
+    parser.read(
+        dedent(
+            """\
+            // FUNCTION: TEST 0x1234
+            void test()
+            {
+                hello();
+                }
+
+            // FUNCTION: TEST 0x5555
+            void test2()
+            {
+                hello();
+            }
+            """
+        )
+    )
+
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 5
+    assert parser.functions[1].line_number == 8
+    assert parser.functions[1].end_line == 11
+
+
+@pytest.mark.xfail(reason="Ends function too soon")
+def test_function_no_tabbing(parser):
+    """Should properly manage scope level even if curly brackets are not tabbed."""
+    parser.read(
+        dedent(
+            """\
+            // FUNCTION: TEST 0x1234
+            void test()
+            {
+            
+            if (1)
+            {
+                hello();
+            }
+            }
+            """
+        )
+    )
+
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 9
+
+
+def test_synthetic(parser):
+    """The SYNTHETIC marker can only be a nameref annotation."""
+    parser.read(
+        dedent(
+            """\
+        // SYNTHETIC: TEST 0x1234
+        // SYNTHETIC: HELLO 0x5678
+        // Test
+        """
+        )
+    )
+
+    # Reported line number is the comment with the name of the function
+    assert parser.functions[0].line_number == 3
+    assert parser.functions[0].end_line == 3
+
+
+def test_string(parser):
+    parser.read(
+        dedent(
+            """\
+        // STRING: TEST 0x1234
+        return "Hello";
+        """
+        )
+    )
+
+    # Reported line number is the one with the string
+    assert parser.strings[0].line_number == 2
+    # TODO: enable when end_line is added
+    # assert parser.strings[0].end_line == 2
+
+
+@pytest.mark.skip(
+    reason="No way to properly test this without end_line attribute for strings."
+)
+def test_string_mutiline_concat(parser):
+    """Capture multiline strings with the line continuation character (backslash)"""
+    parser.read(
+        dedent(
+            """\
+        // STRING: TEST 0x1234
+        const char* test = "Hello"
+        "World";
+        """
+        )
+    )
+
+    assert parser.strings[0].line_number == 2
+    # TODO: enable when end_line is added
+    # assert parser.strings[0].end_line == 3
+
+
+@pytest.mark.xfail(reason="Does not register as a string with our line-based parser.")
+def test_string_line_continuation(parser):
+    """Capture multiline strings with the line continuation character (backslash)"""
+    parser.read(
+        dedent(
+            """\
+        // STRING: TEST 0x1234
+        return "Hello \\
+        World";
+        """
+        )
+    )
+
+    assert parser.strings[0].line_number == 2
+    # TODO: enable when end_line is added
+    # assert parser.strings[0].end_line == 3

--- a/tests/test_parser_samples.py
+++ b/tests/test_parser_samples.py
@@ -36,8 +36,8 @@ def test_sanity(parser):
     assert len(parser.functions) == 3
     assert code_blocks_are_sorted(parser.functions) is True
     # n.b. The parser returns line numbers as 1-based
-    # Function starts when we see the opening curly brace
-    assert parser.functions[0].line_number == 8
+    # Function begins on the first code line
+    assert parser.functions[0].line_number == 7
     assert parser.functions[0].end_line == 10
 
 
@@ -86,19 +86,14 @@ def test_indented(parser):
     with sample_file("basic_class.cpp") as f:
         parser.read(f.read())
 
-    # TODO: We don't properly detect the end of these functions
-    # because the closing brace is indented. However... knowing where each
-    # function ends is less important (for now) than capturing
-    # all the functions that are there.
-
     assert len(parser.functions) == 2
     assert parser.functions[0].offset == int("0x12345678", 16)
-    assert parser.functions[0].line_number == 16
-    # assert parser.functions[0].end_line == 19
+    assert parser.functions[0].line_number == 15
+    assert parser.functions[0].end_line == 19
 
     assert parser.functions[1].offset == int("0xdeadbeef", 16)
-    assert parser.functions[1].line_number == 23
-    # assert parser.functions[1].end_line == 25
+    assert parser.functions[1].line_number == 22
+    assert parser.functions[1].end_line == 25
 
 
 def test_inline(parser):
@@ -120,13 +115,13 @@ def test_multiple_offsets(parser):
 
     assert len(parser.functions) == 4
     assert parser.functions[0].module == "TEST"
-    assert parser.functions[0].line_number == 9
+    assert parser.functions[0].line_number == 8
 
     assert parser.functions[1].module == "HELLO"
-    assert parser.functions[1].line_number == 9
+    assert parser.functions[1].line_number == 8
 
     # Duplicate modules are ignored
-    assert parser.functions[2].line_number == 16
+    assert parser.functions[2].line_number == 15
     assert parser.functions[2].offset == 0x2345
 
     assert parser.functions[3].module == "TEST"


### PR DESCRIPTION
Resolves #57.

I had planned to eventually drop the sample files tested in `test_parser_samples.py` but this is one of the only places we actually test that the line numbers are captured correctly. I had some comments warning about detecting the end line of the function; this seems to work okay (with Allman syntax) so I enabled the tests for those. I don't think it's possible for `end_line` to be `None` but I will save that refactor for later.

The lines database definitely needs improvement (related to #53) but that's not for this PR.