### PR TITLE
Symbol option for nameref annotations

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -55,6 +55,13 @@ There are a few cases where two functions of the same name need to be annotated 
 // ?_Construct@@YAXPAPAVROI@@ABQAV1@@Z
 ```
 
+Names that begin with `?` are assumed to be [MSVC-like symbols](https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling). In all other cases, you should specify that the name is a symbol by adding `SYMBOL` after the address. For example:
+
+```c++
+// LIBRARY: TEST 0x10002000 SYMBOL
+// __strlwr
+```
+
 ### Annotation types
 
 #### `FUNCTION`

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -266,7 +266,7 @@ class Compare:
                     fun.offset, type=EntityType.FUNCTION, stub=fun.should_skip()
                 )
 
-                if fun.name.startswith("?"):
+                if fun.name.startswith("?") or fun.use_linker:
                     batch.set_orig(fun.offset, symbol=fun.name)
                 else:
                     batch.set_orig(fun.offset, name=fun.name)

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -266,7 +266,7 @@ class Compare:
                     fun.offset, type=EntityType.FUNCTION, stub=fun.should_skip()
                 )
 
-                if fun.name.startswith("?") or fun.use_linker:
+                if fun.name.startswith("?") or fun.name_is_symbol:
                     batch.set_orig(fun.offset, symbol=fun.name)
                 else:
                     batch.set_orig(fun.offset, name=fun.name)

--- a/reccmp/isledecomp/parser/error.py
+++ b/reccmp/isledecomp/parser/error.py
@@ -50,6 +50,10 @@ class ParserError(Enum):
     # function marked too, and in the same module.
     ORPHANED_STATIC_VARIABLE = 112
 
+    # WARN: You marked a line-based function annotation with the SYMBOL option.
+    # This makes no sense, so we ignore the option.
+    SYMBOL_OPTION_IGNORED = 113
+
     # This code or higher is an error, not a warning
     DECOMP_ERROR_START = 200
 

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -36,7 +36,8 @@ class ParserFunction(ParserSymbol):
     # referenced by name, but only if this flag is true.
     lookup_by_name: bool = False
 
-    use_linker: bool = False
+    # True if the annotation name is the linker name (symbol) for this entity.
+    name_is_symbol: bool = False
 
     def should_skip(self) -> bool:
         return self.type == MarkerType.STUB

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -36,6 +36,8 @@ class ParserFunction(ParserSymbol):
     # referenced by name, but only if this flag is true.
     lookup_by_name: bool = False
 
+    use_linker: bool = False
+
     def should_skip(self) -> bool:
         return self.type == MarkerType.STUB
 

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -249,10 +249,12 @@ class DecompParser:
             end_line -= 1
 
         for marker in self.fun_markers.iter():
-            use_linker = marker.extra is not None and marker.extra.lower() == "symbol"
-            if use_linker and not lookup_by_name:
+            name_is_symbol = (
+                marker.extra is not None and marker.extra.lower() == "symbol"
+            )
+            if name_is_symbol and not lookup_by_name:
                 self._syntax_warning(ParserError.SYMBOL_OPTION_IGNORED)
-                use_linker = False
+                name_is_symbol = False
 
             self._symbols.append(
                 ParserFunction(
@@ -263,7 +265,7 @@ class DecompParser:
                     name=self.function_sig,
                     filename=self.filename,
                     lookup_by_name=lookup_by_name,
-                    use_linker=use_linker,
+                    name_is_symbol=name_is_symbol,
                     end_line=end_line,
                 )
             )

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -249,6 +249,11 @@ class DecompParser:
             end_line -= 1
 
         for marker in self.fun_markers.iter():
+            use_linker = marker.extra is not None and marker.extra.lower() == "symbol"
+            if use_linker and not lookup_by_name:
+                self._syntax_warning(ParserError.SYMBOL_OPTION_IGNORED)
+                use_linker = False
+
             self._symbols.append(
                 ParserFunction(
                     type=marker.type,
@@ -258,6 +263,7 @@ class DecompParser:
                     name=self.function_sig,
                     filename=self.filename,
                     lookup_by_name=lookup_by_name,
+                    use_linker=use_linker,
                     end_line=end_line,
                 )
             )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -800,16 +800,17 @@ def test_function_symbol_option(parser):
 
     assert len(parser.functions) == 3
     assert all(fun.name == "_strcmp" for fun in parser.functions)
-    assert parser.functions[0].use_linker is True
-    assert parser.functions[1].use_linker is True  # Lower-case is okay (for now)
-    assert parser.functions[2].use_linker is False  # Must be "symbol"
+    assert parser.functions[0].name_is_symbol is True
+    assert parser.functions[1].name_is_symbol is True  # Lower-case is okay (for now)
+    assert parser.functions[2].name_is_symbol is False  # Must be "symbol"
     assert len(parser.alerts) == 0
 
 
 def test_function_symbol_option_multiple(parser):
-    """If there are multiple markers for a name-based annotation, enable the use_linker option only
-    for the modules that have it. It doesn't really make sense to do things differently for different
-    modules but *shrug*. We already allow STUB and FUNCTIONs to be set for different modules.
+    """If there are multiple markers for a name-based annotation, name_is_symbol is true only
+    for the modules where the user specified SYMBOL.
+    I don't know if there's a reason to do things differently for different modules but *shrug*.
+    We already allow STUB and FUNCTION to be used on the same annotation.
     """
     parser.read(
         """\
@@ -821,9 +822,9 @@ def test_function_symbol_option_multiple(parser):
 
     assert len(parser.functions) == 2
     assert parser.functions[0].module == "HELLO"
-    assert parser.functions[0].use_linker is True
+    assert parser.functions[0].name_is_symbol is True
     assert parser.functions[1].module == "TEST"
-    assert parser.functions[1].use_linker is False
+    assert parser.functions[1].name_is_symbol is False
 
 
 def test_function_symbol_option_warning(parser):
@@ -836,5 +837,5 @@ def test_function_symbol_option_warning(parser):
     )
 
     assert len(parser.functions) == 1
-    assert parser.functions[0].use_linker is False
+    assert parser.functions[0].name_is_symbol is False
     assert parser.alerts[0].code == ParserError.SYMBOL_OPTION_IGNORED


### PR DESCRIPTION
Adds support for annotations like this:
```
// LIBRARY: TEST 0x1234 SYMBOL
// _exit
```
If `SYMBOL` is there (in any case) on a function annotation, we create the orig entity using `_exit` as the linker name (symbol) instead of the regular name. This will get matched to a recomp entity by its unique linker name.

This wasn't difficult to add because we already parse the (so called) extra field after the address for vtable multiple inheritance.

Note: for these annotations we only set the linker name and skip the regular name. If it doesn't get matched, you will see `<OFFSETX>` in the asm output because it has no name. (We could assume `name = value[1:]` and remove the leading underscore pretty easily.)

Thoughts on this approach?

Fixes #114 but only for functions.