### PR TITLE
Use string enum `EntityType`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     - name: Install python libraries
       shell: bash
       run: |

--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -1,7 +1,7 @@
 from functools import cache
 from typing import Callable, Protocol
 from reccmp.isledecomp.compare.db import ReccmpEntity
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 
 
 class AddrTestProtocol(Protocol):
@@ -29,7 +29,7 @@ def create_name_lookup(
             return m.match_name()
 
         offset = addr - getattr(m, addr_attribute)
-        if m.compare_type != SymbolType.DATA or offset >= m.size:
+        if m.entity_type != EntityType.DATA or offset >= m.size:
             return None
 
         return m.offset_name(offset)

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -12,7 +12,7 @@ from reccmp.isledecomp.cvdump.demangler import demangle_string_const
 from reccmp.isledecomp.cvdump import Cvdump, CvdumpAnalysis
 from reccmp.isledecomp.parser import DecompCodebase
 from reccmp.isledecomp.dir import walk_source_dir
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 from reccmp.isledecomp.compare.asm import ParseAsm
 from reccmp.isledecomp.compare.asm.replacement import create_name_lookup
 from reccmp.isledecomp.compare.asm.fixes import assert_fixup, find_effective_match
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class DiffReport:
     # pylint: disable=too-many-instance-attributes
-    match_type: SymbolType
+    match_type: EntityType
     orig_addr: int
     recomp_addr: int
     name: str
@@ -165,7 +165,7 @@ class Compare:
                     - sym.offset
                 )
 
-            if sym.node_type == SymbolType.STRING:
+            if sym.node_type == EntityType.STRING:
                 assert sym.decorated_name is not None
                 string_info = demangle_string_const(sym.decorated_name)
                 if string_info is None:
@@ -319,7 +319,7 @@ class Compare:
         # Indexed by recomp addr. Need to preload this data because it is not stored alongside the db rows.
         cvdump_lookup = {x.addr: x for x in self.cvdump_analysis.nodes}
 
-        for match in self._db.get_matches_by_type(SymbolType.DATA):
+        for match in self._db.get_matches_by_type(EntityType.DATA):
             node = cvdump_lookup.get(match.recomp_addr)
             if node is None or node.data_type is None:
                 continue
@@ -405,13 +405,13 @@ class Compare:
             for addr, string in self.orig_bin.iter_string("latin1"):
                 if is_real_string(string):
                     self._db.set_orig_symbol(
-                        addr, type=SymbolType.STRING, name=string, size=len(string)
+                        addr, type=EntityType.STRING, name=string, size=len(string)
                     )
 
             for addr, string in self.recomp_bin.iter_string("latin1"):
                 if is_real_string(string):
                     self._db.set_recomp_symbol(
-                        addr, type=SymbolType.STRING, name=string, size=len(string)
+                        addr, type=EntityType.STRING, name=string, size=len(string)
                     )
 
     def _find_float_const(self):
@@ -420,12 +420,12 @@ class Compare:
         deduped like strings."""
         for addr, size, float_value in self.orig_bin.find_float_consts():
             self._db.set_orig_symbol(
-                addr, type=SymbolType.FLOAT, name=str(float_value), size=size
+                addr, type=EntityType.FLOAT, name=str(float_value), size=size
             )
 
         for addr, size, float_value in self.recomp_bin.find_float_consts():
             self._db.set_recomp_symbol(
-                addr, type=SymbolType.FLOAT, name=str(float_value), size=size
+                addr, type=EntityType.FLOAT, name=str(float_value), size=size
             )
 
     def _match_imports(self):
@@ -453,7 +453,7 @@ class Compare:
                 continue
 
             # Match the __imp__ symbol
-            self._db.set_pair(orig, recomp, SymbolType.POINTER)
+            self._db.set_pair(orig, recomp, EntityType.POINTER)
 
             # Read the relative address from .idata
             try:
@@ -475,9 +475,9 @@ class Compare:
             (dll_name, func_name) = orig_byaddr[orig]
             fullname = dll_name + ":" + func_name
             self._db.set_recomp_symbol(
-                recomp_rva, type=SymbolType.FUNCTION, name=fullname, size=4
+                recomp_rva, type=EntityType.FUNCTION, name=fullname, size=4
             )
-            self._db.set_pair(orig_rva, recomp_rva, SymbolType.FUNCTION)
+            self._db.set_pair(orig_rva, recomp_rva, EntityType.FUNCTION)
             self._db.skip_compare(orig_rva)
 
     def _match_thunks(self):
@@ -580,7 +580,7 @@ class Compare:
         We could do this differently and check only the original vtable,
         construct the name of the vtordisp function and match based on that."""
 
-        for match in self._db.get_matches_by_type(SymbolType.VTABLE):
+        for match in self._db.get_matches_by_type(EntityType.VTABLE):
             assert (
                 match.name is not None
                 and match.orig_addr is not None
@@ -743,7 +743,7 @@ class Compare:
 
         assert match.name is not None
         return DiffReport(
-            match_type=SymbolType.FUNCTION,
+            match_type=EntityType.FUNCTION,
             orig_addr=match.orig_addr,
             recomp_addr=match.recomp_addr,
             name=match.name,
@@ -831,7 +831,7 @@ class Compare:
 
         assert match.name is not None
         return DiffReport(
-            match_type=SymbolType.VTABLE,
+            match_type=EntityType.VTABLE,
             orig_addr=match.orig_addr,
             recomp_addr=match.recomp_addr,
             name=match.name,
@@ -848,21 +848,20 @@ class Compare:
         if match.get("skip", False):
             return None
 
-        assert match.compare_type is not None
         assert match.name is not None
         if match.get("stub", False):
             return DiffReport(
-                match_type=SymbolType(match.compare_type),
+                match_type=match.entity_type,
                 orig_addr=match.orig_addr,
                 recomp_addr=match.recomp_addr,
                 name=match.name,
                 is_stub=True,
             )
 
-        if match.compare_type == SymbolType.FUNCTION:
+        if match.entity_type == EntityType.FUNCTION:
             return self._compare_function(match)
 
-        if match.compare_type == SymbolType.VTABLE:
+        if match.entity_type == EntityType.VTABLE:
             return self._compare_vtable(match)
 
         return None
@@ -892,13 +891,13 @@ class Compare:
         return self._db.get_all()
 
     def get_functions(self) -> Iterator[ReccmpMatch]:
-        return self._db.get_matches_by_type(SymbolType.FUNCTION)
+        return self._db.get_matches_by_type(EntityType.FUNCTION)
 
     def get_vtables(self) -> Iterator[ReccmpMatch]:
-        return self._db.get_matches_by_type(SymbolType.VTABLE)
+        return self._db.get_matches_by_type(EntityType.VTABLE)
 
     def get_variables(self) -> Iterator[ReccmpMatch]:
-        return self._db.get_matches_by_type(SymbolType.DATA)
+        return self._db.get_matches_by_type(EntityType.DATA)
 
     def compare_address(self, addr: int) -> DiffReport | None:
         match = self._db.get_one_match(addr)

--- a/reccmp/isledecomp/types.py
+++ b/reccmp/isledecomp/types.py
@@ -1,14 +1,17 @@
 """Types shared by other modules"""
 
-from enum import IntEnum
+import enum
 
 
-class SymbolType(IntEnum):
-    """Broadly tells us what kind of comparison is required for this symbol."""
+class EntityType(enum.StrEnum):
+    """Broadly tells us what kind of comparison is required for this entity."""
 
-    FUNCTION = 1
-    DATA = 2
-    POINTER = 3
-    STRING = 4
-    VTABLE = 5
-    FLOAT = 6
+    ERRTYPE = enum.auto()
+    UNKNOWN = enum.auto()
+
+    FUNCTION = enum.auto()
+    DATA = enum.auto()
+    POINTER = enum.auto()
+    STRING = enum.auto()
+    VTABLE = enum.auto()
+    FLOAT = enum.auto()

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -20,7 +20,7 @@ from reccmp.isledecomp import (
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.formats.detect import detect_image
 from reccmp.isledecomp.formats.pe import PEImage
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 from reccmp.assets import get_asset_file
 from reccmp.project.logging import argparse_add_logging_args, argparse_parse_logging
 from reccmp.project.detect import (
@@ -281,12 +281,12 @@ def main():
             )
 
         if (
-            match.match_type == SymbolType.FUNCTION
+            match.match_type == EntityType.FUNCTION
             and match.orig_addr == match.recomp_addr
         ):
             functions_aligned_count += 1
 
-        if match.match_type == SymbolType.FUNCTION and not match.is_stub:
+        if match.match_type == EntityType.FUNCTION and not match.is_stub:
             function_count += 1
             total_accuracy += match.ratio
             total_effective_accuracy += match.effective_ratio

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -19,7 +19,7 @@ from reccmp.isledecomp.compare.db import ReccmpEntity
 from reccmp.isledecomp.cvdump import Cvdump
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 from reccmp.project.detect import (
     argparse_add_built_project_target_args,
     argparse_parse_built_project_target,
@@ -104,12 +104,9 @@ def print_sections(sections):
 ALLOWED_TYPE_ABBREVIATIONS = ["fun", "dat", "poi", "str", "vta", "flo"]
 
 
-def match_type_abbreviation(mtype: int | None) -> str:
-    """Return abbreviation of the given SymbolType name"""
-    if mtype is None:
-        return ""
-
-    return SymbolType(mtype).name.lower()[:3]
+def match_type_abbreviation(mtype: EntityType) -> str:
+    """Return abbreviation of the given EntityType name"""
+    return mtype.value.lower()[:3]
 
 
 def get_cmakefiles_prefix(module: str) -> str:
@@ -437,9 +434,9 @@ def main() -> int:
             if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
                 (_, module_name) = module_ref
 
-        row_type = match_type_abbreviation(match.compare_type)
+        row_type = match_type_abbreviation(match.entity_type)
         name = (
-            repr(match.name) if match.compare_type == SymbolType.STRING else match.name
+            repr(match.name) if match.entity_type == EntityType.STRING else match.name
         )
 
         if match.orig_addr is not None:


### PR DESCRIPTION
**Note:** `StrEnum` requires python 3.11 or later, so this effectively becomes our minimum version if this is merged. CI actions here and in isledecomp/isle use 3.12.

---

Resolves #51.

As of #45, items in the database (i.e. the components of the binaries) are "entities". This renames `SymbolType` to `EntityType` to match. It is a [`StrEnum`](https://docs.python.org/3/library/enum.html#enum.StrEnum) to support setting the value via a string (see #32). We use `enum.auto()` to establish the values. The expected behavior is that the raw value is a lower case string version of the enum constant.

There are three other changes. The main one is the `entity_type` property method of `ReccmpEntity` (formerly `compare_type`). It now always returns an `EntityType`. If none is set, return `EntityType.UNKNOWN`. If the raw value in the database is not part of the enum, return `EntityType.ERRTYPE`. This seems appropriate because this method is a helper anyway, and our current code assumes that an enum is returned. You can get the raw value with the `.get()` method.

`match_name()` from `ReccmpEntity` now takes advantage of the fact that `compare_type` is always an enum and so we use its string value directly.

Similarly, `match_type_abbreviation()` from `roadmap` uses the first three characters of the enum value.
