### PR TITLE
Improved behavior for indirect name lookup

### DIFF
--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -10,28 +10,92 @@ class AddrTestProtocol(Protocol):
 
 
 class NameReplacementProtocol(Protocol):
-    def __call__(self, addr: int, exact: bool = False) -> str | None:
+    def __call__(
+        self, addr: int, exact: bool = False, indirect: bool = False
+    ) -> str | None:
         ...
 
 
 def create_name_lookup(
-    db_getter: Callable[[int, bool], ReccmpEntity | None], addr_attribute: str
+    db_getter: Callable[[int, bool], ReccmpEntity | None],
+    bin_read: Callable[[int], int | None],
+    addr_attribute: str,
 ) -> NameReplacementProtocol:
     """Function generator for name replacement"""
 
+    def follow_indirect(pointer: int) -> ReccmpEntity | None:
+        """Read the pointer address and open the entity (if it exists) at the indirect location."""
+        addr = bin_read(pointer)
+        if addr is not None:
+            return db_getter(addr, True)
+
+        return None
+
+    def get_name(entity: ReccmpEntity, offset: int = 0) -> str | None:
+        """The offset is the difference between the input search address and the entity's
+        starting address. Decide whether to return the base name (match_name) or
+        a string wtih the base name plus the offset.
+        Returns None if there is no suitable name."""
+        if offset == 0:
+            return entity.match_name()
+
+        # We will not return an offset name if this is not a variable
+        # or if the offset is outside the range of the entity.
+        if entity.entity_type != EntityType.DATA or offset >= entity.size:
+            return None
+
+        return entity.offset_name(offset)
+
+    def indirect_lookup(addr: int) -> str | None:
+        """Same as regular lookup but aware of the fact that the address is a pointer.
+        Indirect implies exact search, so we drop both parameters from the lookup entry point.
+        """
+        entity = db_getter(addr, True)
+        if entity is not None:
+            # If the indirect call points at a variable initialized to a function,
+            # prefer the variable name as this is more useful.
+            if entity.entity_type == EntityType.DATA:
+                return entity.match_name()
+
+            if entity.entity_type == EntityType.IMPORT:
+                import_name = entity.get("import_name")
+                if import_name is not None:
+                    return "->" + import_name + " (FUNCTION)"
+
+                return entity.match_name()
+
+        # No suitable entity at the base address. Read the pointer and see what we get.
+        entity = follow_indirect(addr)
+
+        if entity is None:
+            return None
+
+        # Exact match only for indirect.
+        # The 'addr' variable still points at the indirect addr.
+        name = get_name(entity, offset=0)
+        if name is not None:
+            return "->" + name
+
+        return None
+
     @cache
-    def lookup(addr: int, exact: bool = False) -> str | None:
-        m = db_getter(addr, exact)
-        if m is None:
+    def lookup(addr: int, exact: bool = False, indirect: bool = False) -> str | None:
+        """Returns the name that represents the entity at the given addresss.
+        If there is no suitable name, return None and let the caller choose one (i.e. placeholder).
+        * exact:    If the addr is an offset of an entity (e.g. struct/array) we may return
+                    a name like 'variable+8'. If exact is True, return a name only if the entity's addr
+                    matches the addr parameter.
+        * indirect: If True, the given addr is a pointer so we have the option to read the address
+                    from the binary to find the name."""
+        if indirect:
+            return indirect_lookup(addr)
+
+        entity = db_getter(addr, exact)
+
+        if entity is None:
             return None
 
-        if getattr(m, addr_attribute) == addr:
-            return m.match_name()
-
-        offset = addr - getattr(m, addr_attribute)
-        if m.entity_type != EntityType.DATA or offset >= m.size:
-            return None
-
-        return m.offset_name(offset)
+        offset = addr - getattr(entity, addr_attribute)
+        return get_name(entity, offset)
 
     return lookup

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -6,7 +6,10 @@ import struct
 import uuid
 from dataclasses import dataclass
 from typing import Callable, Iterable, Iterator
-from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
+from reccmp.isledecomp.formats.exceptions import (
+    InvalidVirtualAddressError,
+    InvalidVirtualReadError,
+)
 from reccmp.isledecomp.formats.pe import PEImage
 from reccmp.isledecomp.cvdump.demangler import (
     demangle_string_const,
@@ -75,13 +78,14 @@ def create_reloc_lookup(bin_file: PEImage) -> Callable[[int], bool]:
     return lookup
 
 
-def create_bin_lookup(bin_file: PEImage) -> Callable[[int, int], bytes | None]:
-    """Function generator for reading from the bin file"""
+def create_bin_lookup(bin_file: PEImage) -> Callable[[int], int | None]:
+    """Function generator to read a pointer from the bin file"""
 
-    def lookup(addr: int, size: int) -> bytes | None:
+    def lookup(addr: int) -> int | None:
         try:
-            return bin_file.read(addr, size)
-        except InvalidVirtualAddressError:
+            (ptr,) = struct.unpack("<L", bin_file.read(addr, 4))
+            return ptr
+        except (struct.error, InvalidVirtualAddressError, InvalidVirtualReadError):
             return None
 
     return lookup
@@ -143,13 +147,17 @@ class Compare:
 
         self.orig_sanitize = ParseAsm(
             addr_test=create_reloc_lookup(self.orig_bin),
-            name_lookup=create_name_lookup(self._db.get_by_orig, "orig_addr"),
-            bin_lookup=create_bin_lookup(self.orig_bin),
+            name_lookup=create_name_lookup(
+                self._db.get_by_orig, create_bin_lookup(self.orig_bin), "orig_addr"
+            ),
         )
         self.recomp_sanitize = ParseAsm(
             addr_test=create_reloc_lookup(self.recomp_bin),
-            name_lookup=create_name_lookup(self._db.get_by_recomp, "recomp_addr"),
-            bin_lookup=create_bin_lookup(self.recomp_bin),
+            name_lookup=create_name_lookup(
+                self._db.get_by_recomp,
+                create_bin_lookup(self.recomp_bin),
+                "recomp_addr",
+            ),
         )
 
     def _load_cvdump(self):
@@ -521,48 +529,28 @@ class Compare:
         recomp_byname = {
             (dll.upper(), name): addr for (dll, name, addr) in self.recomp_bin.imports
         }
-        # Combine these two dictionaries. We don't care about imports from recomp
-        # not found in orig because:
-        # 1. They shouldn't be there
-        # 2. They are already identified via cvdump
-        orig_to_recomp = {
-            addr: recomp_byname.get(pair, None) for addr, pair in orig_byaddr.items()
-        }
 
-        # Now: we have the IAT offset in each matched up, so we need to make
-        # the connection between the thunk functions.
-        # We already have the symbol name we need from the PDB.
-        for orig, recomp in orig_to_recomp.items():
-            if orig is None or recomp is None:
-                continue
+        with self._db.batch() as batch:
+            for dll, name, addr in self.orig_bin.imports:
+                import_name = f"{dll.upper()}:{name}"
+                batch.set_orig(
+                    addr, import_name=import_name, size=4, type=EntityType.IMPORT
+                )
 
-            # Match the __imp__ symbol
-            self._db.set_pair(orig, recomp, EntityType.POINTER)
+            for dll, name, addr in self.recomp_bin.imports:
+                import_name = f"{dll.upper()}:{name}"
+                batch.set_recomp(
+                    addr, import_name=import_name, size=4, type=EntityType.IMPORT
+                )
 
-            # Read the relative address from .idata
-            try:
-                (recomp_rva,) = struct.unpack("<L", self.recomp_bin.read(recomp, 4))
-                (orig_rva,) = struct.unpack("<L", self.orig_bin.read(orig, 4))
-            except ValueError:
-                # Bail out if there's a problem with struct.unpack
-                continue
-
-            # Strictly speaking, this is a hack to support asm sanitize.
-            # When calling an import, we will recognize that the address for the
-            # CALL instruction is a pointer to the actual address, but this is
-            # not only not the address of a function, it is not an address at all.
-            # To make the asm display work correctly (i.e. to match what you see
-            # in ghidra) create a function match on the RVA. This is not a valid
-            # virtual address because it is before the imagebase, but it will
-            # do what we need it to do in the sanitize function.
-
-            (dll_name, func_name) = orig_byaddr[orig]
-            fullname = dll_name + ":" + func_name
-            self._db.set_recomp_symbol(
-                recomp_rva, type=EntityType.FUNCTION, name=fullname, size=4
-            )
-            self._db.set_pair(orig_rva, recomp_rva, EntityType.FUNCTION)
-            self._db.skip_compare(orig_rva)
+            # Combine these two dictionaries. We don't care about imports from recomp
+            # not found in orig because:
+            # 1. They shouldn't be there
+            # 2. They are already identified via cvdump
+            for orig_addr, pair in orig_byaddr.items():
+                recomp_addr = recomp_byname.get(pair, None)
+                if recomp_addr is not None:
+                    batch.match(orig_addr, recomp_addr)
 
     def _match_thunks(self):
         """Thunks are (by nature) matched by indirection. If a thunk from orig

--- a/reccmp/isledecomp/types.py
+++ b/reccmp/isledecomp/types.py
@@ -12,3 +12,4 @@ class EntityType(IntEnum):
     STRING = 4
     VTABLE = 5
     FLOAT = 6
+    IMPORT = 7

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -1,0 +1,217 @@
+import pytest
+from reccmp.isledecomp.types import EntityType
+from reccmp.isledecomp.compare.db import EntityDb
+from reccmp.isledecomp.compare.asm.replacement import (
+    create_name_lookup,
+    NameReplacementProtocol,
+)
+
+
+@pytest.fixture(name="db")
+def fixture_db() -> EntityDb:
+    return EntityDb()
+
+
+def create_lookup(
+    db, addrs: dict[int, int] | None = None, is_orig: bool = True
+) -> NameReplacementProtocol:
+    if addrs is None:
+        addrs = {}
+
+    def bin_lookup(addr: int) -> int | None:
+        return addrs.get(addr)
+
+    if is_orig:
+        return create_name_lookup(db.get_by_orig, bin_lookup, "orig_addr")
+
+    return create_name_lookup(db.get_by_recomp, bin_lookup, "recomp_addr")
+
+
+####
+
+
+def test_name_replacement(db):
+    """Should return a name for an entity that has one.
+    Return None if there are no name attributes set or the entity does not exist."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Test")
+        batch.set_orig(200, computed_name="Hello")
+        batch.set_orig(300)  # No name
+
+    lookup = create_lookup(db)
+
+    # Using "in" here because the returned string may contain other information.
+    # e.g. the entity type
+    assert "Test" in lookup(100)
+    assert "Hello" in lookup(200)
+    assert lookup(300) is None
+
+
+def test_name_hierarchy(db):
+    """Use the "best" entity name. Currently there are only two.
+    'computed_name' is preferred over just 'name'."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Test", computed_name="Hello")
+
+    lookup = create_lookup(db)
+
+    # Should prefer 'computed_name' over 'name'
+    assert "Hello" in lookup(100)
+    assert "Test" not in lookup(100)
+
+
+def test_string_escape_newlines(db):
+    """Make sure newlines are removed from the string.
+    This overlap with tests on the ReccmpEntity name functions, but it is more vital
+    to ensure there are no newlines at this stage because they will disrupt the asm diff.
+    """
+    with db.batch() as batch:
+        batch.set_orig(100, name="Test\nTest", type=EntityType.STRING)
+
+    lookup = create_lookup(db)
+
+    assert "\n" not in lookup(100)
+
+
+def test_offset_name(db):
+    """For some entities (i.e. variables) we will return a name if the search address
+    is inside the address range of the entity. This is determined by the size attribute.
+    """
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.DATA, size=10)
+
+    lookup = create_lookup(db)
+
+    assert lookup(100) is not None
+    assert lookup(101) is not None
+
+    # Outside the range = no name
+    assert lookup(110) is None
+
+
+def test_offset_name_non_variables(db):
+    """Do not return an offset name for non-variable entities. (e.g. functions)."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION, size=10)
+        batch.set_orig(200, name="Hello", size=10)  # No type
+
+    lookup = create_lookup(db)
+
+    assert lookup(100) is not None
+    assert lookup(101) is None
+
+    assert lookup(200) is not None
+    assert lookup(201) is None
+
+
+def test_offset_name_no_size(db):
+    """An enity with no size attribute is considered to have size=0.
+    Meaning: match only against the address value."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.DATA)
+
+    lookup = create_lookup(db)
+
+    assert lookup(100) is not None
+    assert lookup(101) is None
+
+
+def test_exact_restriction(db):
+    """If exact=True, return a name only if the entity's address matches the search address.
+    Otherwise we might return a name if the entity contains the search address."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.DATA, size=10)
+
+    lookup = create_lookup(db)
+
+    assert lookup(100, exact=True) is not None
+    assert lookup(101, exact=True) is None
+
+    # Proof that the exact parameter controls whether we get a name.
+    assert lookup(101, exact=False) is not None
+
+
+def test_indirect_function(db):
+    """An instruction like `call dword ptr [0x1234]` means that we call the function
+    whose address is at address 0x1234. This is an indirect lookup."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+
+    # Mock lookup so we will read 100 from address 200.
+    lookup = create_lookup(db, {200: 100})
+
+    # No entity at 200
+    assert lookup(200) is None
+    assert lookup(200, indirect=True) is not None
+
+    # Imitating ghidra asm display. Not every indirect lookup gets the arrow.
+    assert "->" in lookup(200, indirect=True)
+
+
+def test_indirect_function_variable(db):
+    """If the indirect call instruction has the address of a variable in our database,
+    prefer the variable name rather than reading the pointer."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+        batch.set_orig(200, name="Test", type=EntityType.DATA)
+
+    # Mock lookup so we will read 100 from address 200.
+    lookup = create_lookup(db, {200: 100})
+
+    name = lookup(200, indirect=True)
+    assert name is not None
+    assert "Hello" not in name
+    assert "Test" in name
+    assert "->" not in name
+
+
+def test_indirect_import(db):
+    """If we are indirectly calling an imported funtion, we should see the import_name
+    attribute used in the result. This will probably contain the DLL and function name.
+    """
+    with db.batch() as batch:
+        batch.set_orig(100, import_name="Hello", name="Test", type=EntityType.IMPORT)
+
+    # No mock needed here because we will not need to read any data.
+    lookup = create_lookup(db)
+
+    # Should use import name with arrow to suggest indirect call.
+    name = lookup(100, indirect=True)
+    assert name is not None
+    assert "Hello" in name
+    assert "->" in name
+
+    # Show the entity name instead. (e.g. __imp__ symbol)
+    name = lookup(100, indirect=False)
+    assert name is not None
+    assert "Test" in name
+    assert "->" not in name
+
+
+def test_indirect_import_missing_data(db):
+    """Edge cases for indirect lookup on an IMPORT entity.."""
+    with db.batch() as batch:
+        batch.set_orig(100, name="Test", type=EntityType.IMPORT)
+
+    lookup = create_lookup(db)
+
+    # No import name. Use the regular entity name instead (i.e. match indirect=False lookup)
+    name = lookup(100, indirect=True)
+    assert name is not None
+    assert "Test" in name
+    assert "->" not in name
+
+
+def test_indirect_failed_lookup(db):
+    """In the general case (i.e. we do not use the base entity to get the name)
+    if there is no entity at the pointer location, return None."""
+    with db.batch() as batch:
+        batch.set_orig(200, name="Hello", type=EntityType.FUNCTION)
+
+    # Mock lookup so we will read 100 from address 200.
+    lookup = create_lookup(db, {200: 100})
+
+    # There is an entity at 200 but we can't use it to generate a name.
+    # There is no entity at 100 (indirect location)
+    assert lookup(200, indirect=False) is not None
+    assert lookup(200, indirect=True) is None


### PR DESCRIPTION
There are a few different types of "indirect" calls:

```
1. call dword ptr [g_unk0x101013b0 (DATA)]
2. call dword ptr [->Matrix4::Clear (FUNCTION)]
3. call dword ptr [->GDI32.DLL:CreateFontA (FUNCTION)]
```

The path to get the name depends on what we're looking at:

In 1, we are calling the function pointer at the given variable, which may or may not have an initial value. 2 is a virtual method but we are calling it this way instead of loading the vptr base into `ecx` and using an offset. 3 is an imported function from a DLL.

In all cases, the address in the instruction is a pointer to the actual address we want to call. In 1, we have the variable in our database and it's more useful to use that as the name. (The initial value may be irrelevant.) For 2, we can get to the annotated function by reading the pointer address from the binary and looking up _that_ value in our database.

We can do the same for 3, except that the pointer location does not have an address. It is a _relative_ virtual address. When the image is loaded, this value should be updated to point at the location of the imported function, but in the file it looks like this:

```
                    ********************************************
                    *       POINTER to EXTERNAL FUNCTION       *
                    ********************************************
                    undefined DirectDrawCreate()
         undefined    AL:1      <RETURN>
                    5  DirectDrawCreate  <<not bound>>
                    PTR_DirectDrawCreate_1010b32c     XREF[1]: DirectDrawCreate:100d3...
   1010b32c 1e be      addr    DDRAW.DLL::DirectDrawCreate
            10 00

```

`0x10be1e` is the RVA to the `IMAGE_IMPORT_BY_NAME` struct for this function.

This currently works for asm sanitize by the hack of loading the RVA as if it were an address. The problem comes later when we want to iterate through all entities in the database. We have to filter out the fake addresses so they are ignored by `roadmap` or the ghidra import scripts.

We could patch the binary (in memory) so the RVA becomes a real address, then use that as the entity with the DLL name. What I did instead is change the name replacement function to recognize an indirect lookup and use a different attribute of the import entity for this situation.

That change required these steps:

- Keep indirect and direct lookups separate during asm sanitize. The reason is that the same address can produce two different names depending on the context. For example:

```
mov esi, dword ptr [__imp__timeGetTime@0 (IMPORT)]

versus

call dword ptr [->WINMM.DLL:timeGetTime (FUNCTION)]
```

- The binary lookup was a dependency of asm sanitize. This is now used directly by the name replacement function and it specifically returns a pointer instead of allowing a read of any size.

- We now have `EntityType.IMPORT` specifically for imports from `.idata`. Previously we used `POINTER` as the type. We also set the `import_name` attribute to contain the DLL name and function name. This attribute is used by the name replacement function.

- Loading and matching of imports is a lot simpler because we don't need to set up the aforementioned hack with the RVA.

We also have a lot of new comments and tests surrounding name replacement and asm sanitize. The only changes to the generated assembly are:
- `POINTER` is now `IMPORT` for the various `__imp__` entities.
- The placeholder offset numbers are bumped by one in functions with indirect calls where we can't come up with a name. Previously the placeholder was shared between direct and indirect references if there was not a better name to use.

BETA10 had one minor drop in accuracy on the library function `_amsg_exit`. No change to LEGO1.