### PR TITLE
Fix issues with `pyproject.toml`

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,20 @@
+name: Install
+
+on: [push, pull_request]
+
+jobs:
+  install:
+    name: 'Test reccmp install'
+    runs-on: 'ubuntu-latest'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install reccmp
+      shell: bash
+      run: |
+        pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,6 @@
 [project]
+name = "reccmp"
+dynamic = ["classifiers", "dependencies", "license", "scripts", "version"]
 requires-python = ">= 3.10"
 
 [flake8]


### PR DESCRIPTION
#68 modified `pyproject.toml` to add the `[project]` section. This conflicts with values from `setup.cfg` and `pip` cannot properly install the package. I marked the required fields as "dynamic" so `pip` will use the values from `setup.cfg` instead.

To catch problems like this in the future, I added a new test that just installs `reccmp`.