### PR TITLE
Find vtordisp functions using regex

### DIFF
--- a/reccmp/isledecomp/analysis/__init__.py
+++ b/reccmp/isledecomp/analysis/__init__.py
@@ -1,1 +1,2 @@
 from .float_const import find_float_consts
+from .vtordisp import find_vtordisp

--- a/reccmp/isledecomp/analysis/vtordisp.py
+++ b/reccmp/isledecomp/analysis/vtordisp.py
@@ -1,0 +1,77 @@
+"""Find multiple-inheritance thunk (vtordisp) functions."""
+
+import re
+import struct
+from typing import Iterator, NamedTuple
+from reccmp.isledecomp.formats.pe import PEImage
+
+# Each vtordisp function begins with `sub ecx, <byte>`
+VTOR_START_RE = re.compile(rb"\x2b\x49")
+
+# n.b. These regex strings all use positive lookahead to support overlapping matches.
+# They could be used individually to check the entire code section, but it is faster to
+# check only spots where we can find `2B 49`.
+
+# vtordisp{byte, 0}
+VTOR_RE = re.compile(rb"(?=\x2b\x49(.)\xe9(.{4}))", flags=re.S)
+
+# vtordisp{byte, dword}
+VTOR_ADD_RE = re.compile(rb"(?=\x2b\x49(.)\x81\xc1(.{4})\xe9(.{4}))", flags=re.S)
+
+# vtordisp{byte, byte}
+VTOR_SUB_RE = re.compile(rb"(?=\x2b\x49(.)\x83\xe9(.)\xe9(.{4}))", flags=re.S)
+
+
+class VtordispFunction(NamedTuple):
+    addr: int
+    displacement: tuple[int, int]
+    func_addr: int
+
+
+def find_displacements(buf: bytes, base_addr: int = 0) -> Iterator[VtordispFunction]:
+    for start_match in VTOR_START_RE.finditer(buf):
+        start = start_match.start()
+
+        # For each of these three kinds of vtordisp:
+        # 1.  Read one or two displacement values
+        # 2.  If there is a second displacement value, it is positive or negative
+        #     based on whether ADD or SUB instruction is used
+        # 3.  Correct the jump displacement for the size of the function so we get
+        #     the address of the function being thunked.
+
+        if (match := VTOR_RE.match(buf[start:])) is not None:
+            (displace,) = struct.unpack("b", match.group(1))
+            (jmp_ofs,) = struct.unpack("<i", match.group(2))
+
+            addr = base_addr + start
+            jmp_addr = addr + 8 + jmp_ofs
+
+            yield VtordispFunction(addr, (displace, 0), jmp_addr)
+
+        elif (match := VTOR_ADD_RE.match(buf[start:])) is not None:
+            (displace,) = struct.unpack("b", match.group(1))
+            (displace2,) = struct.unpack("<i", match.group(2))
+            (jmp_ofs,) = struct.unpack("<i", match.group(3))
+
+            addr = base_addr + start
+            jmp_addr = addr + 14 + jmp_ofs
+
+            yield VtordispFunction(addr, (displace, 2**32 - displace2), jmp_addr)
+
+        elif (match := VTOR_SUB_RE.match(buf[start:])) is not None:
+            (displace,) = struct.unpack("b", match.group(1))
+            (displace2,) = struct.unpack("b", match.group(2))
+            (jmp_ofs,) = struct.unpack("<i", match.group(3))
+
+            addr = base_addr + start
+            jmp_addr = addr + 11 + jmp_ofs
+
+            yield VtordispFunction(addr, (displace, displace2), jmp_addr)
+
+
+def find_vtordisp(image: PEImage) -> Iterator[VtordispFunction]:
+    # TODO: Should check all code sections.
+    code_sections = (image.get_section_by_name(".text"),)
+
+    for sect in code_sections:
+        yield from find_displacements(sect.view, sect.virtual_address)

--- a/tests/test_analysis_vtordisp.py
+++ b/tests/test_analysis_vtordisp.py
@@ -1,0 +1,27 @@
+"""Test find_vtordisp for PE images"""
+
+from reccmp.isledecomp.formats import PEImage
+from reccmp.isledecomp.analysis.vtordisp import find_vtordisp, find_displacements
+
+
+def test_vtor_overlap():
+    """Must be able to match potential instructions that overlap.
+    Because we are not disassembling, we don't know whether a given
+    byte is the start of an instruction."""
+    code = b"\x2b\x49\xfc\xe9\x2b\x49\xfc\xe9\x08\x00\x00\x00"
+    vtors = list(find_displacements(code))
+    assert len(vtors) == 2
+
+
+def test_detection(binfile: PEImage):
+    """Make sure we detect some known floats in our sample PE image"""
+    vtors = list(find_vtordisp(binfile))
+
+    # {byte, 0}
+    assert (0x1000FBB0, (-4, 0), 0x1000FBC0) in vtors
+
+    # {byte, dword}
+    assert (0x10014CD0, (-4, 4294966924), 0x1001C290) in vtors
+
+    # {byte, byte}
+    assert (0x100432B0, (-4, 64), 0x1001C870) in vtors


### PR DESCRIPTION
The vtordisp functions (thunks used in vtables for multiple inheritance) take one of three forms:

```asm
; vtordisp{byte, 0}
sub ecx, dword ptr [ecx - byte]
jmp function

; vtordisp{byte, dword}
sub ecx, dword ptr [ecx - byte]
add ecx, dword
jmp function

; vtordisp{byte, byte}
sub ecx, dword ptr [ecx - byte]
sub ecx, byte
jmp function
```

If there are others, we haven't seen them yet in `LEGO1`/`BETA10` and we should add them.

Our current method of identifying and matching these is to scan each multiple inheritance vtable and check the bytes of the function in each position. We can tell which vtables have multiple inheritance by their name in the PDB. e.g. ``Act2Actor::`vftable'{for `LegoPathActor'}``

This change now identifies these functions via regex search without having to mark vtables first. The functions are very distinctive so I would not expect false positives unless the binary has handwritten assembly.

We can now drop the `is_vtordisp` function from the database. This relied upon the demangler module to do the check. We can't properly name these functions without having a name for the thunked function, but that's nothing new.

This marks a lot of new vtordisp functions in `BETA10`: the reason we could not do this before is that there are many layers of indirection and not all of these functions were matched. The vtables point to a thunk on the vtordisp, which itself points to a thunk on the real function.

Also fixes #110.