### PR TITLE
reccmp-aggregate: support fromfile arguments

### DIFF
--- a/reccmp/tools/aggregate.py
+++ b/reccmp/tools/aggregate.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import argparse
 import logging
 from typing import Sequence
@@ -77,10 +78,11 @@ class TwoOrFewerArgsAction(argparse.Action):
         setattr(namespace, self.dest, values)
 
 
-def main():
+def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         allow_abbrev=False,
         description="Aggregate saved accuracy reports.",
+        fromfile_prefix_chars="@",
     )
     parser.add_argument(
         "--diff",
@@ -115,7 +117,7 @@ def main():
         "--no-color", "-n", action="store_true", help="Do not color the output"
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not (args.samples or args.diff):
         parser.error(
@@ -126,6 +128,15 @@ def main():
         parser.error(
             "expected arguments for --output, --html, or --diff. (No output action specified)"
         )
+
+    if args.diff and len(args.diff) == 1 and not args.samples:
+        parser.error("expected two report files to diff")
+
+    return args
+
+
+def main():
+    args = parse_args(sys.argv[1:])
 
     agg_report: ReccmpStatusReport | None = None
 

--- a/reccmp/tools/aggregate.py
+++ b/reccmp/tools/aggregate.py
@@ -79,7 +79,13 @@ class TwoOrFewerArgsAction(argparse.Action):
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    if len(argv) > 1:
+        prog = Path(argv[0]).stem
+    else:
+        prog = None  # defer to sys.argv
+
     parser = argparse.ArgumentParser(
+        prog=prog,
         allow_abbrev=False,
         description="Aggregate saved accuracy reports.",
         fromfile_prefix_chars="@",
@@ -117,7 +123,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--no-color", "-n", action="store_true", help="Do not color the output"
     )
 
-    args = parser.parse_args(argv)
+    args = parser.parse_args(argv[1:])
 
     if not (args.samples or args.diff):
         parser.error(
@@ -130,13 +136,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         )
 
     if args.diff and len(args.diff) == 1 and not args.samples:
-        parser.error("expected two report files to diff")
+        parser.error("--diff expects two report files")
 
     return args
 
 
 def main():
-    args = parse_args(sys.argv[1:])
+    args = parse_args(sys.argv)
 
     agg_report: ReccmpStatusReport | None = None
 

--- a/tests/test_tools_aggregate.py
+++ b/tests/test_tools_aggregate.py
@@ -1,0 +1,89 @@
+"""Testing command-line input for the reccmp-aggregate tool."""
+import pytest
+from reccmp.tools.aggregate import parse_args
+
+
+def test_args_none():
+    """Should fail without required params"""
+    with pytest.raises(SystemExit):
+        parse_args([])
+
+
+def test_args_diff():
+    """The --diff option requires:
+    1. Two report files to compare
+    2. One report file and 2 or more samples"""
+    parse_args(["--diff", "A.json", "B.json"])
+    parse_args(["--diff", "A.json", "--samples", "X.json", "Y.json"])
+
+    # Can also save HTML or JSON output
+    parse_args(
+        ["--diff", "A.json", "--samples", "X.json", "Y.json", "--html", "report.html"]
+    )
+    parse_args(
+        ["--diff", "A.json", "--samples", "X.json", "Y.json", "--output", "report.json"]
+    )
+
+
+def test_args_diff_not_enough_files():
+    """Cannot diff zero files.
+    Cannot diff one file if no samples are provided."""
+    with pytest.raises(SystemExit):
+        parse_args(["--diff"])
+
+    with pytest.raises(SystemExit):
+        parse_args(["--diff", "A.json"])
+
+    with pytest.raises(SystemExit):
+        parse_args(["--diff", "--samples", "X.json", "Y.json"])
+
+
+def test_args_diff_two_files():
+    """The second diff file will be ignored if --samples is used. Non-fatal error."""
+    parse_args(["--diff", "A.json", "B.json", "--samples", "X.json", "Y.json"])
+
+
+def test_args_diff_three_plus_files():
+    """Fail if more than two files are provided for --diff. We would never use files 3-N."""
+    with pytest.raises(SystemExit):
+        parse_args(
+            ["--diff", "A.json", "B.json", "C.json", "--samples", "X.json", "Y.json"]
+        )
+
+
+def test_args_samples():
+    """The --samples option requires two or more sample files, and:
+    1. A saved report to diff against (--diff)
+    2. At least one output format (--html or --output)"""
+    parse_args(["--diff", "A.json", "--samples", "X.json", "Y.json"])
+    parse_args(["--samples", "X.json", "Y.json", "--html", "report.html"])
+    parse_args(["--samples", "X.json", "Y.json", "--output", "report.json"])
+
+
+def test_args_samples_no_output():
+    """Fail if no diff file or output formats provided."""
+    with pytest.raises(SystemExit):
+        parse_args(["--samples", "X.json", "Y.json"])
+
+
+def test_args_samples_not_enough():
+    """Fail with zero or one samples"""
+    with pytest.raises(SystemExit):
+        parse_args(["--diff", "A.json", "--samples"])
+
+    with pytest.raises(SystemExit):
+        parse_args(["--diff", "A.json", "--samples", "X.json"])
+
+
+def test_args_samples_from_file(tmp_path):
+    """Confirm we can load sample list from a file.
+    This is possible for any argument but --samples is the primary use case."""
+    tmp_file = tmp_path / "args.txt"
+    files = ["X.json", "Y.json", "Z.json"]
+    tmp_file.write_text("\n".join(files), encoding="utf-8")
+    args = parse_args(["--diff", "A.json", "--samples", f"@{tmp_file}"])
+
+    assert len(args.samples) == 3
+
+    # Get base filename from these pathlib.Path objects
+    assert [path.name for path in args.samples] == files

--- a/tests/test_tools_aggregate.py
+++ b/tests/test_tools_aggregate.py
@@ -8,20 +8,41 @@ def test_args_none():
     with pytest.raises(SystemExit):
         parse_args([])
 
+    with pytest.raises(SystemExit):
+        parse_args([""])
+
 
 def test_args_diff():
     """The --diff option requires:
     1. Two report files to compare
     2. One report file and 2 or more samples"""
-    parse_args(["--diff", "A.json", "B.json"])
-    parse_args(["--diff", "A.json", "--samples", "X.json", "Y.json"])
+    parse_args(["", "--diff", "A.json", "B.json"])
+    parse_args(["", "--diff", "A.json", "--samples", "X.json", "Y.json"])
 
     # Can also save HTML or JSON output
     parse_args(
-        ["--diff", "A.json", "--samples", "X.json", "Y.json", "--html", "report.html"]
+        [
+            "",
+            "--diff",
+            "A.json",
+            "--samples",
+            "X.json",
+            "Y.json",
+            "--html",
+            "report.html",
+        ]
     )
     parse_args(
-        ["--diff", "A.json", "--samples", "X.json", "Y.json", "--output", "report.json"]
+        [
+            "",
+            "--diff",
+            "A.json",
+            "--samples",
+            "X.json",
+            "Y.json",
+            "--output",
+            "report.json",
+        ]
     )
 
 
@@ -29,25 +50,34 @@ def test_args_diff_not_enough_files():
     """Cannot diff zero files.
     Cannot diff one file if no samples are provided."""
     with pytest.raises(SystemExit):
-        parse_args(["--diff"])
+        parse_args(["", "--diff"])
 
     with pytest.raises(SystemExit):
-        parse_args(["--diff", "A.json"])
+        parse_args(["", "--diff", "A.json"])
 
     with pytest.raises(SystemExit):
-        parse_args(["--diff", "--samples", "X.json", "Y.json"])
+        parse_args(["", "--diff", "--samples", "X.json", "Y.json"])
 
 
 def test_args_diff_two_files():
     """The second diff file will be ignored if --samples is used. Non-fatal error."""
-    parse_args(["--diff", "A.json", "B.json", "--samples", "X.json", "Y.json"])
+    parse_args(["", "--diff", "A.json", "B.json", "--samples", "X.json", "Y.json"])
 
 
 def test_args_diff_three_plus_files():
     """Fail if more than two files are provided for --diff. We would never use files 3-N."""
     with pytest.raises(SystemExit):
         parse_args(
-            ["--diff", "A.json", "B.json", "C.json", "--samples", "X.json", "Y.json"]
+            [
+                "",
+                "--diff",
+                "A.json",
+                "B.json",
+                "C.json",
+                "--samples",
+                "X.json",
+                "Y.json",
+            ]
         )
 
 
@@ -55,24 +85,24 @@ def test_args_samples():
     """The --samples option requires two or more sample files, and:
     1. A saved report to diff against (--diff)
     2. At least one output format (--html or --output)"""
-    parse_args(["--diff", "A.json", "--samples", "X.json", "Y.json"])
-    parse_args(["--samples", "X.json", "Y.json", "--html", "report.html"])
-    parse_args(["--samples", "X.json", "Y.json", "--output", "report.json"])
+    parse_args(["", "--diff", "A.json", "--samples", "X.json", "Y.json"])
+    parse_args(["", "--samples", "X.json", "Y.json", "--html", "report.html"])
+    parse_args(["", "--samples", "X.json", "Y.json", "--output", "report.json"])
 
 
 def test_args_samples_no_output():
     """Fail if no diff file or output formats provided."""
     with pytest.raises(SystemExit):
-        parse_args(["--samples", "X.json", "Y.json"])
+        parse_args(["", "--samples", "X.json", "Y.json"])
 
 
 def test_args_samples_not_enough():
     """Fail with zero or one samples"""
     with pytest.raises(SystemExit):
-        parse_args(["--diff", "A.json", "--samples"])
+        parse_args(["", "--diff", "A.json", "--samples"])
 
     with pytest.raises(SystemExit):
-        parse_args(["--diff", "A.json", "--samples", "X.json"])
+        parse_args(["", "--diff", "A.json", "--samples", "X.json"])
 
 
 def test_args_samples_from_file(tmp_path):
@@ -81,7 +111,7 @@ def test_args_samples_from_file(tmp_path):
     tmp_file = tmp_path / "args.txt"
     files = ["X.json", "Y.json", "Z.json"]
     tmp_file.write_text("\n".join(files), encoding="utf-8")
-    args = parse_args(["--diff", "A.json", "--samples", f"@{tmp_file}"])
+    args = parse_args(["", "--diff", "A.json", "--samples", f"@{tmp_file}"])
 
     assert len(args.samples) == 3
 


### PR DESCRIPTION
Resolves #96. One-line fix thanks to @madebr.

We now also have some rudimentary tests on command-line parsing. We should add this for all the tools eventually. I thought I would start here because we have only a few arguments to deal with. Suggestions welcome on alternative ways to set this up.