### PR TITLE
Give overloaded functions a unique name

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -786,12 +786,13 @@ class Compare:
             is_effective_match = False
             unified_diff = []
 
-        assert match.name is not None
+        best_name = match.best_name()
+        assert best_name is not None
         return DiffReport(
             match_type=EntityType.FUNCTION,
             orig_addr=match.orig_addr,
             recomp_addr=match.recomp_addr,
-            name=match.name,
+            name=best_name,
             udiff=unified_diff,
             ratio=ratio,
             is_effective_match=is_effective_match,

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -76,11 +76,16 @@ class ReccmpEntity:
         """Combination of the name and compare type.
         Intended for name substitution in the diff. If there is a diff,
         it will be more obvious what this symbol indicates."""
-        if self.name is None:
+        best_name: str
+        for key in ("computed_name", "name"):
+            if (value := self.options.get(key)) is not None:
+                best_name = str(value)
+                break
+        else:
             return None
 
         ctype = EntityTypeLookup.get(self.entity_type or -1, "UNK")
-        name = repr(self.name) if self.entity_type == EntityType.STRING else self.name
+        name = repr(self.name) if self.entity_type == EntityType.STRING else best_name
         return f"{name} ({ctype})"
 
     def offset_name(self, ofs: int) -> str | None:

--- a/reccmp/isledecomp/cvdump/demangler.py
+++ b/reccmp/isledecomp/cvdump/demangler.py
@@ -79,6 +79,21 @@ def get_vtordisp_name(symbol: str) -> str | None:
         return name
 
 
+def get_function_arg_string(symbol: str) -> str | None:
+    # pylint: disable=c-extension-no-member
+    """Demangle the given symbol and return its parameters.
+    We can use this to distinguish functions with the same name."""
+    raw = pydemangler.demangle(symbol)
+    if raw is None:
+        return None
+
+    try:
+        # Just get what's in the parens
+        return raw[raw.index("(") : raw.rindex(")") + 1]
+    except ValueError:
+        return None
+
+
 def demangle_vtable(symbol: str) -> str:
     # pylint: disable=c-extension-no-member
     """Get the class name referenced in the vtable symbol."""

--- a/tests/test_entity_obj.py
+++ b/tests/test_entity_obj.py
@@ -1,0 +1,66 @@
+"""Tests related to the ReccmpEntity ORM object"""
+
+import json
+from reccmp.isledecomp.types import EntityType
+from reccmp.isledecomp.compare.db import ReccmpEntity
+
+
+def create_entity(
+    orig_addr: int | None, recomp_addr: int | None, **kwargs
+) -> ReccmpEntity:
+    """Helper to create the JSON string representation of the key/value args."""
+    return ReccmpEntity(orig_addr, recomp_addr, json.dumps(kwargs))
+
+
+def test_match_name_none():
+    """match_name() returns None if there are no name attributes"""
+    assert create_entity(100, 200).match_name() is None
+
+
+def test_match_name_no_type():
+    """If we have a name, the entity_type is included in the match_name().
+    If type is None, the type string is 'UNK'"""
+    e = create_entity(100, 200, name="Test")
+    assert "Test" in e.match_name()
+    assert "UNK" in e.match_name()
+
+
+def test_match_name_with_type():
+    """Use all-caps representation of entity type in the match name"""
+    e = create_entity(100, 200, type=EntityType.FUNCTION, name="Test")
+    assert "Test" in e.match_name()
+    assert "FUNCTION" in e.match_name()
+
+
+def test_match_name_computed_name():
+    """Use the 'computed_name' field if present"""
+    e = create_entity(100, 200, computed_name="Hello")
+    assert "Hello" in e.match_name()
+
+
+def test_match_name_priority():
+    """Prefer 'computed_name' over 'name'"""
+    e = create_entity(100, 200, computed_name="Hello", name="Test")
+    assert "Hello" in e.match_name()
+
+
+def test_computed_name_string():
+    """Ignore 'computed_name' if entity is a string"""
+
+    e = create_entity(
+        100, 200, computed_name="Hello", name="Test", type=EntityType.STRING
+    )
+    assert "Test" in e.match_name()
+
+
+def test_match_name_string():
+    """We currently store the string value in the name field.
+    If the string includes newlines, we need to escape them before replacing the
+    value during asm sanitize. (It will interfere with diff calculation.)"""
+    string = """A string
+    with
+    newlines"""
+
+    e = create_entity(100, None, type=EntityType.STRING, name=string)
+    assert "\n" not in e.match_name()
+    assert "\\n" in e.match_name()


### PR DESCRIPTION
**Update:** Now enabled for console and HTML output from `asmcmp`.

For functions with the same name but different parameters (overloaded functions) we set a unique name that contains the argument list and use this in asm sanitize. For example:

- `list<MxDriver,allocator<MxDriver> >::iterator::operator++(int)`
- `MxRect32::MxRect32(void)`
- `MxPalette::MxPalette(struct tagRGBQUAD const *)`

This is done by running the symbol from the PDB through the demangler function. If we don't have a symbol for some reason, we just number the function.

This uses a new entity attribute "computed_name" as to not interfere with "name". The ghidra scripts need the base name without arguments to set the function labels.

Limitations:
- Does not distinguish const and non-const return types. This can be added later.
- Thunks are not altered. We would need to maintain a reference back to the original function address. Once we have that, set all the thunk names as a final step (after the original functions have been updated) or generate the name dynamically when needed. This needs its own PR because it requires more database changes.