### PR TITLE
Test on Python 3.10 through 3.13

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     - name: Install python libraries
       shell: bash
       run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,17 +4,18 @@ on: [push, pull_request]
 
 jobs:
   fetch-deps:
-    name: Download original binaries
+    name: Prepare sample binary files
     uses: ./.github/workflows/legobin.yml
 
-  pytest-win:
-    name: 'pytest ${{ matrix.platform.name }}'
+  test:
+    name: '${{ matrix.platform.name }} ${{ matrix.python-version }}'
     runs-on: ${{ matrix.platform.os }}
     needs: fetch-deps
 
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         platform:
           - { name: 'Windows', os: 'windows-latest' }
           - { name: 'Linux',   os: 'ubuntu-latest' }
@@ -24,9 +25,9 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python-version }}
 
-    - name: Restore cached original binaries
+    - name: Restore cached binary files
       id: cache-original-binaries
       uses: actions/cache/restore@v3
       with:
@@ -39,7 +40,7 @@ jobs:
       run: |
         pip install -r requirements.txt -r requirements-tests.txt
 
-    - name: Run python unit tests (Windows)
+    - name: Run unit tests
       shell: bash
       run: |
         pytest . --lego1=legobin/LEGO1.DLL

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Restore cached binary files
       id: cache-original-binaries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[project]
+requires-python = ">= 3.10"
+
 [flake8]
 max-line-length = 120
 

--- a/reccmp/isledecomp/formats/ne.py
+++ b/reccmp/isledecomp/formats/ne.py
@@ -115,7 +115,7 @@ class NewExeHeader:
             (items[13], items[12]),  # SS:SP
             *items[14:26],
             NETargetOSFlags(items[26]),
-            *items[27:]
+            *items[27:],
         )
         return result, offset + struct_size
 


### PR DESCRIPTION
Resolves #66.

We now test on Windows and Ubuntu for Python versions 3.10 through the latest 3.13. (3.14 is not finalized yet.)

The "format" task now runs 3.12. This will happen next Friday (Jan 17) regardless because we use `ubuntu-latest` as the runner. (See https://github.com/actions/runner-images/issues/10636)

I changed some of the text for the tasks if anyone has feedback.