### PR TITLE
Solve some of the `TYPES` parsing issues

### DIFF
--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -243,7 +243,7 @@ class CvdumpTypesParser:
     )
     LF_ENUM_UDT = re.compile(r"^\s*UDT\((?P<udt>0x\w+)\)$")
     LF_UNION_LINE = re.compile(
-        r"^.*field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^,]|,\S)+)(?:,\s.*UDT\((?P<udt>0x\w+)\))?"
+        r"^.*field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^,]|,\S)+)(?:, unique name = [^,]+)?(?:,\s.*UDT\((?P<udt>0x\w+)\))?$"
     )
 
     MODES_OF_INTEREST = {

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -201,7 +201,7 @@ class CvdumpTypesParser:
 
     # LF_CLASS/LF_STRUCTURE name and other info
     CLASS_NAME_RE = re.compile(
-        r"^\s+Size = (?P<size>\d+), class name = (?P<name>(?:[^,]|,\S)+)(?:, UDT\((?P<udt>0x\w+)\))?"
+        r"^\s+Size = (?P<size>\d+), class name = (?P<name>(?:[^,]|,\S)+)(?:, unique name = [^,]+)?(?:, UDT\((?P<udt>0x\w+)\))?"
     )
 
     # LF_MODIFIER, type being modified

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -212,7 +212,7 @@ class CvdumpTypesParser:
 
     # LF_ARGLIST list entry
     LF_ARGLIST_ENTRY = re.compile(
-        r"^\s+list\[(?P<index>\d+)\] = (?P<arg_type>[\w()]+)$"
+        r"^\s+list\[(?P<index>\d+)\] = (?P<arg_type>[?\w()]+)$"
     )
 
     # LF_POINTER element
@@ -220,7 +220,7 @@ class CvdumpTypesParser:
 
     # LF_MFUNCTION attribute key-value pairs
     LF_MFUNCTION_ATTRIBUTES = [
-        re.compile(r"\s*Return type = (?P<return_type>[\w()]+)$"),
+        re.compile(r"\s*Return type = (?P<return_type>[^,]+)$"),
         re.compile(r"\s*Class type = (?P<class_type>[\w()]+)$"),
         re.compile(r"\s*This type = (?P<this_type>[\w()]+)$"),
         # Call type may contain whitespace
@@ -231,9 +231,7 @@ class CvdumpTypesParser:
         re.compile(
             r"\s*This adjust = (?P<this_adjust>[\w()]+)$"
         ),  # By how much the incoming pointers are shifted in virtual inheritance; hex value without `0x` prefix
-        re.compile(
-            r"\s*Func attr = (?P<func_attr>[\w()]+)$"
-        ),  # Only for completeness, is always `none`
+        re.compile(r"\s*Func attr = (?P<func_attr>.+)$"),
     ]
 
     LF_ENUM_ATTRIBUTES = [
@@ -245,7 +243,7 @@ class CvdumpTypesParser:
     )
     LF_ENUM_UDT = re.compile(r"^\s*UDT\((?P<udt>0x\w+)\)$")
     LF_UNION_LINE = re.compile(
-        r"^.*field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^,]|,\S)+)(?:,\s.*UDT\((?P<udt>0x\w+)\))?$"
+        r"^.*field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^,]|,\S)+)(?:,\s.*UDT\((?P<udt>0x\w+)\))?"
     )
 
     MODES_OF_INTEREST = {
@@ -662,7 +660,13 @@ class CvdumpTypesParser:
             # in case we missed some relevant data
             if not any(
                 stripped_line.startswith(prefix)
-                for prefix in ["Pointer", "const Pointer", "L-value", "volatile"]
+                for prefix in [
+                    "R-value Reference",
+                    "Pointer",
+                    "const Pointer",
+                    "L-value",
+                    "volatile",
+                ]
             ):
                 logger.error("Unrecognized pointer attribute: %s", line[:-1])
 

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -789,3 +789,21 @@ def test_mfunction_unk_return_type():
         parser.read_line(line)
 
     assert parser.keys["0x11d8"]["return_type"] == "???(047C)"
+
+
+CLASS_WITH_UNIQUE_NAME = """
+0x1cf0 : Length = 134, Leaf = 0x1504 LF_CLASS
+    # members = 8,  field list type 0x1cef, CONSTRUCTOR, OVERLOAD, NESTED, OVERLOADED ASSIGNMENT, 
+        CASTING, 
+    Derivation list type 0x0000, VT shape type 0x0000
+    Size = 8, class name = std::basic_ostream<char,std::char_traits<char> >::sentry, unique name = .?AVsentry@?$basic_ostream@DU?$char_traits@D@std@@@std@@, UDT(0x00001cf0)
+"""
+
+
+def test_class_unique_name():
+    """Make sure we can parse the UDT when the 'unique name' attribute is present"""
+    parser = CvdumpTypesParser()
+    for line in CLASS_WITH_UNIQUE_NAME.split("\n"):
+        parser.read_line(line)
+
+    assert parser.keys["0x1cf0"]["udt"] == "0x1cf0"


### PR DESCRIPTION
As reported in #85. Not sure if this resolves it per se, because we now have the problem of unknown types. For example:

```
0x11f5 : Length = 22, Leaf = 0x1201 LF_ARGLIST argument count = 4
    list[0] = 0x11EA
    list[1] = ???(047C)
    list[2] = ???(047C)
    list[3] = 0x11F2
```

`0x047c` and `0x007c` are not listed in [cvinfo.h](https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h) so that's probably why cvdump can't provide a type name like `T_RCHAR`.

It would help to know what these types are in the real program. Looks like they're related to `std` data structures.

We probably can't use `datacmp` effectively until we sort out the phantom types, but we can at least parse the `TYPES` section from #85 without an error.

There are still alerts for `LF_CLASS` attributes "CASTING" and "OVERLOADED ASSIGNMENT". I think we should parse these sections using a different regex that covers all the comma-delimited values. I have that working but it will go in a separate PR. It may bite us in the long run so we should discuss whether it's worth it to change our approach.

Other things addressed here:

- `LF_UNION` that doesn't end with a UDT attribute.
- Alert for "Return type = ???(047C)" in `LF_MFUNCTION`
- Alert for "Func attr" values other than "none"
- Alert for `LF_POINTER` type "R-value Reference"
- In `LF_CLASS`, make sure we can parse the UDT if the "unique name" field is present