### PR TITLE
Rename `SymbolType` to `EntityType`

### DIFF
--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -1,7 +1,7 @@
 from functools import cache
 from typing import Callable, Protocol
 from reccmp.isledecomp.compare.db import ReccmpEntity
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 
 
 class AddrTestProtocol(Protocol):
@@ -29,7 +29,7 @@ def create_name_lookup(
             return m.match_name()
 
         offset = addr - getattr(m, addr_attribute)
-        if m.compare_type != SymbolType.DATA or offset >= m.size:
+        if m.entity_type != EntityType.DATA or offset >= m.size:
             return None
 
         return m.offset_name(offset)

--- a/reccmp/isledecomp/types.py
+++ b/reccmp/isledecomp/types.py
@@ -3,7 +3,7 @@
 from enum import IntEnum
 
 
-class SymbolType(IntEnum):
+class EntityType(IntEnum):
     """Broadly tells us what kind of comparison is required for this symbol."""
 
     FUNCTION = 1

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -20,7 +20,7 @@ from reccmp.isledecomp import (
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.formats.detect import detect_image
 from reccmp.isledecomp.formats.pe import PEImage
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 from reccmp.assets import get_asset_file
 from reccmp.project.logging import argparse_add_logging_args, argparse_parse_logging
 from reccmp.project.detect import (
@@ -281,12 +281,12 @@ def main():
             )
 
         if (
-            match.match_type == SymbolType.FUNCTION
+            match.match_type == EntityType.FUNCTION
             and match.orig_addr == match.recomp_addr
         ):
             functions_aligned_count += 1
 
-        if match.match_type == SymbolType.FUNCTION and not match.is_stub:
+        if match.match_type == EntityType.FUNCTION and not match.is_stub:
             function_count += 1
             total_accuracy += match.ratio
             total_effective_accuracy += match.effective_ratio

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -19,7 +19,7 @@ from reccmp.isledecomp.compare.db import ReccmpEntity
 from reccmp.isledecomp.cvdump import Cvdump
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
-from reccmp.isledecomp.types import SymbolType
+from reccmp.isledecomp.types import EntityType
 from reccmp.project.detect import (
     argparse_add_built_project_target_args,
     argparse_parse_built_project_target,
@@ -105,11 +105,11 @@ ALLOWED_TYPE_ABBREVIATIONS = ["fun", "dat", "poi", "str", "vta", "flo"]
 
 
 def match_type_abbreviation(mtype: int | None) -> str:
-    """Return abbreviation of the given SymbolType name"""
+    """Return abbreviation of the given EntityType name"""
     if mtype is None:
         return ""
 
-    return SymbolType(mtype).name.lower()[:3]
+    return EntityType(mtype).name.lower()[:3]
 
 
 def get_cmakefiles_prefix(module: str) -> str:
@@ -437,9 +437,9 @@ def main() -> int:
             if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
                 (_, module_name) = module_ref
 
-        row_type = match_type_abbreviation(match.compare_type)
+        row_type = match_type_abbreviation(match.entity_type)
         name = (
-            repr(match.name) if match.compare_type == SymbolType.STRING else match.name
+            repr(match.name) if match.entity_type == EntityType.STRING else match.name
         )
 
         if match.orig_addr is not None:

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -1,12 +1,12 @@
 """Testing compare database behavior, particularly matching"""
 
 import pytest
-from reccmp.isledecomp.compare.db import CompareDb
+from reccmp.isledecomp.compare.db import EntityDb
 
 
 @pytest.fixture(name="db")
 def fixture_db():
-    return CompareDb()
+    return EntityDb()
 
 
 def test_ignore_recomp_collision(db):


### PR DESCRIPTION
(Just the rename from #65.)

As of https://github.com/isledecomp/reccmp/pull/45, items in the database (i.e. the components of the binaries) are "entities". Therefore:

- `SymbolType` enum is now `EntityType`.
- `compare_type` property method of `ReccmpEntity` is now `entity_type`.
- `CompareDb` is now `EntityDb`.
- SQL table `symbols` is now `entities`.