### PR TITLE
Database batch update API

### DIFF
--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -165,6 +165,15 @@ class EntityBatch:
         self._orig_to_recomp = {}
         self._recomp_to_orig = {}
 
+    def reset(self):
+        """Clear all pending changes"""
+        self._orig_insert.clear()
+        self._recomp_insert.clear()
+        self._orig.clear()
+        self._recomp.clear()
+        self._orig_to_recomp.clear()
+        self._recomp_to_orig.clear()
+
     def insert_orig(self, addr: int, **kwargs):
         self._orig_insert.setdefault(addr, {}).update(kwargs)
 
@@ -201,20 +210,16 @@ class EntityBatch:
         if self._orig_to_recomp:
             self.base.bulk_match(self._orig_to_recomp.items())
 
-        self._orig_insert.clear()
-        self._recomp_insert.clear()
-
-        self._orig.clear()
-        self._recomp.clear()
-
-        self._orig_to_recomp.clear()
-        self._recomp_to_orig.clear()
+        self.reset()
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.commit()
+        if exc_type is not None:
+            self.reset()
+        else:
+            self.commit()
 
 
 class EntityDb:

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -195,20 +195,22 @@ class EntityBatch:
         self._recomp_to_orig[recomp] = orig
 
     def commit(self):
-        if self._orig_insert:
-            self.base.bulk_orig_insert(self._orig_insert.items())
+        # SQL transaction
+        with self.base.sql:
+            if self._orig_insert:
+                self.base.bulk_orig_insert(self._orig_insert.items())
 
-        if self._recomp_insert:
-            self.base.bulk_recomp_insert(self._recomp_insert.items())
+            if self._recomp_insert:
+                self.base.bulk_recomp_insert(self._recomp_insert.items())
 
-        if self._orig:
-            self.base.bulk_orig_insert(self._orig.items(), upsert=True)
+            if self._orig:
+                self.base.bulk_orig_insert(self._orig.items(), upsert=True)
 
-        if self._recomp:
-            self.base.bulk_recomp_insert(self._recomp.items(), upsert=True)
+            if self._recomp:
+                self.base.bulk_recomp_insert(self._recomp.items(), upsert=True)
 
-        if self._orig_to_recomp:
-            self.base.bulk_match(self._orig_to_recomp.items())
+            if self._orig_to_recomp:
+                self.base.bulk_match(self._orig_to_recomp.items())
 
         self.reset()
 

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -326,7 +326,7 @@ def test_batch_sqlite_exception(db):
     # Insert bad data that will cause a binding error
     batch.match(100, ("bogus",))
 
-    with pytest.raises(sqlite3.ProgrammingError):
+    with pytest.raises(sqlite3.Error):
         batch.commit()
 
     # Should rollback everything
@@ -340,7 +340,7 @@ def test_batch_sqlite_exception_insert_only(db):
     batch.insert_orig(100, name="Test")
     batch.insert_orig(("bogus",), name="Test")
 
-    with pytest.raises(sqlite3.ProgrammingError):
+    with pytest.raises(sqlite3.Error):
         batch.commit()
 
     assert db.get_by_orig(100) is None


### PR DESCRIPTION
Updating the sqlite db using `executemany` and generator functions is a necessary evil for performance. This change abstracts away the implementation details and provides a much friendlier interface:

```python
# Before:

self._db.bulk_recomp_insert(
    ((addr, {"name": values["name"]}) for addr, values in dataset.items()),
    upsert=True,
)
self._db.bulk_match(
    (
        (orig_addr, recomp_addr)
        for recomp_addr, orig_addr in orig_by_recomp.items()
    )
)


# After:

with self._db.batch() as batch:
    # Assume we are in a loop
        batch.set_recomp(recomp_addr, name="Test")
        batch.match(orig_addr, recomp_addr)

```

You can use the batch object with the context manager as shown, or manually call `batch.commit()`.

The batch object provides five methods. When you commit, the changes are applied in this order (regardless of what order the methods were called):

- `insert_orig` and `insert_recomp` will set an entity in the database, but only if there is no existing data. (i.e. `INSERT`.)
- `set_orig` and `set_recomp` will insert or update data for the entity. (i.e. `INSERT or REPLACE`.)
- `match` will combine an orig address with a recomp address if neither is already matched.

The other big change is that matching will now combine two entities if both the orig and recomp addresses already exist but neither are matched. Until now, it was only possible to match by setting an unused orig address on an existing recomp entity. This will finally allow us to have inserting data and matching entities as two distinct operations. I have new modularized match functions mostly done in the stash. We can add these incrementally and now finally have some good tests on the matching behavior.

I only used the batch in a few places in `core.py` for now. These new matching functions will use it extensively and we can refactor the existing code that works with thunks, vtordisps, and strings.