### PR TITLE
Use unique function name in vtable diff

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -783,7 +783,7 @@ class Compare:
                 recomp = (
                     hex(m.recomp_addr) if m.recomp_addr is not None else "no recomp"
                 )
-                return f"({orig} / {recomp})  :  {m.name}"
+                return f"({orig} / {recomp})  :  {m.best_name()}"
 
             if raw_addr is not None:
                 return f"0x{raw_addr:x} from orig not annotated."


### PR DESCRIPTION
If there are virtual methods that use the same name, display the unique name (including param type) in the vtable diff if we have it.

Before:
```
vtable0x1c : (0x1016a740 / 0x1011e545)  :  TglImpl::GroupImpl::Add
vtable0x20 : (0x1016a6c0 / 0x1011e4c8)  :  TglImpl::GroupImpl::Add
```

After:
```
vtable0x1c : (0x1016a740 / 0x1011e545)  :  TglImpl::GroupImpl::Add(class Tgl::MeshBuilder const *)
vtable0x20 : (0x1016a6c0 / 0x1011e4c8)  :  TglImpl::GroupImpl::Add(class Tgl::Group const *)
```

Should update `reccmp-vtable` output along with `reccmp-reccmp` HTML and terminal output. (They all call the same function to generate the text.)