### PR TITLE
`decomplint`: check only the specified module

### DIFF
--- a/reccmp/isledecomp/parser/linter.py
+++ b/reccmp/isledecomp/parser/linter.py
@@ -40,6 +40,10 @@ class DecompLinter:
         """Helper for loading (module, offset) tuples while the DecompParser
         has them broken up into three different lists."""
         for marker in marker_list:
+            # If we are checking a specific module, ignore problems in other modules
+            if self._module is not None and marker.module != self._module:
+                continue
+
             is_string = isinstance(marker, ParserString)
 
             value = (marker.module, marker.offset)


### PR DESCRIPTION
Resolves #60.

Something else I noticed (that we'll address later) is that we don't check function order unless the module is specified. This doesn't seem necessary, and I forget why it's there. We can just split the addresses into separate lists by module.