### PR TITLE
New PDB path conversion method

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -118,7 +118,8 @@ class Compare:
         self.debug: bool = False
         self.runid: str = uuid.uuid4().hex[:8]
 
-        self._lines_db = LinesDb(code_dir)
+        code_files = [Path(p) for p in walk_source_dir(self.code_dir)]
+        self._lines_db = LinesDb(code_files)
         self._db = EntityDb()
 
         # For now, just redirect match alerts to the logger.

--- a/reccmp/isledecomp/compare/lines.py
+++ b/reccmp/isledecomp/compare/lines.py
@@ -3,33 +3,36 @@ between FUNCTION markers and PDB analysis."""
 
 import logging
 from functools import cache
-from pathlib import Path, PureWindowsPath
-from reccmp.isledecomp.dir import convert_foreign_path, walk_source_dir
+from pathlib import Path, PurePath, PureWindowsPath
+from collections.abc import Sequence
+from reccmp.isledecomp.dir import convert_foreign_path
 
 
 logger = logging.getLogger(__name__)
 
 
 class LinesDb:
-    def __init__(self, code_dir) -> None:
-        # Code files of interest
-        # TODO: It may be better to provide the list of files instead of the directory
-        self._code_files = tuple(Path(p) for p in walk_source_dir(code_dir))
+    def __init__(
+        self, files: Sequence[Path] | Sequence[PurePath] | Sequence[str]
+    ) -> None:
         self._path_resolver = cache(convert_foreign_path)
 
         # Set up memoized map of filenames to their paths
-        self._filenames: dict[str, list[Path]] = {}
-        for path in self._code_files:
+        self._filenames: dict[str, list[PurePath]] = {}
+        for path in files:
+            if not isinstance(path, PurePath):
+                path = PurePath(path)
+
             self._filenames.setdefault(path.name.lower(), []).append(path)
 
         # Local filename to list of (line_no, address) pairs
         # This has to be a list instead of a dict because line numbers may be used twice.
         # e.g. for the start and end of a loop.
-        self._map: dict[Path, list[tuple[int, int]]] = {}
+        self._map: dict[PurePath, list[tuple[int, int]]] = {}
 
-    def add_line(self, path: str, line_no: int, addr: int):
+    def add_line(self, foreign_path: str, line_no: int, addr: int):
         """Connect the remote path to a line number and address pair."""
-        pdb_path = PureWindowsPath(path)
+        pdb_path = PureWindowsPath(foreign_path)
         filename = pdb_path.name.lower()
 
         candidates = self._filenames.get(filename)
@@ -41,13 +44,13 @@ class LinesDb:
         if sourcepath is None:
             return
 
-        # mypy coersion. The function returns a PurePath because it is a superclass of Path.
-        assert isinstance(sourcepath, Path)
-
         self._map.setdefault(sourcepath, []).append((line_no, addr))
 
     def search_line(
-        self, path: str, line_start: int, line_end: int | None = None
+        self,
+        local_path: str | Path | PurePath,
+        line_start: int,
+        line_end: int | None = None,
     ) -> int | None:
         """The database contains the first line of each function, as verified by
         reducing the starting list of line-offset pairs using other information from the pdb.
@@ -58,7 +61,10 @@ class LinesDb:
         if line_end is None:
             line_end = line_start
 
-        lines = self._map.get(Path(path))
+        if not isinstance(local_path, PurePath):
+            local_path = PurePath(local_path)
+
+        lines = self._map.get(local_path)
         if lines is None:
             return None
 
@@ -75,7 +81,7 @@ class LinesDb:
         if len(possible_functions) > 1:
             logger.error(
                 "Debug data out of sync with function near: %s:%d",
-                path,
+                local_path,
                 line_start,
             )
             return None
@@ -84,7 +90,7 @@ class LinesDb:
         # the function was eliminated or inlined by compiler optimizations.
         logger.error(
             "Failed to find function symbol with filename and line: %s:%d",
-            path,
+            local_path,
             line_start,
         )
         return None

--- a/reccmp/isledecomp/dir.py
+++ b/reccmp/isledecomp/dir.py
@@ -1,3 +1,4 @@
+"""Utility functions and modules for path resolution and traversal"""
 import os
 import subprocess
 from typing import Iterator
@@ -10,6 +11,53 @@ def winepath_win_to_unix(path: str) -> str:
 
 def winepath_unix_to_win(path: str) -> str:
     return subprocess.check_output(["winepath", "-w", path], text=True).strip()
+
+
+def _iter_path_components(path: PurePath) -> Iterator[str]:
+    """Walk path components in reverse and convert to lower case for matching."""
+    for p in reversed(path.parts):
+        yield p.lower()
+
+
+def _count_matching_path_parts(
+    remote_path: PurePath, local_path: PurePath
+) -> tuple[int, PurePath]:
+    score = 0
+    for rp, lp in zip(
+        _iter_path_components(remote_path), _iter_path_components(local_path)
+    ):
+        # Don't try to resolve any dot directories.
+        # We would get it wrong if any of the paths are symlinks.
+        if rp != lp or rp in (".", "..") or lp in (".", ".."):
+            break
+
+        score += 1
+
+    return (score, local_path)
+
+
+def convert_foreign_path(
+    remote_path: PurePath, local_paths: tuple[PurePath]
+) -> PurePath | None:
+    """Connect the given remote_path to the best match from the list of local_paths.
+    For best performance, you should narrow down the starting list to paths
+    that match the base filename."""
+    scored = [_count_matching_path_parts(remote_path, p) for p in local_paths]
+    scored.sort(reverse=True)
+
+    if len(scored) >= 2:
+        [(top_score, top_path), (next_score, _)] = scored[:2]
+        # Return if this is the best match above all others
+        if top_score > next_score:
+            return top_path
+
+    elif len(scored) == 1:
+        (top_score, top_path) = scored[0]
+        # Return only if we matched at least one part
+        if top_score > 0:
+            return top_path
+
+    return None
 
 
 class PathResolver:

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -70,7 +70,8 @@ def test_db_hash_windows():
 
 def test_db_hash_posix():
     """Same as above, but POSIX paths *are* case-sensitive.
-    The goal here is just to show that we are not _____"""
+    The goal here is to show that we are not taking liberties with PurePath
+    and when it can be expected to match."""
 
     path = PurePosixPath("test.cpp")
     lines = LinesDb([path])

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,0 +1,82 @@
+"""Testing lines database: mapping between (filename, line_number) to virtual address."""
+
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+from reccmp.isledecomp.compare.lines import LinesDb
+
+TEST_PATH = PurePath("test.cpp")
+
+
+def test_lines():
+    """Basic demonstration of behavior"""
+    lines = LinesDb([TEST_PATH])
+
+    # We haven't added any addresses yet.
+    assert lines.search_line(TEST_PATH, 1, 10) is None
+
+    # Test search on line 2 only
+    lines.add_line(TEST_PATH, 2, 0x1234)
+    assert lines.search_line(TEST_PATH, 2) == 0x1234
+
+    # Search window
+    assert lines.search_line(TEST_PATH, 1, 2) == 0x1234
+
+    # Outside of search window
+    assert lines.search_line(TEST_PATH, 1, 1) is None
+    assert lines.search_line(TEST_PATH, 3, 10) is None
+
+
+def test_no_files_of_interest():
+    """Same as above test, but with no files declared up front.
+    Calls to add_line do not alter the db."""
+
+    lines = LinesDb([])
+    lines.add_line(TEST_PATH, 2, 0x1234)
+    # The address is ignored because "test.cpp" is not part of the decomp code base.
+    assert lines.search_line(TEST_PATH, 2) is None
+
+
+def test_multiple_match():
+    """search_line looks for function starts in the range specified.
+    If we find more than one address, the file does not match our data source (PDB or MAP).
+    """
+
+    # TODO: Change this when we add *all* lines instead of just known function starts.
+    lines = LinesDb([TEST_PATH])
+    lines.add_line(TEST_PATH, 2, 0x1234)
+    lines.add_line(TEST_PATH, 3, 0x1235)
+
+    # Both match on their own
+    assert lines.search_line(TEST_PATH, 2) == 0x1234
+    assert lines.search_line(TEST_PATH, 3) == 0x1235
+
+    # Two addresses in this range of line numbers. return None.
+    assert lines.search_line(TEST_PATH, 2, 3) is None
+
+
+def test_db_hash_windows():
+    """Our DB uses PurePath as the key, so we rely on
+    the equality check for whichever platform you are running on.
+    Windows paths are not case-sensitive."""
+
+    path = PureWindowsPath("test.cpp")
+    lines = LinesDb([path])
+    lines.add_line(path, 2, 0x1234)
+
+    # Should match any variation
+    assert lines.search_line(path, 2) == 0x1234
+    assert lines.search_line(PureWindowsPath("Test.cpp"), 2) == 0x1234
+    assert lines.search_line(PureWindowsPath("TEST.CPP"), 2) == 0x1234
+
+
+def test_db_hash_posix():
+    """Same as above, but POSIX paths *are* case-sensitive.
+    The goal here is just to show that we are not _____"""
+
+    path = PurePosixPath("test.cpp")
+    lines = LinesDb([path])
+    lines.add_line(path, 2, 0x1234)
+
+    # Should match only the exact path
+    assert lines.search_line(path, 2) == 0x1234
+    assert lines.search_line(PurePosixPath("Test.cpp"), 2) is None
+    assert lines.search_line(PurePosixPath("TEST.CPP"), 2) is None

--- a/tests/test_path_converter.py
+++ b/tests/test_path_converter.py
@@ -1,0 +1,63 @@
+"""Tests for foreign path conversion, used to resolve PDB paths from a build run on
+another system or on a non-Windows host using Wine."""
+from pathlib import PurePosixPath, PureWindowsPath
+from reccmp.isledecomp.dir import convert_foreign_path as resolve
+
+
+def test_resolve():
+    # Can't do anything with no file options
+    assert resolve(PureWindowsPath("Z:\\test\\file.cpp"), ()) is None
+
+    # Match
+    path = PurePosixPath("/test/file.cpp")
+    assert resolve(PureWindowsPath("Z:\\test\\file.cpp"), (path,)) == path
+
+    # Match filename only
+    path = PurePosixPath("file.cpp")
+    assert resolve(PureWindowsPath("Z:\\test\\file.cpp"), (path,)) == path
+
+    # No match
+    assert resolve(PureWindowsPath("Z:\\test\\file.h"), (path,)) is None
+
+    # Match even from a different path if at least the filename matches
+    path = PurePosixPath("/a/b/c/file.h")
+    assert resolve(PureWindowsPath("Z:\\test\\file.h"), (path,)) == path
+
+
+def test_resolve_case():
+    """Match is case-insensitive, allowing for discrepancies in how the PDB
+    path is presented and whether the host OS requires case match for paths."""
+    # Should still match although case is different
+    path = PurePosixPath("/TEST/FILE.CPP")
+    assert resolve(PureWindowsPath("Z:\\test\\file.cpp"), (path,)) == path
+
+    # Still match even if some of the parts match case
+    path = PurePosixPath("/TEST/file.cpp")
+    assert resolve(PureWindowsPath("Z:\\test\\file.cpp"), (path,)) == path
+
+
+def test_resolve_best_match():
+    """Choose the most specific match from several candidates."""
+    pdb_path = PureWindowsPath("Z:\\test\\src\\core\\game.cpp")
+    # Two options for "game.cpp"
+    path = PurePosixPath("/Users/test/src/core/game.cpp")
+    path2 = PurePosixPath("/Users/test/game.cpp")
+    # Should pick the one that matches more path components
+    assert resolve(pdb_path, (path, path2)) == path
+
+
+def test_resolve_many_options():
+    """Should return None if there are multiple equally likely options."""
+    pdb_path = PureWindowsPath("Z:\\test\\game.cpp")
+    # Two options for "game.cpp"
+    path = PurePosixPath("xyz/test/game.cpp")
+    path2 = PurePosixPath("abc/test/game.cpp")
+    # Should pick the one that matches more path components
+    assert resolve(pdb_path, (path, path2)) is None
+
+
+def test_resolve_relative():
+    """Can still match a relative path"""
+    pdb_path = PureWindowsPath("core\\game.cpp")
+    path = PurePosixPath("/files/core/game.cpp")
+    assert resolve(pdb_path, (path,)) == path


### PR DESCRIPTION
Resolves #95. It may also obviate #53 although that code has not changed.

The `LINES` section from the PDB connects code line numbers with addresses. The output from `cvdump` looks like this:

```
C:\work\lego-island\isle\LEGO1\mxdirectx\mxdirectdraw.cpp (None), 0001:0009BDB0-0009BE28, line/addr pairs = 7

 26 0009BDB0     27 0009BDB8     29 0009BDBE     31 0009BDC4
 33 0009BDCA     48 0009BE1F     49 0009BE25
```

We assume that the PDB came from a build on your machine and that this path exists. If you are not on Windows, we use `winepath` to resolve it.

The main limitation is that you cannot use a binary and PDB built somewhere else. We follow every path from the PDB, even if it would cause us to escape outside the directories provided to `reccmp`. There is a performance penalty on non-Windows platforms: if the PDB path is relative but cannot be found in the provided code directory, we need to call `winepath` to resolve it.[^1]

We now match the paths by comparing each path segment as a string. We use the provided code directory to create a list of candidate file paths. We convert everything to lower case to allow for differences in how the path appears in the PDB and on your host platform.

For example, if the path `/projects/isle/LEGO1/mxdirectx/mxdirectdraw.cpp` is the only path to a file called `mxdirectdraw.cpp`, we can match it easily. If we add `/projects/test/mxdirectdraw.cpp` to the list, we would still choose the earlier path because more of its segments match. If the PDB paths contains `.` or `..` then we stop comparing segments. We cannot resolve the path with 100% certainty because the user may have symlinks.

This isn't radically different to what we've already been doing. I haven't seen any issues with LEGO1 or BETA10 on Windows or Mac. For other projects, the success would depend on the uniqueness of the path segments. To protect against this, if we find two matches that are equally likely, the function returns `None`.

I could successfully run `reccmp` on my Mac against `LEGO1.DLL` and `LEGO1.PDB` built on my Windows box. It should be possible to run it this way in the Github CI on an Ubuntu runner, but I didn't get it working before submitting this. We still need Wine to run `cvdump` and I had issues with installing it.

I removed the sqlite db from the `lines.py` module. `Path` is a hashable type so we can use it as a dict key and it just works better. I want to eventually add _all_ code lines to this database, not just the addresses that start each function. We could then display the code lines with the assembly diff in the command line `reccmp-reccmp`.

[^1]:For example: code lines for templates from the MSVC include directory.