### PR TITLE
Refactor: Replace legacy type annotations

### DIFF
--- a/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -28,7 +28,7 @@ import sys
 import logging
 from pathlib import Path
 import traceback
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import ghidra

--- a/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -196,7 +196,7 @@ def do_execute_import(
 
 
 def log_and_track_failure(
-    function_name: Optional[str], error: Exception, unexpected: bool = False
+    function_name: str | None, error: Exception, unexpected: bool = False
 ):
     if GLOBALS.statistics.track_failure_and_tell_if_new(error):
         logger.error(

--- a/reccmp/ghidra_scripts/lego_util/function_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/function_importer.py
@@ -351,9 +351,7 @@ class FullPdbFunctionImporter(PdbFunctionImporter):
             None,
         )
 
-    def get_matching_register_symbol(
-        self, register: str
-    ) -> CppRegisterSymbol | None:
+    def get_matching_register_symbol(self, register: str) -> CppRegisterSymbol | None:
         return next(
             (
                 symbol

--- a/reccmp/ghidra_scripts/lego_util/function_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/function_importer.py
@@ -4,7 +4,6 @@
 # pyright: reportMissingModuleSource=false
 
 import logging
-from typing import Optional
 from abc import ABC, abstractmethod
 
 from ghidra.program.model.listing import Function, Parameter

--- a/reccmp/ghidra_scripts/lego_util/function_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/function_importer.py
@@ -341,7 +341,7 @@ class FullPdbFunctionImporter(PdbFunctionImporter):
 
         param.setName(name, SourceType.USER_DEFINED)
 
-    def get_matching_stack_symbol(self, stack_offset: int) -> Optional[CppStackSymbol]:
+    def get_matching_stack_symbol(self, stack_offset: int) -> CppStackSymbol | None:
         return next(
             (
                 symbol
@@ -354,7 +354,7 @@ class FullPdbFunctionImporter(PdbFunctionImporter):
 
     def get_matching_register_symbol(
         self, register: str
-    ) -> Optional[CppRegisterSymbol]:
+    ) -> CppRegisterSymbol | None:
         return next(
             (
                 symbol

--- a/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
+++ b/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
@@ -35,7 +35,7 @@ class FunctionSignature:
     call_type: str
     arglist: list[str]
     return_type: str
-    class_type: Optional[str]
+    class_type: str | None
     stack_symbols: list[CppStackOrRegisterSymbol]
     # if non-zero: an offset to the `this` parameter in a __thiscall
     this_adjust: int
@@ -44,7 +44,7 @@ class FunctionSignature:
 @dataclass
 class PdbFunction:
     match_info: ReccmpMatch
-    signature: Optional[FunctionSignature]
+    signature: FunctionSignature | None
     is_stub: bool
 
 
@@ -65,14 +65,14 @@ class PdbFunctionExtractor:
         "STD Near": "__stdcall",
     }
 
-    def _get_cvdump_type(self, type_name: Optional[str]) -> Optional[dict[str, Any]]:
+    def _get_cvdump_type(self, type_name: str | None) -> dict[str, Any | None]:
         return (
             None
             if type_name is None
             else self.compare.cv.types.keys.get(type_name.lower())
         )
 
-    def get_func_signature(self, fn: SymbolsEntry) -> Optional[FunctionSignature]:
+    def get_func_signature(self, fn: SymbolsEntry) -> FunctionSignature | None:
         function_type_str = fn.func_type
         if function_type_str == "T_NOTYPE(0000)":
             logger.debug("Treating NOTYPE function as thunk: %s", fn.name)
@@ -141,7 +141,7 @@ class PdbFunctionExtractor:
         )
         return [signature for signature in handled if signature is not None]
 
-    def handle_matched_function(self, match_info: ReccmpMatch) -> Optional[PdbFunction]:
+    def handle_matched_function(self, match_info: ReccmpMatch) -> PdbFunction | None:
         function_data = next(
             (
                 y

--- a/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
+++ b/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import re
-from typing import Any, Optional
+from typing import Any
 import logging
 
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError

--- a/reccmp/ghidra_scripts/lego_util/type_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/type_importer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Iterator, Optional, TypeVar
+from typing import Any, Callable, Iterator, TypeVar
 
 # Disable spurious warnings in vscode / pylance
 # pyright: reportMissingModuleSource=false

--- a/reccmp/ghidra_scripts/lego_util/type_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/type_importer.py
@@ -326,7 +326,7 @@ class PdbTypeImporter:
         class_name_with_namespace: str,
         current_type: StructureInternal,
     ) -> Iterator[dict[str, Any]]:
-        vbasepointer: Optional[VirtualBasePointer] = field_list.get("vbase", None)
+        vbasepointer: VirtualBasePointer | None = field_list.get("vbase", None)
 
         if vbasepointer is not None and any(x.direct for x in vbasepointer.bases):
             vbaseptr_type = get_or_add_pointer_type(

--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Sequence, Tuple, Set
+from typing import Sequence, Tuple, Set
 
 DiffOpcode = Tuple[str, int, int, int, int]
 

--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -42,7 +42,7 @@ def is_operand_swap(a: str, b: str) -> bool:
     return a.partition(", ")[0] != b.partition(", ")[0] and sorted(a) == sorted(b)
 
 
-def can_cmp_swap(orig: List[str], recomp: List[str]) -> bool:
+def can_cmp_swap(orig: list[str], recomp: list[str]) -> bool:
     # Make sure we have 1 cmp and 1 jmp for both
     if len(orig) != 2 or len(recomp) != 2:
         return False
@@ -72,7 +72,7 @@ def patch_jump(a: str, b: str) -> str:
 
 
 def patch_cmp_swaps(
-    codes: Sequence[DiffOpcode], orig_asm: List[str], recomp_asm: List[str]
+    codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
 ) -> Set[int]:
     """Can we resolve the diffs between orig and recomp by patching
     swapped cmp instructions?
@@ -107,7 +107,7 @@ def patch_cmp_swaps(
     return fixed_lines
 
 
-def effective_match_possible(orig_asm: List[str], recomp_asm: List[str]) -> bool:
+def effective_match_possible(orig_asm: list[str], recomp_asm: list[str]) -> bool:
     # We can only declare an effective match based on the text
     # so you need the same amount of "stuff" in each
     if len(orig_asm) != len(recomp_asm):
@@ -124,11 +124,11 @@ def effective_match_possible(orig_asm: List[str], recomp_asm: List[str]) -> bool
     return True
 
 
-def find_regs_used(inst: str) -> List[str]:
+def find_regs_used(inst: str) -> list[str]:
     return REG_FIND.findall(inst)
 
 
-def find_regs_changed(a: str, b: str) -> List[Tuple[str, str]]:
+def find_regs_changed(a: str, b: str) -> list[Tuple[str, str]]:
     """For instructions a, b, return the pairs of registers that were used.
     This is not a very precise way to compare the instructions, so it depends
     on the input being two instructions that would match *except* for
@@ -137,7 +137,7 @@ def find_regs_changed(a: str, b: str) -> List[Tuple[str, str]]:
 
 
 def bad_register_swaps(
-    swaps: Set[int], orig_asm: List[str], recomp_asm: List[str]
+    swaps: Set[int], orig_asm: list[str], recomp_asm: list[str]
 ) -> Set[int]:
     """The list of recomp indices in `swaps` tells which instructions are
     a match for orig except for the registers used. From that list, check
@@ -188,7 +188,7 @@ def instruction_alters_regs(inst: str, regs: Set[str]) -> bool:
 
 
 def relocate_instructions(
-    codes: Sequence[DiffOpcode], orig_asm: List[str], recomp_asm: List[str]
+    codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
 ) -> Set[int]:
     """Collect the list of instructions deleted from orig and inserted
     into recomp, according to the diff opcodes. Using this list, match up
@@ -234,7 +234,7 @@ WORD_REGS = ("ax", "bx", "cx", "dx", "si", "di", "bp", "sp")
 BYTE_REGS = ("ah", "al", "bh", "bl", "ch", "cl", "dh", "dl")
 
 
-def naive_register_replacement(orig_asm: List[str], recomp_asm: List[str]) -> Set[int]:
+def naive_register_replacement(orig_asm: list[str], recomp_asm: list[str]) -> Set[int]:
     """Replace all registers of the same size with a placeholder string.
     After doing that, compare orig and recomp again.
     Return indices from recomp that are now equal to the same index in orig.
@@ -265,7 +265,7 @@ def naive_register_replacement(orig_asm: List[str], recomp_asm: List[str]) -> Se
 
 
 def find_effective_match(
-    codes: Sequence[DiffOpcode], orig_asm: List[str], recomp_asm: List[str]
+    codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
 ) -> bool:
     """Check whether the two sequences of instructions are an effective match.
     Meaning: do they differ only by instruction order or register selection?"""
@@ -302,7 +302,7 @@ def find_effective_match(
     return corrections.issuperset(recomp_lines_disputed)
 
 
-def assert_fixup(asm: List[Tuple[str, str]]):
+def assert_fixup(asm: list[Tuple[str, str]]):
     """Detect assert calls and replace the code filename and line number
     values with macros (from assert.h)."""
     for i, (_, line) in enumerate(asm):

--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -1,5 +1,5 @@
 import re
-from typing import Sequence, Set
+from typing import Sequence
 
 DiffOpcode = tuple[str, int, int, int, int]
 
@@ -73,7 +73,7 @@ def patch_jump(a: str, b: str) -> str:
 
 def patch_cmp_swaps(
     codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
-) -> Set[int]:
+) -> set[int]:
     """Can we resolve the diffs between orig and recomp by patching
     swapped cmp instructions?
     For example:
@@ -137,8 +137,8 @@ def find_regs_changed(a: str, b: str) -> list[tuple[str, str]]:
 
 
 def bad_register_swaps(
-    swaps: Set[int], orig_asm: list[str], recomp_asm: list[str]
-) -> Set[int]:
+    swaps: set[int], orig_asm: list[str], recomp_asm: list[str]
+) -> set[int]:
     """The list of recomp indices in `swaps` tells which instructions are
     a match for orig except for the registers used. From that list, check
     whether a register swap should not be allowed.
@@ -178,7 +178,7 @@ def bad_register_swaps(
 MODIFIER_INSTRUCTIONS = ("adc", "add", "lea", "mov", "neg", "sbb", "sub", "pop", "xor")
 
 
-def instruction_alters_regs(inst: str, regs: Set[str]) -> bool:
+def instruction_alters_regs(inst: str, regs: set[str]) -> bool:
     (mnemonic, _, op_str) = inst.partition(" ")
     (first_operand, _, __) = op_str.partition(", ")
 
@@ -189,7 +189,7 @@ def instruction_alters_regs(inst: str, regs: Set[str]) -> bool:
 
 def relocate_instructions(
     codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
-) -> Set[int]:
+) -> set[int]:
     """Collect the list of instructions deleted from orig and inserted
     into recomp, according to the diff opcodes. Using this list, match up
     any pairs of instructions that we assume to be relocated and return
@@ -234,7 +234,7 @@ WORD_REGS = ("ax", "bx", "cx", "dx", "si", "di", "bp", "sp")
 BYTE_REGS = ("ah", "al", "bh", "bl", "ch", "cl", "dh", "dl")
 
 
-def naive_register_replacement(orig_asm: list[str], recomp_asm: list[str]) -> Set[int]:
+def naive_register_replacement(orig_asm: list[str], recomp_asm: list[str]) -> set[int]:
     """Replace all registers of the same size with a placeholder string.
     After doing that, compare orig and recomp again.
     Return indices from recomp that are now equal to the same index in orig.

--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -1,7 +1,7 @@
 import re
-from typing import Sequence, Tuple, Set
+from typing import Sequence, Set
 
-DiffOpcode = Tuple[str, int, int, int, int]
+DiffOpcode = tuple[str, int, int, int, int]
 
 REG_FIND = re.compile(r"(?: |\[)(e?[a-d]x|e?[s,d]i|[a-d][l,h]|e?[b,s]p)")
 
@@ -128,7 +128,7 @@ def find_regs_used(inst: str) -> list[str]:
     return REG_FIND.findall(inst)
 
 
-def find_regs_changed(a: str, b: str) -> list[Tuple[str, str]]:
+def find_regs_changed(a: str, b: str) -> list[tuple[str, str]]:
     """For instructions a, b, return the pairs of registers that were used.
     This is not a very precise way to compare the instructions, so it depends
     on the input being two instructions that would match *except* for
@@ -302,7 +302,7 @@ def find_effective_match(
     return corrections.issuperset(recomp_lines_disputed)
 
 
-def assert_fixup(asm: list[Tuple[str, str]]):
+def assert_fixup(asm: list[tuple[str, str]]):
     """Detect assert calls and replace the code filename and line number
     values with macros (from assert.h)."""
     for i, (_, line) in enumerate(asm):

--- a/reccmp/isledecomp/compare/asm/instgen.py
+++ b/reccmp/isledecomp/compare/asm/instgen.py
@@ -5,14 +5,14 @@ import re
 import bisect
 import struct
 from enum import Enum, auto
-from typing import Iterable, Literal, NamedTuple, Tuple
+from typing import Iterable, Literal, NamedTuple
 from capstone import Cs, CS_ARCH_X86, CS_MODE_32  # type: ignore
 from .const import JUMP_MNEMONICS
 from .types import DisasmLiteInst
 
 disassembler = Cs(CS_ARCH_X86, CS_MODE_32)
 
-DisasmLiteTuple = Tuple[int, int, str, str]
+DisasmLiteTuple = tuple[int, int, str, str]
 
 displacement_regex = re.compile(r".*\+ (0x[0-9a-f]+)\]")
 
@@ -33,7 +33,7 @@ TabSectionType = Literal[SectionType.DATA_TAB] | Literal[SectionType.ADDR_TAB]
 
 class TabSection(NamedTuple):
     type: TabSectionType
-    contents: list[Tuple[int, int]]
+    contents: list[tuple[int, int]]
 
 
 FuncSection = CodeSection | TabSection

--- a/reccmp/isledecomp/compare/asm/instgen.py
+++ b/reccmp/isledecomp/compare/asm/instgen.py
@@ -5,7 +5,7 @@ import re
 import bisect
 import struct
 from enum import Enum, auto
-from typing import Iterable, List, Literal, NamedTuple, Optional, Tuple
+from typing import Iterable, Literal, NamedTuple, Tuple
 from capstone import Cs, CS_ARCH_X86, CS_MODE_32  # type: ignore
 from .const import JUMP_MNEMONICS
 from .types import DisasmLiteInst

--- a/reccmp/isledecomp/compare/asm/instgen.py
+++ b/reccmp/isledecomp/compare/asm/instgen.py
@@ -25,7 +25,7 @@ class SectionType(Enum):
 
 class CodeSection(NamedTuple):
     type: Literal[SectionType.CODE]
-    contents: List[DisasmLiteInst]
+    contents: list[DisasmLiteInst]
 
 
 TabSectionType = Literal[SectionType.DATA_TAB] | Literal[SectionType.ADDR_TAB]
@@ -33,7 +33,7 @@ TabSectionType = Literal[SectionType.DATA_TAB] | Literal[SectionType.ADDR_TAB]
 
 class TabSection(NamedTuple):
     type: TabSectionType
-    contents: List[Tuple[int, int]]
+    contents: list[Tuple[int, int]]
 
 
 FuncSection = CodeSection | TabSection
@@ -59,19 +59,19 @@ class InstructGen:
         self.start = start
         self.end = len(blob) + start
         self.section_end: int = self.end
-        self.code_tracks: List[List[DisasmLiteInst]] = []
+        self.code_tracks: list[list[DisasmLiteInst]] = []
 
         # Todo: Could be refactored later
         self.cur_addr: int = 0
         self.cur_section_type: SectionType = SectionType.CODE
         self.section_start = start
 
-        self.sections: List[FuncSection] = []
+        self.sections: list[FuncSection] = []
 
         self.confirmed_addrs: dict[int, SectionType] = {}
         self.analysis()
 
-    def _finish_code_section(self, contents: List[DisasmLiteInst]):
+    def _finish_code_section(self, contents: list[DisasmLiteInst]):
         self.sections.append(CodeSection(SectionType.CODE, contents))
 
     def _finish_tab_section(self, type_: TabSectionType, stuff: list[tuple[int, int]]):
@@ -94,7 +94,7 @@ class InstructGen:
         if type_ != self.cur_section_type and addr > self.cur_addr:
             self.section_end = min(self.section_end, addr)
 
-    def _next_section(self, addr: int) -> Optional[SectionType]:
+    def _next_section(self, addr: int) -> SectionType | None:
         """We have reached the start of a new section. Tell what kind of
         data we are looking at (code or other) and how much we should read."""
 
@@ -134,7 +134,7 @@ class InstructGen:
 
         return new_type
 
-    def _get_code_for(self, addr: int) -> List[DisasmLiteInst]:
+    def _get_code_for(self, addr: int) -> list[DisasmLiteInst]:
         """Start disassembling at the given address."""
         # If we are reading a code block beyond the first, see if we already
         # have disassembled instructions beginning at the specified address.

--- a/reccmp/isledecomp/compare/asm/parse.py
+++ b/reccmp/isledecomp/compare/asm/parse.py
@@ -25,7 +25,7 @@ immediate_replace_regex = re.compile(r"(?:^|, )(0x[0-9a-f]+)")
 
 
 @cache
-def from_hex(string: str) -> Optional[int]:
+def from_hex(string: str) -> int | None:
     try:
         return int(string, 16)
     except ValueError:
@@ -34,7 +34,7 @@ def from_hex(string: str) -> Optional[int]:
     return None
 
 
-def bytes_to_dword(b: bytes) -> Optional[int]:
+def bytes_to_dword(b: bytes) -> int | None:
     if len(b) == 4:
         return struct.unpack("<L", b)[0]
 
@@ -44,9 +44,9 @@ def bytes_to_dword(b: bytes) -> Optional[int]:
 class ParseAsm:
     def __init__(
         self,
-        addr_test: Optional[AddrTestProtocol] = None,
-        name_lookup: Optional[NameReplacementProtocol] = None,
-        bin_lookup: Optional[Callable[[int, int], Optional[bytes]]] = None,
+        addr_test: AddrTestProtocol | None = None,
+        name_lookup: NameReplacementProtocol | None = None,
+        bin_lookup: Callable[[int, int], bytes | None] | None = None,
     ) -> None:
         self.addr_test = addr_test
         self.name_lookup = name_lookup
@@ -64,7 +64,7 @@ class ParseAsm:
 
         return False
 
-    def lookup(self, addr: int, exact: bool = False) -> Optional[str]:
+    def lookup(self, addr: int, exact: bool = False) -> str | None:
         """Wrapper for user-provided name lookup"""
         if callable(self.name_lookup):
             return self.name_lookup(addr, exact=exact)

--- a/reccmp/isledecomp/compare/asm/parse.py
+++ b/reccmp/isledecomp/compare/asm/parse.py
@@ -9,7 +9,7 @@ placeholder string."""
 import re
 import struct
 from functools import cache
-from typing import Callable, Optional, Tuple
+from typing import Callable, Tuple
 from .const import JUMP_MNEMONICS, SINGLE_OPERAND_INSTS
 from .instgen import InstructGen, SectionType
 from .replacement import AddrTestProtocol, NameReplacementProtocol

--- a/reccmp/isledecomp/compare/asm/parse.py
+++ b/reccmp/isledecomp/compare/asm/parse.py
@@ -9,7 +9,7 @@ placeholder string."""
 import re
 import struct
 from functools import cache
-from typing import Callable, Tuple
+from typing import Callable
 from .const import JUMP_MNEMONICS, SINGLE_OPERAND_INSTS
 from .instgen import InstructGen, SectionType
 from .replacement import AddrTestProtocol, NameReplacementProtocol
@@ -134,7 +134,7 @@ class ParseAsm:
 
         return match.group(0).replace(match.group(1), self.replace(value))
 
-    def sanitize(self, inst: DisasmLiteInst) -> Tuple[str, str]:
+    def sanitize(self, inst: DisasmLiteInst) -> tuple[str, str]:
         # For jumps or calls, if the entire op_str is a hex number, the value
         # is a relative offset.
         # Otherwise (i.e. it looks like `dword ptr [address]`) it is an

--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -1,5 +1,5 @@
 from functools import cache
-from typing import Callable, Protocol, Optional
+from typing import Callable, Protocol
 from reccmp.isledecomp.compare.db import ReccmpEntity
 from reccmp.isledecomp.types import SymbolType
 

--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -10,17 +10,17 @@ class AddrTestProtocol(Protocol):
 
 
 class NameReplacementProtocol(Protocol):
-    def __call__(self, addr: int, exact: bool = False) -> Optional[str]:
+    def __call__(self, addr: int, exact: bool = False) -> str | None:
         pass
 
 
 def create_name_lookup(
-    db_getter: Callable[[int, bool], Optional[ReccmpEntity]], addr_attribute: str
+    db_getter: Callable[[int, bool], ReccmpEntity | None], addr_attribute: str
 ) -> NameReplacementProtocol:
     """Function generator for name replacement"""
 
     @cache
-    def lookup(addr: int, exact: bool = False) -> Optional[str]:
+    def lookup(addr: int, exact: bool = False) -> str | None:
         m = db_getter(addr, exact)
         if m is None:
             return None

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -772,9 +772,7 @@ class Compare:
             [t for (t,) in struct.iter_unpack("<L", recomp_table)],
         )
 
-        def match_text(
-            m: ReccmpEntity | None, raw_addr: int | None = None
-        ) -> str:
+        def match_text(m: ReccmpEntity | None, raw_addr: int | None = None) -> str:
             """Format the function reference at this vtable index as text.
             If we have not identified this function, we have the option to
             display the raw address. This is only worth doing for the original addr

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -31,7 +31,7 @@ class DiffReport:
     orig_addr: int
     recomp_addr: int
     name: str
-    udiff: Optional[CombinedDiffOutput] = None
+    udiff: CombinedDiffOutput | None = None
     ratio: float = 0.0
     is_effective_match: bool = False
     is_stub: bool = False
@@ -54,10 +54,10 @@ def create_reloc_lookup(bin_file: PEImage) -> Callable[[int], bool]:
     return lookup
 
 
-def create_bin_lookup(bin_file: PEImage) -> Callable[[int, int], Optional[bytes]]:
+def create_bin_lookup(bin_file: PEImage) -> Callable[[int, int], bytes | None]:
     """Function generator for reading from the bin file"""
 
-    def lookup(addr: int, size: int) -> Optional[bytes]:
+    def lookup(addr: int, size: int) -> bytes | None:
         try:
             return bin_file.read(addr, size)
         except InvalidVirtualAddressError:
@@ -773,7 +773,7 @@ class Compare:
         )
 
         def match_text(
-            m: Optional[ReccmpEntity], raw_addr: Optional[int] = None
+            m: ReccmpEntity | None, raw_addr: int | None = None
         ) -> str:
             """Format the function reference at this vtable index as text.
             If we have not identified this function, we have the option to
@@ -841,7 +841,7 @@ class Compare:
             ratio=ratio,
         )
 
-    def _compare_match(self, match: ReccmpMatch) -> Optional[DiffReport]:
+    def _compare_match(self, match: ReccmpMatch) -> DiffReport | None:
         """Router for comparison type"""
 
         if match.size is None or match.size == 0:
@@ -884,10 +884,10 @@ class Compare:
 
         return match.recomp_addr == recomp_addr
 
-    def get_by_orig(self, addr: int) -> Optional[ReccmpEntity]:
+    def get_by_orig(self, addr: int) -> ReccmpEntity | None:
         return self._db.get_by_orig(addr)
 
-    def get_by_recomp(self, addr: int) -> Optional[ReccmpEntity]:
+    def get_by_recomp(self, addr: int) -> ReccmpEntity | None:
         return self._db.get_by_recomp(addr)
 
     def get_all(self) -> Iterator[ReccmpEntity]:
@@ -902,7 +902,7 @@ class Compare:
     def get_variables(self) -> Iterator[ReccmpMatch]:
         return self._db.get_matches_by_type(SymbolType.DATA)
 
-    def compare_address(self, addr: int) -> Optional[DiffReport]:
+    def compare_address(self, addr: int) -> DiffReport | None:
         match = self._db.get_one_match(addr)
         if match is None:
             return None

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import struct
 import uuid
 from dataclasses import dataclass
-from typing import Callable, Iterable, Iterator, Optional
+from typing import Callable, Iterable, Iterator
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
 from reccmp.isledecomp.formats.pe import PEImage
 from reccmp.isledecomp.cvdump.demangler import demangle_string_const

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -5,7 +5,7 @@ import sqlite3
 import logging
 import json
 from functools import cached_property
-from typing import Any, Iterable, Iterator, List, Optional
+from typing import Any, Iterable, Iterator
 from reccmp.isledecomp.types import SymbolType
 from reccmp.isledecomp.cvdump.demangler import get_vtordisp_name
 

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -27,12 +27,12 @@ SymbolTypeLookup: dict[int, str] = {
 class ReccmpEntity:
     """ORM object for Reccmp database entries."""
 
-    _orig_addr: Optional[int]
-    _recomp_addr: Optional[int]
+    _orig_addr: int | None
+    _recomp_addr: int | None
     _kvstore: str
 
     def __init__(
-        self, orig: Optional[int], recomp: Optional[int], kvstore: str = "{}"
+        self, orig: int | None, recomp: int | None, kvstore: str = "{}"
     ) -> None:
         """Requires one or both of the addresses to be defined"""
         assert orig is not None or recomp is not None
@@ -45,19 +45,19 @@ class ReccmpEntity:
         return json.loads(self._kvstore)
 
     @property
-    def orig_addr(self) -> Optional[int]:
+    def orig_addr(self) -> int | None:
         return self._orig_addr
 
     @property
-    def recomp_addr(self) -> Optional[int]:
+    def recomp_addr(self) -> int | None:
         return self._recomp_addr
 
     @property
-    def compare_type(self) -> Optional[int]:
+    def compare_type(self) -> int | None:
         return self.options.get("type")
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         return self.options.get("name")
 
     @property
@@ -72,7 +72,7 @@ class ReccmpEntity:
     def get(self, key: str, default: Any = None) -> Any:
         return self.options.get(key, default)
 
-    def match_name(self) -> Optional[str]:
+    def match_name(self) -> str | None:
         """Combination of the name and compare type.
         Intended for name substitution in the diff. If there is a diff,
         it will be more obvious what this symbol indicates."""
@@ -83,7 +83,7 @@ class ReccmpEntity:
         name = repr(self.name) if self.compare_type == SymbolType.STRING else self.name
         return f"{name} ({ctype})"
 
-    def offset_name(self, ofs: int) -> Optional[str]:
+    def offset_name(self, ofs: int) -> str | None:
         if self.name is None:
             return None
 
@@ -177,7 +177,7 @@ class CompareDb:
             "UPDATE or ignore symbols SET orig_addr = ? WHERE recomp_addr = ?", pairs
         )
 
-    def get_unmatched_strings(self) -> List[str]:
+    def get_unmatched_strings(self) -> list[str]:
         """Return any strings not already identified by `STRING` markers."""
 
         cur = self._sql.execute(
@@ -204,7 +204,7 @@ class CompareDb:
         cur.row_factory = matched_entity_factory
         yield from cur
 
-    def get_one_match(self, addr: int) -> Optional[ReccmpMatch]:
+    def get_one_match(self, addr: int) -> ReccmpMatch | None:
         cur = self._sql.execute(
             """SELECT orig_addr, recomp_addr, kvstore FROM symbols
             WHERE orig_addr = ?
@@ -215,7 +215,7 @@ class CompareDb:
         cur.row_factory = matched_entity_factory
         return cur.fetchone()
 
-    def _get_closest_orig(self, addr: int) -> Optional[int]:
+    def _get_closest_orig(self, addr: int) -> int | None:
         for (value,) in self._sql.execute(
             "SELECT orig_addr FROM symbols WHERE ? >= orig_addr ORDER BY orig_addr desc LIMIT 1",
             (addr,),
@@ -224,7 +224,7 @@ class CompareDb:
 
         return None
 
-    def _get_closest_recomp(self, addr: int) -> Optional[int]:
+    def _get_closest_recomp(self, addr: int) -> int | None:
         for (value,) in self._sql.execute(
             "SELECT recomp_addr FROM symbols WHERE ? >= recomp_addr ORDER BY recomp_addr desc LIMIT 1",
             (addr,),
@@ -233,7 +233,7 @@ class CompareDb:
 
         return None
 
-    def get_by_orig(self, orig: int, exact: bool = True) -> Optional[ReccmpEntity]:
+    def get_by_orig(self, orig: int, exact: bool = True) -> ReccmpEntity | None:
         addr = self._get_closest_orig(orig)
         if addr is None or exact and orig != addr:
             return None
@@ -245,7 +245,7 @@ class CompareDb:
         cur.row_factory = entity_factory
         return cur.fetchone()
 
-    def get_by_recomp(self, recomp: int, exact: bool = True) -> Optional[ReccmpEntity]:
+    def get_by_recomp(self, recomp: int, exact: bool = True) -> ReccmpEntity | None:
         addr = self._get_closest_recomp(recomp)
         if addr is None or exact and recomp != addr:
             return None
@@ -278,7 +278,7 @@ class CompareDb:
         return cur.fetchone() is not None
 
     def set_pair(
-        self, orig: int, recomp: int, compare_type: Optional[SymbolType] = None
+        self, orig: int, recomp: int, compare_type: SymbolType | None = None
     ) -> bool:
         if self._orig_used(orig):
             logger.debug("Original address %s not unique!", hex(orig))
@@ -292,7 +292,7 @@ class CompareDb:
         return cur.rowcount > 0
 
     def set_pair_tentative(
-        self, orig: int, recomp: int, compare_type: Optional[SymbolType] = None
+        self, orig: int, recomp: int, compare_type: SymbolType | None = None
     ) -> bool:
         """Declare a match for the original and recomp addresses given, but only if:
         1. The original address is not used elsewhere (as with set_pair)
@@ -481,7 +481,7 @@ class CompareDb:
 
         return False
 
-    def get_next_orig_addr(self, addr: int) -> Optional[int]:
+    def get_next_orig_addr(self, addr: int) -> int | None:
         """Return the original address (matched or not) that follows
         the one given. If our recomp function size would cause us to read
         too many bytes for the original function, we can adjust it."""
@@ -508,7 +508,7 @@ class CompareDb:
         return did_match
 
     def match_vtable(
-        self, addr: int, class_name: str, base_class: Optional[str] = None
+        self, addr: int, class_name: str, base_class: str | None = None
     ) -> bool:
         """Match the vtable for the given class name. If a base class is provided,
         we will match the multiple inheritance vtable instead.

--- a/reccmp/isledecomp/compare/diff.py
+++ b/reccmp/isledecomp/compare/diff.py
@@ -1,17 +1,17 @@
 from difflib import SequenceMatcher
-from typing import Tuple, TypedDict
+from typing import TypedDict
 
-CombinedDiffInput = list[Tuple[str, str]]
+CombinedDiffInput = list[tuple[str, str]]
 
-MatchingBlock = TypedDict("MatchingBlock", {"both": list[Tuple[str, str, str]]})
+MatchingBlock = TypedDict("MatchingBlock", {"both": list[tuple[str, str, str]]})
 MismatchingBlock = TypedDict(
-    "MismatchingBlock", {"orig": list[Tuple[str, str]], "recomp": list[Tuple[str, str]]}
+    "MismatchingBlock", {"orig": list[tuple[str, str]], "recomp": list[tuple[str, str]]}
 )
 MatchingOrMismatchingBlock = MatchingBlock | MismatchingBlock
 
-# Tuple[str, list[...]]: One contiguous part of the diff (without skipping matching code)
+# tuple[str, list[...]]: One contiguous part of the diff (without skipping matching code)
 # list[...]: The list of all the contiguous diffs of a given function
-CombinedDiffOutput = list[Tuple[str, list[MatchingOrMismatchingBlock]]]
+CombinedDiffOutput = list[tuple[str, list[MatchingOrMismatchingBlock]]]
 
 
 def combined_diff(

--- a/reccmp/isledecomp/compare/diff.py
+++ b/reccmp/isledecomp/compare/diff.py
@@ -1,17 +1,17 @@
 from difflib import SequenceMatcher
 from typing import List, Tuple, TypedDict
 
-CombinedDiffInput = List[Tuple[str, str]]
+CombinedDiffInput = list[Tuple[str, str]]
 
-MatchingBlock = TypedDict("MatchingBlock", {"both": List[Tuple[str, str, str]]})
+MatchingBlock = TypedDict("MatchingBlock", {"both": list[Tuple[str, str, str]]})
 MismatchingBlock = TypedDict(
-    "MismatchingBlock", {"orig": List[Tuple[str, str]], "recomp": List[Tuple[str, str]]}
+    "MismatchingBlock", {"orig": list[Tuple[str, str]], "recomp": list[Tuple[str, str]]}
 )
 MatchingOrMismatchingBlock = MatchingBlock | MismatchingBlock
 
-# Tuple[str, List[...]]: One contiguous part of the diff (without skipping matching code)
-# List[...]: The list of all the contiguous diffs of a given function
-CombinedDiffOutput = List[Tuple[str, List[MatchingOrMismatchingBlock]]]
+# Tuple[str, list[...]]: One contiguous part of the diff (without skipping matching code)
+# list[...]: The list of all the contiguous diffs of a given function
+CombinedDiffOutput = list[Tuple[str, list[MatchingOrMismatchingBlock]]]
 
 
 def combined_diff(
@@ -33,7 +33,7 @@ def combined_diff(
     unified_diff = []
 
     for group in diff.get_grouped_opcodes(context_size):
-        subgroups: List[MatchingOrMismatchingBlock] = []
+        subgroups: list[MatchingOrMismatchingBlock] = []
 
         # Keep track of the addresses we've seen in this diff group.
         # This helps create the "@@" line. (Does this have a name?)

--- a/reccmp/isledecomp/compare/diff.py
+++ b/reccmp/isledecomp/compare/diff.py
@@ -1,5 +1,5 @@
 from difflib import SequenceMatcher
-from typing import List, Tuple, TypedDict
+from typing import Tuple, TypedDict
 
 CombinedDiffInput = list[Tuple[str, str]]
 

--- a/reccmp/isledecomp/cvdump/analysis.py
+++ b/reccmp/isledecomp/cvdump/analysis.py
@@ -14,29 +14,29 @@ class CvdumpNode:
     section: int
     offset: int
     # aka the mangled name from the PUBLICS section
-    decorated_name: Optional[str] = None
+    decorated_name: str | None = None
     # optional "nicer" name (e.g. of a function from SYMBOLS section)
-    friendly_name: Optional[str] = None
+    friendly_name: str | None = None
     # To be determined by context after inserting data, unless the decorated
     # name makes this obvious. (i.e. string constants or vtables)
     # We choose not to assume that section 1 (probably ".text") contains only
     # functions. Smacker functions are linked to their own section "_UNSTEXT"
-    node_type: Optional[SymbolType] = None
+    node_type: SymbolType | None = None
     # Function size can be read from the LINES section so use this over any
     # other value if we have it.
     # TYPES section can tell us the size of structs and other complex types.
-    confirmed_size: Optional[int] = None
+    confirmed_size: int | None = None
     # Estimated by reading the distance between this symbol and the one that
     # follows in the same section.
     # If this is the last symbol in the section, we cannot estimate a size.
-    estimated_size: Optional[int] = None
+    estimated_size: int | None = None
     # Size as reported by SECTION CONTRIBUTIONS section. Not guaranteed to be
     # accurate.
-    section_contribution: Optional[int] = None
-    addr: Optional[int] = None
-    symbol_entry: Optional[SymbolsEntry] = None
+    section_contribution: int | None = None
+    addr: int | None = None
+    symbol_entry: SymbolsEntry | None = None
     # Preliminary - only used for non-static variables at the moment
-    data_type: Optional[TypeInfo] = None
+    data_type: TypeInfo | None = None
 
     def __init__(self, section: int, offset: int) -> None:
         self.section = section
@@ -69,7 +69,7 @@ class CvdumpNode:
             # https://learn.microsoft.com/en-us/cpp/build/reference/decorated-names?view=msvc-170#FormatC
             self.node_type = SymbolType.FUNCTION
 
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """Prefer "friendly" name if we have it.
         This is what we have been using to match functions."""
         return (
@@ -78,7 +78,7 @@ class CvdumpNode:
             else self.decorated_name
         )
 
-    def size(self) -> Optional[int]:
+    def size(self) -> int | None:
         if self.confirmed_size is not None:
             return self.confirmed_size
 

--- a/reccmp/isledecomp/cvdump/analysis.py
+++ b/reccmp/isledecomp/cvdump/analysis.py
@@ -1,6 +1,5 @@
 """For collating the results from parsing cvdump.exe into a more directly useful format."""
 
-from typing import Optional
 from reccmp.isledecomp.types import SymbolType
 from .demangler import demangle_string_const, demangle_vtable
 from .parser import CvdumpParser

--- a/reccmp/isledecomp/cvdump/demangler.py
+++ b/reccmp/isledecomp/cvdump/demangler.py
@@ -4,7 +4,7 @@ https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling
 """
 
 import re
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 import pydemangler  # type: ignore
 
 

--- a/reccmp/isledecomp/cvdump/demangler.py
+++ b/reccmp/isledecomp/cvdump/demangler.py
@@ -36,7 +36,7 @@ class StringConstInfo(NamedTuple):
     is_utf16: bool
 
 
-def demangle_string_const(symbol: str) -> Optional[StringConstInfo]:
+def demangle_string_const(symbol: str) -> StringConstInfo | None:
     """Don't bother to decode the string text from the symbol.
     We can just read it from the binary once we have the length."""
     match = string_const_regex.match(symbol)
@@ -56,7 +56,7 @@ def demangle_string_const(symbol: str) -> Optional[StringConstInfo]:
     return StringConstInfo(len=strlen, is_utf16=is_utf16)
 
 
-def get_vtordisp_name(symbol: str) -> Optional[str]:
+def get_vtordisp_name(symbol: str) -> str | None:
     # pylint: disable=c-extension-no-member
     """For adjuster thunk functions, the PDB will sometimes use a name
     that contains "vtordisp" but often will just reuse the name of the

--- a/reccmp/isledecomp/cvdump/parser.py
+++ b/reccmp/isledecomp/cvdump/parser.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, NamedTuple, Tuple
+from typing import Iterable, NamedTuple
 from .types import CvdumpTypesParser
 from .symbols import CvdumpSymbolsParser
 
@@ -91,7 +91,7 @@ class CvdumpParser:
     # pylint: disable=too-many-instance-attributes
     def __init__(self) -> None:
         self._section: str = ""
-        self._lines_function: Tuple[str, int] = ("", 0)
+        self._lines_function: tuple[str, int] = ("", 0)
 
         self.lines: dict[tuple[int, int], tuple[str, int]] = {}
         self.publics: list[PublicsEntry] = []

--- a/reccmp/isledecomp/cvdump/runner.py
+++ b/reccmp/isledecomp/cvdump/runner.py
@@ -1,7 +1,6 @@
 import io
 from os import name as os_name
 from enum import Enum
-from typing import List
 import subprocess
 from reccmp.bin import lib_path_join
 from reccmp.isledecomp.dir import winepath_unix_to_win

--- a/reccmp/isledecomp/cvdump/runner.py
+++ b/reccmp/isledecomp/cvdump/runner.py
@@ -62,7 +62,7 @@ class Cvdump:
         self._options.add(DumpOpt.TYPES)
         return self
 
-    def cmd_line(self) -> List[str]:
+    def cmd_line(self) -> list[str]:
         cvdump_exe = lib_path_join("cvdump.exe")
         flags = [cvdump_opt_map[opt] for opt in self._options]
 

--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -28,7 +28,7 @@ class SymbolsEntry:
     name: str
     stack_symbols: list[StackOrRegisterSymbol] = field(default_factory=list)
     frame_pointer_present: bool = False
-    addr: Optional[int] = None  # Absolute address. Will be set later, if at all
+    addr: int | None = None  # Absolute address. Will be set later, if at all
 
 
 class CvdumpSymbolsParser:
@@ -87,7 +87,7 @@ class CvdumpSymbolsParser:
 
     def __init__(self):
         self.symbols: list[SymbolsEntry] = []
-        self.current_function: Optional[SymbolsEntry] = None
+        self.current_function: SymbolsEntry | None = None
         # If we read an S_BLOCK32 node, increment this level.
         # This is so we do not end the proc early by reading an S_END
         # that indicates the end of the block.
@@ -115,7 +115,7 @@ class CvdumpSymbolsParser:
 
     def _parse_generic_case(self, line, line_match: Match[str]):
         symbol_type: str = line_match.group("symbol_type")
-        second_part: Optional[str] = line_match.group("second_part")
+        second_part: str | None = line_match.group("second_part")
 
         if symbol_type in ["S_GPROC32", "S_LPROC32"]:
             assert second_part is not None

--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 import logging
 import re
 from re import Match
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 
 logger = logging.getLogger(__name__)

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import re
 import logging
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple
 
 
 logger = logging.getLogger(__name__)

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import re
 import logging
-from typing import Any, Dict, NamedTuple
+from typing import Any, NamedTuple
 
 
 logger = logging.getLogger(__name__)
@@ -265,7 +265,7 @@ class CvdumpTypesParser:
     def __init__(self) -> None:
         self.mode: str | None = None
         self.last_key = ""
-        self.keys: Dict[str, Dict[str, Any]] = {}
+        self.keys: dict[str, dict[str, Any]] = {}
 
     def _new_type(self):
         """Prepare a new dict for the type we just parsed.
@@ -295,7 +295,7 @@ class CvdumpTypesParser:
         variants: list[dict[str, Any]] = obj["variants"]
         variants.append({"name": name, "value": value})
 
-    def _get_field_list(self, type_obj: Dict[str, Any]) -> list[FieldListItem]:
+    def _get_field_list(self, type_obj: dict[str, Any]) -> list[FieldListItem]:
         """Return the field list for the given LF_CLASS/LF_STRUCTURE reference"""
 
         if type_obj.get("type") == "LF_FIELDLIST":
@@ -325,7 +325,7 @@ class CvdumpTypesParser:
 
         return sorted(members, key=lambda m: m.offset)
 
-    def _mock_array_members(self, type_obj: Dict) -> list[FieldListItem]:
+    def _mock_array_members(self, type_obj: dict[str, Any]) -> list[FieldListItem]:
         """LF_ARRAY elements provide the element type and the total size.
         We want the list of "members" as if this was a struct."""
 

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -42,7 +42,7 @@ class VirtualBasePointer:
 
 class ScalarType(NamedTuple):
     offset: int
-    name: Optional[str]
+    name: str | None
     type: str
 
     @property
@@ -60,9 +60,9 @@ class ScalarType(NamedTuple):
 
 class TypeInfo(NamedTuple):
     key: str
-    size: Optional[int]
-    name: Optional[str] = None
-    members: Optional[List[FieldListItem]] = None
+    size: int | None
+    name: str | None = None
+    members: list[FieldListItem] | None = None
 
     def is_scalar(self) -> bool:
         # TODO: distinction between a class with zero members and no vtable?
@@ -127,7 +127,7 @@ def scalar_type_format_char(type_name: str) -> str:
     return char if scalar_type_signed(type_name) else char.upper()
 
 
-def member_list_to_struct_string(members: List[ScalarType]) -> str:
+def member_list_to_struct_string(members: list[ScalarType]) -> str:
     """Create a string for use with struct.unpack"""
 
     format_string = "".join(m.format_char for m in members)
@@ -137,7 +137,7 @@ def member_list_to_struct_string(members: List[ScalarType]) -> str:
     return ""
 
 
-def join_member_names(parent: str, child: Optional[str]) -> str:
+def join_member_names(parent: str, child: str | None) -> str:
     """Helper method to combine parent/child member names.
     Child member name is None if the child is a scalar type."""
 
@@ -263,7 +263,7 @@ class CvdumpTypesParser:
     }
 
     def __init__(self) -> None:
-        self.mode: Optional[str] = None
+        self.mode: str | None = None
         self.last_key = ""
         self.keys: Dict[str, Dict[str, Any]] = {}
 
@@ -295,7 +295,7 @@ class CvdumpTypesParser:
         variants: list[dict[str, Any]] = obj["variants"]
         variants.append({"name": name, "value": value})
 
-    def _get_field_list(self, type_obj: Dict[str, Any]) -> List[FieldListItem]:
+    def _get_field_list(self, type_obj: Dict[str, Any]) -> list[FieldListItem]:
         """Return the field list for the given LF_CLASS/LF_STRUCTURE reference"""
 
         if type_obj.get("type") == "LF_FIELDLIST":
@@ -304,7 +304,7 @@ class CvdumpTypesParser:
             field_list_type = type_obj["field_list_type"]
             field_obj = self.keys[field_list_type]
 
-        members: List[FieldListItem] = []
+        members: list[FieldListItem] = []
 
         super_ids = field_obj.get("super", [])
         for super_id in super_ids:
@@ -325,7 +325,7 @@ class CvdumpTypesParser:
 
         return sorted(members, key=lambda m: m.offset)
 
-    def _mock_array_members(self, type_obj: Dict) -> List[FieldListItem]:
+    def _mock_array_members(self, type_obj: Dict) -> list[FieldListItem]:
         """LF_ARRAY elements provide the element type and the total size.
         We want the list of "members" as if this was a struct."""
 
@@ -408,7 +408,7 @@ class CvdumpTypesParser:
         # TODO
         raise NotImplementedError
 
-    def get_scalars(self, type_key: str) -> List[ScalarType]:
+    def get_scalars(self, type_key: str) -> list[ScalarType]:
         """Reduce the given type to a list of scalars so we can
         compare each component value."""
 
@@ -434,7 +434,7 @@ class CvdumpTypesParser:
             for cm in self.get_scalars(m.type)
         ]
 
-    def get_scalars_gapless(self, type_key: str) -> List[ScalarType]:
+    def get_scalars_gapless(self, type_key: str) -> list[ScalarType]:
         """Reduce the given type to a list of scalars so we can
         compare each component value."""
 

--- a/reccmp/isledecomp/formats/pe.py
+++ b/reccmp/isledecomp/formats/pe.py
@@ -336,7 +336,7 @@ class CodeViewHeaderNB10:
     pdb_file_name: bytes  # zero terminated string with the name of the PDB file
 
     @classmethod
-    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderNB10" | None:
+    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderNB10| None":
         struct_fmt = "<4sIII"
         if not cls.taste(data, offset):
             raise ValueError
@@ -363,7 +363,7 @@ class CodeViewHeaderRSDS:
     pdb_file_name: bytes  # zero terminated string with the name of the PDB file
 
     @classmethod
-    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderRSDS" | None:
+    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderRSDS | None":
         struct_fmt = "<4s16s"
         if not cls.taste(data, offset):
             raise ValueError

--- a/reccmp/isledecomp/formats/pe.py
+++ b/reccmp/isledecomp/formats/pe.py
@@ -189,7 +189,7 @@ class PEImageOptionalHeader:
     size_of_uninitialized_data: int
     address_of_entry_point: int
     base_of_code: int
-    base_of_data: Optional[int]
+    base_of_data: int | None
     image_base: int
     section_alignment: int
     file_alignment: int
@@ -336,7 +336,7 @@ class CodeViewHeaderNB10:
     pdb_file_name: bytes  # zero terminated string with the name of the PDB file
 
     @classmethod
-    def from_memory(cls, data: bytes, offset: int) -> Optional["CodeViewHeaderNB10"]:
+    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderNB10" | None:
         struct_fmt = "<4sIII"
         if not cls.taste(data, offset):
             raise ValueError
@@ -363,7 +363,7 @@ class CodeViewHeaderRSDS:
     pdb_file_name: bytes  # zero terminated string with the name of the PDB file
 
     @classmethod
-    def from_memory(cls, data: bytes, offset: int) -> Optional["CodeViewHeaderRSDS"]:
+    def from_memory(cls, data: bytes, offset: int) -> "CodeViewHeaderRSDS" | None:
         struct_fmt = "<4s16s"
         if not cls.taste(data, offset):
             raise ValueError
@@ -549,7 +549,7 @@ class PEImage(Image):
 
     def get_data_directory_region(
         self, t: PEDataDirectoryItemType
-    ) -> Optional[PEDataDirectoryItemRegion]:
+    ) -> PEDataDirectoryItemRegion | None:
         directory_header = self.optional_header.directories[t.value]
         if not directory_header.rva:
             return None
@@ -573,7 +573,7 @@ class PEImage(Image):
         )
 
     @property
-    def pdb_filename(self) -> Optional[str]:
+    def pdb_filename(self) -> str | None:
         debug_directory = self.get_data_directory_region(PEDataDirectoryItemType.DEBUG)
         if not debug_directory:
             return None
@@ -610,7 +610,7 @@ class PEImage(Image):
     def get_relocated_addresses(self) -> list[int]:
         return sorted(self._relocated_addrs)
 
-    def find_string(self, target: bytes) -> Optional[int]:
+    def find_string(self, target: bytes) -> int | None:
         # Pad with null terminator to make sure we don't
         # match on a subset of the full string
         if not target.endswith(b"\x00"):

--- a/reccmp/isledecomp/formats/pe.py
+++ b/reccmp/isledecomp/formats/pe.py
@@ -10,7 +10,7 @@ from enum import IntEnum, IntFlag
 from functools import cached_property
 from pathlib import Path
 import struct
-from typing import Iterator, Optional, cast
+from typing import Iterator, cast
 
 from .exceptions import (
     InvalidVirtualAddressError,

--- a/reccmp/isledecomp/parser/codebase.py
+++ b/reccmp/isledecomp/parser/codebase.py
@@ -13,7 +13,7 @@ from .node import (
 
 class DecompCodebase:
     def __init__(self, filenames: Iterable[str], module: str) -> None:
-        self._symbols: List[ParserSymbol] = []
+        self._symbols: list[ParserSymbol] = []
 
         parser = DecompParser()
         for filename in filenames:
@@ -27,7 +27,7 @@ class DecompCodebase:
 
     def prune_invalid_addrs(
         self, is_valid: Callable[[int], bool]
-    ) -> List[ParserSymbol]:
+    ) -> list[ParserSymbol]:
         """Some decomp annotations might have an invalid address.
         Return the list of addresses where we fail the is_valid check,
         and remove those from our list of symbols."""

--- a/reccmp/isledecomp/parser/codebase.py
+++ b/reccmp/isledecomp/parser/codebase.py
@@ -1,6 +1,6 @@
 """For aggregating decomp markers read from an entire directory and for a single module."""
 
-from typing import Callable, Iterable, Iterator, List
+from typing import Callable, Iterable, Iterator
 from .parser import DecompParser
 from .node import (
     ParserSymbol,

--- a/reccmp/isledecomp/parser/error.py
+++ b/reccmp/isledecomp/parser/error.py
@@ -88,7 +88,7 @@ class ParserError(Enum):
 class ParserAlert:
     code: ParserError
     line_number: int
-    line: Optional[str] = None
+    line: str | None = None
 
     def is_warning(self) -> bool:
         return self.code.value < ParserError.DECOMP_ERROR_START.value

--- a/reccmp/isledecomp/parser/error.py
+++ b/reccmp/isledecomp/parser/error.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Optional
 from dataclasses import dataclass
 
 

--- a/reccmp/isledecomp/parser/linter.py
+++ b/reccmp/isledecomp/parser/linter.py
@@ -11,10 +11,10 @@ def get_checkorder_filter(module):
 
 class DecompLinter:
     def __init__(self) -> None:
-        self.alerts: List[ParserAlert] = []
+        self.alerts: list[ParserAlert] = []
         self._parser = DecompParser()
         self._filename: str = ""
-        self._module: Optional[str] = None
+        self._module: str | None = None
         # Set of (str, int) tuples for each module/offset pair seen while scanning.
         # This is _not_ reset between files and is intended to report offset reuse
         # when scanning the entire directory.

--- a/reccmp/isledecomp/parser/linter.py
+++ b/reccmp/isledecomp/parser/linter.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence
+from typing import Sequence
 from .parser import DecompParser
 from .error import ParserAlert, ParserError
 from .node import ParserSymbol, ParserString

--- a/reccmp/isledecomp/parser/marker.py
+++ b/reccmp/isledecomp/parser/marker.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Tuple
+from typing import Tuple
 from enum import Enum
 
 

--- a/reccmp/isledecomp/parser/marker.py
+++ b/reccmp/isledecomp/parser/marker.py
@@ -1,5 +1,4 @@
 import re
-from typing import Tuple
 from enum import Enum
 
 
@@ -89,7 +88,7 @@ class DecompMarker:
         return MarkerCategory.ADDRESS
 
     @property
-    def key(self) -> Tuple[MarkerCategory, str, str | None]:
+    def key(self) -> tuple[MarkerCategory, str, str | None]:
         """For use with the MarkerDict. To detect/avoid marker collision."""
         return (self.category, self.module, self.extra)
 

--- a/reccmp/isledecomp/parser/marker.py
+++ b/reccmp/isledecomp/parser/marker.py
@@ -41,7 +41,7 @@ markerExactRegex = re.compile(
 
 class DecompMarker:
     def __init__(
-        self, marker_type: str, module: str, offset: int, extra: Optional[str] = None
+        self, marker_type: str, module: str, offset: int, extra: str | None = None
     ) -> None:
         try:
             self._type = MarkerType[marker_type.upper()]
@@ -53,7 +53,7 @@ class DecompMarker:
         # we will emit a syntax error.
         self._module: str = module.upper()
         self._offset: int = offset
-        self._extra: Optional[str] = extra
+        self._extra: str | None = extra
 
     @property
     def type(self) -> MarkerType:
@@ -68,7 +68,7 @@ class DecompMarker:
         return self._offset
 
     @property
-    def extra(self) -> Optional[str]:
+    def extra(self) -> str | None:
         return self._extra
 
     @property
@@ -89,7 +89,7 @@ class DecompMarker:
         return MarkerCategory.ADDRESS
 
     @property
-    def key(self) -> Tuple[MarkerCategory, str, Optional[str]]:
+    def key(self) -> Tuple[MarkerCategory, str, str | None]:
         """For use with the MarkerDict. To detect/avoid marker collision."""
         return (self.category, self.module, self.extra)
 
@@ -129,7 +129,7 @@ class DecompMarker:
         return self._type in (MarkerType.GLOBAL, MarkerType.STRING)
 
 
-def match_marker(line: str) -> Optional[DecompMarker]:
+def match_marker(line: str) -> DecompMarker | None:
     match = markerRegex.match(line)
     if match is None:
         return None

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from dataclasses import dataclass
 from .marker import MarkerType
 

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -16,7 +16,7 @@ class ParserSymbol:
 
     # The parser doesn't (currently) know about the code filename, but if you
     # wanted to set it here after the fact, here's the spot.
-    filename: Optional[str] = None
+    filename: str | None = None
 
     def should_skip(self) -> bool:
         """The default is to compare any symbols we have"""
@@ -31,7 +31,7 @@ class ParserSymbol:
 class ParserFunction(ParserSymbol):
     # We are able to detect the closing line of a function with some reliability.
     # This isn't used for anything right now, but perhaps later it will be.
-    end_line: Optional[int] = None
+    end_line: int | None = None
 
     # All marker types are referenced by name except FUNCTION/STUB. These can also be
     # referenced by name, but only if this flag is true.
@@ -50,12 +50,12 @@ class ParserFunction(ParserSymbol):
 @dataclass
 class ParserVariable(ParserSymbol):
     is_static: bool = False
-    parent_function: Optional[int] = None
+    parent_function: int | None = None
 
 
 @dataclass
 class ParserVtable(ParserSymbol):
-    base_class: Optional[str] = None
+    base_class: str | None = None
 
 
 @dataclass

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -55,8 +55,8 @@ class MarkerDict:
         return False
 
     def query(
-        self, category: MarkerCategory, module: str, extra: Optional[str] = None
-    ) -> Optional[DecompMarker]:
+        self, category: MarkerCategory, module: str, extra: str | None = None
+    ) -> DecompMarker | None:
         return self.markers.get((category, module, extra))
 
     def iter(self) -> Iterator[DecompMarker]:
@@ -83,7 +83,7 @@ class CurlyManager:
         except IndexError:
             pass
 
-    def get_prefix(self, name: Optional[str] = None) -> str:
+    def get_prefix(self, name: str | None = None) -> str:
         """Return the prefix for where we are."""
 
         scopes = [t for t in self._stack if t != "{"]
@@ -124,8 +124,8 @@ class DecompParser:
     # but not right now
     def __init__(self) -> None:
         # The lists to be populated as we parse
-        self._symbols: List[ParserSymbol] = []
-        self.alerts: List[ParserAlert] = []
+        self._symbols: list[ParserSymbol] = []
+        self.alerts: list[ParserAlert] = []
 
         self.line_number: int = 0
         self.state: ReaderState = ReaderState.SEARCH
@@ -174,22 +174,22 @@ class DecompParser:
         self.curly.reset()
 
     @property
-    def functions(self) -> List[ParserFunction]:
+    def functions(self) -> list[ParserFunction]:
         return [s for s in self._symbols if isinstance(s, ParserFunction)]
 
     @property
-    def vtables(self) -> List[ParserVtable]:
+    def vtables(self) -> list[ParserVtable]:
         return [s for s in self._symbols if isinstance(s, ParserVtable)]
 
     @property
-    def variables(self) -> List[ParserVariable]:
+    def variables(self) -> list[ParserVariable]:
         return [s for s in self._symbols if isinstance(s, ParserVariable)]
 
     @property
-    def strings(self) -> List[ParserString]:
+    def strings(self) -> list[ParserString]:
         return [s for s in self._symbols if isinstance(s, ParserString)]
 
-    def iter_symbols(self, module: Optional[str] = None) -> Iterator[ParserSymbol]:
+    def iter_symbols(self, module: str | None = None) -> Iterator[ParserSymbol]:
         for s in self._symbols:
             if module is None or s.module == module:
                 yield s
@@ -290,7 +290,7 @@ class DecompParser:
             self.state = ReaderState.IN_GLOBAL
 
     def _variable_done(
-        self, variable_name: Optional[str] = None, string_value: Optional[str] = None
+        self, variable_name: str | None = None, string_value: str | None = None
     ):
         if variable_name is None and string_value is None:
             self._syntax_error(ParserError.NO_SUITABLE_NAME)

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -1,7 +1,7 @@
 # C++ file parser
 
 import io
-from typing import List, Iterator, Optional
+from typing import Iterator
 from enum import Enum
 from .util import (
     get_class_name,

--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -1,6 +1,5 @@
 # C++ Parser utility functions and data structures
 import re
-from typing import Optional
 from ast import literal_eval
 
 # The goal here is to just read whatever is on the next line, so some

--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -27,7 +27,7 @@ doubleQuoteRegex = re.compile(r"(\"(?:[^\"\\]|\\.)*\")")
 scopeDetectRegex = re.compile(r"(?:class|struct|namespace) (?P<name>\w+).*(?:{)?")
 
 
-def get_synthetic_name(line: str) -> Optional[str]:
+def get_synthetic_name(line: str) -> str | None:
     """Synthetic names appear on a single line comment on the line after the marker.
     If that's not what we have, return None"""
     template_match = templateCommentRegex.match(line)
@@ -95,7 +95,7 @@ def fix_template_type(class_name: str) -> str:
     return template_regex.sub(template_replace, class_name)
 
 
-def get_class_name(line: str) -> Optional[str]:
+def get_class_name(line: str) -> str | None:
     """For VTABLE markers, extract the class name from the code line or comment
     where it appears."""
 
@@ -110,7 +110,7 @@ global_regex = re.compile(r"(?P<name>(?:\w+::)*g_\w+)")
 less_strict_global_regex = re.compile(r"(?P<name>(?:\w+::)*\w+)(?:\)\(|\[.*|\s*=.*|;)")
 
 
-def get_variable_name(line: str) -> Optional[str]:
+def get_variable_name(line: str) -> str | None:
     """Grab the name of the variable annotated with the GLOBAL marker.
     Correct syntax would have the variable start with the prefix "g_"
     but we will try to match regardless."""
@@ -124,7 +124,7 @@ def get_variable_name(line: str) -> Optional[str]:
     return None
 
 
-def get_string_contents(line: str) -> Optional[str]:
+def get_string_contents(line: str) -> str | None:
     """Return the first C string seen on this line.
     We have to unescape the string, and a simple way to do that is to use
     python's ast.literal_eval. I'm sure there are many pitfalls to doing

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -123,7 +123,7 @@ class ComparisonItem(NamedTuple):
 
 def create_comparison_item(
     var: ReccmpMatch,
-    compared: list[ComparedOffset | None] = None,
+    compared: list[ComparedOffset] | None = None,
     error: str | None = None,
     raw_only: bool = False,
 ) -> ComparisonItem:

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -81,7 +81,7 @@ class CompareResult(Enum):
 class ComparedOffset(NamedTuple):
     offset: int
     # name is None for scalar types
-    name: Optional[str]
+    name: str | None
     match: bool
     values: Tuple[str, str]
 
@@ -98,10 +98,10 @@ class ComparisonItem(NamedTuple):
     # For a scalar type, this is a list of size one.
     # If we could not retrieve type information, this is
     # a list of size one but without any specific type.
-    compared: List[ComparedOffset]
+    compared: list[ComparedOffset]
 
     # If present, the error message from the types parser.
-    error: Optional[str] = None
+    error: str | None = None
 
     # If true, there is no type specified for this variable. (i.e. non-public)
     # In this case, we can only compare the raw bytes.
@@ -123,8 +123,8 @@ class ComparisonItem(NamedTuple):
 
 def create_comparison_item(
     var: ReccmpMatch,
-    compared: Optional[List[ComparedOffset]] = None,
-    error: Optional[str] = None,
+    compared: list[ComparedOffset | None] = None,
+    error: str | None = None,
     raw_only: bool = False,
 ) -> ComparisonItem:
     """Helper to create the ComparisonItem from the fields in the reccmp database."""
@@ -308,7 +308,7 @@ def do_the_comparison(target: RecCmpBuiltTarget) -> Iterable[ComparisonItem]:
         yield create_comparison_item(var, compared=compared)
 
 
-def value_get(value: Optional[str], default: str):
+def value_get(value: str | None, default: str):
     return value if value is not None else default
 
 

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -4,7 +4,7 @@ import os
 import argparse
 import logging
 from enum import Enum
-from typing import Iterable, List, NamedTuple, Optional, Tuple
+from typing import Iterable, NamedTuple, Tuple
 from struct import unpack
 import colorama
 import reccmp

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -4,7 +4,7 @@ import os
 import argparse
 import logging
 from enum import Enum
-from typing import Iterable, NamedTuple, Tuple
+from typing import Iterable, NamedTuple
 from struct import unpack
 import colorama
 import reccmp
@@ -83,7 +83,7 @@ class ComparedOffset(NamedTuple):
     # name is None for scalar types
     name: str | None
     match: bool
-    values: Tuple[str, str]
+    values: tuple[str, str]
 
 
 class ComparisonItem(NamedTuple):

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -12,7 +12,7 @@ import logging
 from pathlib import Path
 import statistics
 import bisect
-from typing import Iterator, Tuple
+from typing import Iterator
 from collections import namedtuple
 import reccmp
 from reccmp.isledecomp import PEImage, detect_image
@@ -208,7 +208,7 @@ class DeltaCollector:
 
             self.disp_map[row.module].append(row.displacement)
 
-    def iter_sorted(self) -> Iterator[Tuple[int, int]]:
+    def iter_sorted(self) -> Iterator[tuple[int, int]]:
         """Compute the average address for each module, then generate them
         in ascending order."""
         avg_address = {

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -12,7 +12,7 @@ import logging
 from pathlib import Path
 import statistics
 import bisect
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator, Tuple
 from collections import namedtuple
 import reccmp
 from reccmp.isledecomp import PEImage, detect_image

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -59,17 +59,17 @@ class ModuleMap:
         # For bisect performance enhancement
         self.contrib_starts = [start for (start, _, __) in self.section_contrib]
 
-    def get_lib_for_module(self, module: str) -> Optional[str]:
+    def get_lib_for_module(self, module: str) -> str | None:
         return self.library_lookup.get(module)
 
-    def get_all_cmake_modules(self) -> List[str]:
+    def get_all_cmake_modules(self) -> list[str]:
         return [
             obj
             for (_, (__, obj)) in self.module_lookup.items()
             if obj.startswith("CMakeFiles")
         ]
 
-    def get_module(self, addr: int) -> Optional[str]:
+    def get_module(self, addr: int) -> str | None:
         i = bisect.bisect_left(self.contrib_starts, addr)
         # If the addr matches the section contribution start, we are in the
         # right spot. Otherwise, we need to subtract one here.
@@ -105,7 +105,7 @@ def print_sections(sections):
 ALLOWED_TYPE_ABBREVIATIONS = ["fun", "dat", "poi", "str", "vta", "flo"]
 
 
-def match_type_abbreviation(mtype: Optional[int]) -> str:
+def match_type_abbreviation(mtype: int | None) -> str:
     """Return abbreviation of the given SymbolType name"""
     if mtype is None:
         return ""
@@ -136,7 +136,7 @@ def truncate_module_name(prefix: str, module: str) -> str:
     return module
 
 
-def avg_remove_outliers(entries: List[int]) -> int:
+def avg_remove_outliers(entries: list[int]) -> int:
     """Compute the average from this list of entries (addresses)
     after removing outlier values."""
 
@@ -218,7 +218,7 @@ class DeltaCollector:
             yield (avg, mod)
 
 
-def suggest_order(results: List[RoadmapRow], module_map: ModuleMap, match_type: str):
+def suggest_order(results: list[RoadmapRow], module_map: ModuleMap, match_type: str):
     """Suggest the order of modules for CMakeLists.txt"""
 
     dc = DeltaCollector(match_type)
@@ -303,7 +303,7 @@ def suggest_order(results: List[RoadmapRow], module_map: ModuleMap, match_type: 
         print(f"{lib:40} {start:08x}")
 
 
-def print_text_report(results: List[RoadmapRow]):
+def print_text_report(results: list[RoadmapRow]):
     """Print the result with original and recomp addresses."""
     for row in results:
         print(
@@ -320,7 +320,7 @@ def print_text_report(results: List[RoadmapRow]):
         )
 
 
-def print_diff_report(results: List[RoadmapRow]):
+def print_diff_report(results: list[RoadmapRow]):
     """Print only entries where we have the recomp address.
     This is intended for generating a file to diff against.
     The recomp addresses are always changing so we hide those."""
@@ -341,7 +341,7 @@ def print_diff_report(results: List[RoadmapRow]):
         )
 
 
-def export_to_csv(csv_file: str, results: List[RoadmapRow]):
+def export_to_csv(csv_file: str, results: list[RoadmapRow]):
     with open(csv_file, "w+", encoding="utf-8") as f:
         f.write(
             "orig_sect_ofs,recomp_sect_ofs,orig_addr,recomp_addr,displacement,row_type,size,name,module\n"

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -3,7 +3,7 @@ import re
 import logging
 import argparse
 import struct
-from typing import Dict, NamedTuple, Set
+from typing import NamedTuple
 
 import colorama
 import reccmp
@@ -72,7 +72,7 @@ class StackPair(NamedTuple):
     recomp: StackRegisterOffset
 
 
-StackPairs = Set[StackPair]
+StackPairs = set[StackPair]
 
 
 @dataclass
@@ -92,7 +92,7 @@ def extract_stack_offset_from_instruction(
 
 
 def analyze_diff(
-    diff: Dict[str, list[tuple[str, ...]]], warnings: Warnings
+    diff: dict[str, list[tuple[str, ...]]], warnings: Warnings
 ) -> StackPairs:
     stack_pairs: StackPairs = set()
     if "both" in diff:
@@ -188,7 +188,7 @@ def compare_function_stacks(udiff: CombinedDiffOutput, fn_symbol: SymbolsEntry):
     # but only to entries above (i.e. the function arguments on the stack).
     # See also pdb_extraction.py.
 
-    stack_symbols: Dict[int, StackSymbol] = {}
+    stack_symbols: dict[int, StackSymbol] = {}
 
     for symbol in fn_symbol.stack_symbols:
         if symbol.symbol_type == "S_BPREL32":

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -3,7 +3,7 @@ import re
 import logging
 import argparse
 import struct
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple
+from typing import Dict, NamedTuple, Set, Tuple
 
 import colorama
 import reccmp

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -46,7 +46,7 @@ class StackSymbol:
 class StackRegisterOffset:
     register: str
     offset: int
-    symbol: Optional[StackSymbol] = None
+    symbol: StackSymbol | None = None
 
     def __str__(self) -> str:
         first_part = (
@@ -92,7 +92,7 @@ def extract_stack_offset_from_instruction(
 
 
 def analyze_diff(
-    diff: Dict[str, List[Tuple[str, ...]]], warnings: Warnings
+    diff: Dict[str, list[Tuple[str, ...]]], warnings: Warnings
 ) -> StackPairs:
     stack_pairs: StackPairs = set()
     if "both" in diff:
@@ -161,14 +161,14 @@ def print_non_bijective_match(left: str, right: str):
 
 
 def print_structural_mismatch(
-    orig: List[Tuple[str, ...]], recomp: List[Tuple[str, ...]]
+    orig: list[Tuple[str, ...]], recomp: list[Tuple[str, ...]]
 ) -> str:
     orig_str = "\n".join(f"-{x[1]}" for x in orig) if orig else "-"
     recomp_str = "\n".join(f"+{x[1]}" for x in recomp) if recomp else "+"
     return f"{colorama.Fore.RED}{orig_str}\n{colorama.Fore.GREEN}{recomp_str}\n{colorama.Style.RESET_ALL}"
 
 
-def format_list_of_offsets(offsets: List[StackRegisterOffset]) -> str:
+def format_list_of_offsets(offsets: list[StackRegisterOffset]) -> str:
     return str([str(x) for x in offsets])
 
 

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -3,7 +3,7 @@ import re
 import logging
 import argparse
 import struct
-from typing import Dict, NamedTuple, Set, Tuple
+from typing import Dict, NamedTuple, Set
 
 import colorama
 import reccmp
@@ -92,7 +92,7 @@ def extract_stack_offset_from_instruction(
 
 
 def analyze_diff(
-    diff: Dict[str, list[Tuple[str, ...]]], warnings: Warnings
+    diff: Dict[str, list[tuple[str, ...]]], warnings: Warnings
 ) -> StackPairs:
     stack_pairs: StackPairs = set()
     if "both" in diff:
@@ -161,7 +161,7 @@ def print_non_bijective_match(left: str, right: str):
 
 
 def print_structural_mismatch(
-    orig: list[Tuple[str, ...]], recomp: list[Tuple[str, ...]]
+    orig: list[tuple[str, ...]], recomp: list[tuple[str, ...]]
 ) -> str:
     orig_str = "\n".join(f"-{x[1]}" for x in orig) if orig else "-"
     recomp_str = "\n".join(f"+{x[1]}" for x in recomp) if recomp else "+"

--- a/reccmp/tools/vtable.py
+++ b/reccmp/tools/vtable.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-from typing import List
 import colorama
 import reccmp
 from reccmp.isledecomp import PEImage, detect_image
@@ -14,6 +13,7 @@ from reccmp.project.detect import (
     argparse_parse_built_project_target,
     RecCmpProjectException,
 )
+from reccmp.isledecomp.compare.diff import CombinedDiffOutput
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def show_vtable_diff(udiff: List, _: bool = False, plain: bool = False):
+def show_vtable_diff(udiff: CombinedDiffOutput, _: bool = False, plain: bool = False):
     print_combined_diff(udiff, plain)
 
 
@@ -86,7 +86,8 @@ def main():
         if tbl_match.ratio < 1:
             problem_count += 1
 
-            udiff = list(tbl_match.udiff)
+            udiff = tbl_match.udiff
+            assert udiff is not None
 
             print(
                 tbl_match.name,
@@ -102,10 +103,12 @@ def main():
     # They should always match 100%. If not, there is a problem
     # with the inheritance or an overriden function.
     for fun_match in engine.get_functions():
+        assert fun_match.name is not None
         if "`vtordisp" not in fun_match.name:
             continue
 
         diff = engine.compare_address(fun_match.orig_addr)
+        assert diff is not None
         if diff.ratio < 1.0:
             problem_count += 1
             print(

--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -3,7 +3,6 @@
 2. Provides an interface to read from the DLL or EXE using a virtual address.
 These are some basic smoke tests."""
 
-from typing import Tuple
 import pytest
 from reccmp.isledecomp.formats import PEImage
 from reccmp.isledecomp.formats.exceptions import (
@@ -144,7 +143,7 @@ IMPORT_REFS = (
 
 
 @pytest.mark.parametrize("import_ref", IMPORT_REFS)
-def test_imports(import_ref: Tuple[str, str, int], binfile: PEImage):
+def test_imports(import_ref: tuple[str, str, int], binfile: PEImage):
     assert import_ref in binfile.imports
 
 
@@ -156,7 +155,7 @@ THUNKS = (
 
 
 @pytest.mark.parametrize("thunk_ref", THUNKS)
-def test_thunks(thunk_ref: Tuple[int, int], binfile: PEImage):
+def test_thunks(thunk_ref: tuple[int, int], binfile: PEImage):
     assert thunk_ref in binfile.thunks
 
 

--- a/tests/test_parser_samples.py
+++ b/tests/test_parser_samples.py
@@ -14,7 +14,7 @@ def sample_file(filename: str) -> TextIO:
     return open(full_path, "r", encoding="utf-8")
 
 
-def code_blocks_are_sorted(blocks: List[ParserSymbol]) -> bool:
+def code_blocks_are_sorted(blocks: list[ParserSymbol]) -> bool:
     """Helper to make this more idiomatic"""
     just_offsets = [block.offset for block in blocks]
     return just_offsets == sorted(just_offsets)

--- a/tests/test_parser_samples.py
+++ b/tests/test_parser_samples.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, TextIO
+from typing import TextIO
 import pytest
 from reccmp.isledecomp.parser import DecompParser
 from reccmp.isledecomp.parser.node import ParserSymbol

--- a/tests/test_parser_statechange.py
+++ b/tests/test_parser_statechange.py
@@ -105,7 +105,7 @@ state_change_marker_cases = [
     "state, marker_type, new_state, expected_error", state_change_marker_cases
 )
 def test_state_change_by_marker(
-    state: _rs, marker_type: str, new_state: _rs, expected_error: Optional[_pe]
+    state: _rs, marker_type: str, new_state: _rs, expected_error: _pe | None
 ):
     p = DecompParser()
     p.state = state

--- a/tests/test_parser_statechange.py
+++ b/tests/test_parser_statechange.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import pytest
 from reccmp.isledecomp.parser.parser import (
     ReaderState as _rs,

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -1,6 +1,5 @@
 """Tests for asm sanitize, 32-bit pointers."""
 
-from typing import Optional
 from unittest.mock import Mock, patch
 import pytest
 from reccmp.isledecomp.compare.asm.parse import DisasmLiteInst, ParseAsm

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -336,7 +336,7 @@ def test_replacement_numbering():
     """If we can use the name lookup for the first address but not the second,
     the second replacement should be <OFFSET2> not <OFFSET1>."""
 
-    def substitute_1234(addr: int, **_) -> Optional[str]:
+    def substitute_1234(addr: int, **_) -> str | None:
         return "Hello" if addr == 0x1234 else None
 
     p = ParseAsm(name_lookup=substitute_1234)
@@ -356,14 +356,14 @@ def test_absolute_indirect():
     we have it, but there are some circumstances where we want to replace
     with the pointer's name (i.e. an import function)."""
 
-    def name_lookup(addr: int, **_) -> Optional[str]:
+    def name_lookup(addr: int, **_) -> str | None:
         return {
             0x1234: "Hello",
             0x4321: "xyz",
             0x5555: "Test",
         }.get(addr)
 
-    def bin_lookup(addr: int, _: int) -> Optional[bytes]:
+    def bin_lookup(addr: int, _: int) -> bytes | None:
         return (
             {
                 0x1234: b"\x55\x55\x00\x00",
@@ -411,7 +411,7 @@ def test_consistent_numbering():
 
     # Assume only the JMP and CMP addresses are known so we can test
     # the placeholder string for the other values.
-    def name_lookup(addr: int, **_) -> Optional[str]:
+    def name_lookup(addr: int, **_) -> str | None:
         return {0x5555: "Test", 0x8000: "Hello"}.get(addr)
 
     # Must be empty before starting


### PR DESCRIPTION
Python 3.8 is now EOL and Python 3.9 supports type annotations on generics. `Optional[]` and the capital `List[]`, `Dict[]`, etc. are now gone.