### PR TITLE
Fix and clean up log output

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -677,7 +677,9 @@ class Compare:
                     thunk_fn.name,
                     orig_addr,
                 )
-            self._db.set_function_pair(orig_addr, recomp_addr)
+            # Use `tentative` because vtordisps can be shared between different vtables.
+            # We get a lot of `address not unique!` debug logs otherwise
+            self._db.set_function_pair_tentative(orig_addr, recomp_addr)
 
     def _unique_names_for_overloaded_functions(self):
         """Our asm sanitize will use the "friendly" name of a function.

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -338,6 +338,11 @@ class EntityDb:
         """For lineref match or _entry"""
         return self.set_pair(orig, recomp, EntityType.FUNCTION)
 
+
+    def set_function_pair_tentative(self, orig: int, recomp: int) -> bool:
+        """For lineref match or _entry"""
+        return self.set_pair_tentative(orig, recomp, EntityType.FUNCTION)
+
     def create_orig_thunk(self, addr: int, name: str) -> bool:
         """Create a thunk function reference using the orig address.
         We are here because we have a match on the thunked function,

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -338,7 +338,6 @@ class EntityDb:
         """For lineref match or _entry"""
         return self.set_pair(orig, recomp, EntityType.FUNCTION)
 
-
     def set_function_pair_tentative(self, orig: int, recomp: int) -> bool:
         """For lineref match or _entry"""
         return self.set_pair_tentative(orig, recomp, EntityType.FUNCTION)

--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -68,6 +68,14 @@ class CvdumpSymbolsParser:
         r"\s*Parent: (?P<parent_addr>\w+), End: (?P<end_addr>\w+), Next: (?P<next_addr>\w+)$"
     )
 
+    _module_start_regex = re.compile(
+        r'\*\* Module: "(?P<module>[^"]+)"(?: from "(?P<from>[^"]+)")?$'
+    )
+
+    _compile_key_value = re.compile(
+        r"\s{9}(?P<key>[^:]+):\s(?P<value>.+)$"
+    )
+
     _flags_frame_pointer_regex = re.compile(r"\s*Flags: Frame Ptr Present$")
 
     _register_stack_symbols = ["S_BPREL32", "S_REGISTER"]
@@ -109,8 +117,13 @@ class CvdumpSymbolsParser:
                 )
                 return
             self.current_function.frame_pointer_present = True
+        elif (match := self._module_start_regex.match(line)) is not None:
+            # We do not need this info at the moment, might be useful in the future
+            pass
+        elif (match := self._compile_key_value.match(line)) is not None:
+            # We do not need this info at the moment, might be useful in the future
+            pass
         else:
-            # Most of these are either `** Module: [...]` or data we do not care about
             logger.debug("Unhandled line: %s", line[:-1])
 
     def _parse_generic_case(self, line, line_match: Match[str]):

--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -72,9 +72,12 @@ class CvdumpSymbolsParser:
         r'\*\* Module: "(?P<module>[^"]+)"(?: from "(?P<from>[^"]+)")?$'
     )
 
-    _compile_key_value = re.compile(
-        r"\s{9}(?P<key>[^:]+):\s(?P<value>.+)$"
-    )
+    _compile_key_value = re.compile(r"\s{9}(?P<key>[^:]+):\s(?P<value>.+)$")
+    """
+    For lines like
+    `         Target processor: 80486`
+    within an `S_COMPILE` symbol.
+    """
 
     _flags_frame_pointer_regex = re.compile(r"\s*Flags: Frame Ptr Present$")
 

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -232,11 +232,6 @@ def main():
     if not isinstance(recompfile, PEImage):
         raise ValueError(f"{target.recompiled_path} is not a PE executable")
 
-    if args.verbose is not None:
-        # Mute logger events from compare engine
-        logging.getLogger("isledecomp.compare.db").setLevel(logging.CRITICAL)
-        logging.getLogger("isledecomp.compare.lines").setLevel(logging.CRITICAL)
-
     isle_compare = IsleCompare(
         origfile,
         recompfile,

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -374,11 +374,6 @@ def parse_args() -> argparse.Namespace:
     argparse_add_logging_args(parser)
     args = parser.parse_args()
     argparse_parse_logging(args=args)
-    if args.loglevel != logging.DEBUG:
-        # Mute logger events from compare engine
-        logging.getLogger("isledecomp.compare.core").setLevel(logging.CRITICAL)
-        logging.getLogger("isledecomp.compare.db").setLevel(logging.CRITICAL)
-        logging.getLogger("isledecomp.compare.lines").setLevel(logging.CRITICAL)
 
     return args
 

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -319,11 +319,6 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
 
     argparse_parse_logging(args=args)
-    if args.loglevel != logging.DEBUG:
-        # Mute logger events from compare engine
-        logging.getLogger("isledecomp.compare.core").setLevel(logging.CRITICAL)
-        logging.getLogger("isledecomp.compare.db").setLevel(logging.CRITICAL)
-        logging.getLogger("isledecomp.compare.lines").setLevel(logging.CRITICAL)
 
     return args
 


### PR DESCRIPTION
This PR fixes two of the underlying reasons for some of the more spammy log messages, especially when enabling `--debug`.

I have also removed an older functionality where some logs were suppressed in `asmcmp` and other scripts - the code didn't even work correctly anymore (it wouldn't actually suppress any logs we were seeing). Closes #5 