### PR TITLE
Refactor cvdump `TYPES` parsing

### DIFF
--- a/reccmp/isledecomp/cvdump/runner.py
+++ b/reccmp/isledecomp/cvdump/runner.py
@@ -1,6 +1,8 @@
+import re
 import io
 from os import name as os_name
 from enum import Enum
+from typing import Iterable, Iterator
 import subprocess
 from reccmp.bin import lib_path_join
 from reccmp.isledecomp.dir import winepath_unix_to_win
@@ -26,6 +28,26 @@ cvdump_opt_map = {
     DumpOpt.MODULES: "-m",
     DumpOpt.TYPES: "-t",
 }
+
+
+def iter_cvdump_sections(stream: Iterable[str]) -> Iterator[tuple[str, str]]:
+    r_section = re.compile(r"\*{3} ([A-Z]{2,}.+)\n")
+    section = None
+    lines = []
+
+    for line in stream:
+        if line[0] == "*" and (match := r_section.match(line)) is not None:
+            if section is not None:
+                yield (section, "".join(lines))
+                lines.clear()
+
+            section = match.group(1)
+        else:
+            lines.append(line)
+
+    # Save the final section from stdout
+    if section is not None:
+        yield (section, "".join(lines))
 
 
 class Cvdump:
@@ -75,11 +97,8 @@ class Cvdump:
         call = self.cmd_line()
         with subprocess.Popen(call, stdout=subprocess.PIPE) as proc:
             assert proc.stdout is not None
-            for line in io.TextIOWrapper(
-                proc.stdout, encoding="utf-8", errors="ignore"
-            ):
-                # Blank lines are there to help the reader; they have no context significance
-                if line != "\n":
-                    parser.read_line(line)
+            wrap = io.TextIOWrapper(proc.stdout, encoding="utf-8", errors="ignore")
+            for name, section in iter_cvdump_sections(wrap):
+                parser.read_section(name, section)
 
         return parser

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -204,7 +204,7 @@ class CvdumpTypesParser:
     LF_ARGLIST_ENTRY = re.compile(r"list\[(?P<index>\d+)\] = (?P<arg_type>[?\w()]+)")
 
     LF_POINTER_RE = re.compile(
-        r"\s+(?P<type>.+\S) \(\w+\), Size: \d+\n\s+Element type : (?P<element_type>.+)"
+        r"\s+(?P<type>.+\S) \(\w+\), Size: \d+\n\s+Element type : (?P<element_type>[^\n,]+)[\n,]"
     )
 
     LF_PROCEDURE_RE = re.compile(
@@ -639,6 +639,8 @@ class CvdumpTypesParser:
             "L-value Reference",
             "volatile Pointer",
             "volatile const Pointer",
+            "Pointer to member",
+            "Pointer to member function",
         )
 
         return {"element_type": match.group("element_type")}

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -158,83 +158,70 @@ class CvdumpTypesParser:
     # Marks the start of a new type
     INDEX_RE = re.compile(r"(?P<key>0x\w+) : .* (?P<type>LF_\w+)")
 
-    # LF_FIELDLIST class/struct member (1/2)
+    # LF_FIELDLIST class/struct member
     LIST_RE = re.compile(
-        r"\s+list\[\d+\] = LF_MEMBER, (?P<scope>\w+), type = (?P<type>.*), offset = (?P<offset>\d+)"
+        r"list\[\d+\] = LF_MEMBER, (?P<scope>\w+), type = (?P<type>[^,]*), offset = (?P<offset>\d+)\s+member name = '(?P<name>[^']*)'"
     )
 
     # LF_FIELDLIST vtable indicator
-    VTABLE_RE = re.compile(r"^\s+list\[\d+\] = LF_VFUNCTAB")
+    VTABLE_RE = re.compile(r"list\[\d+\] = LF_VFUNCTAB")
 
     # LF_FIELDLIST superclass indicator
     SUPERCLASS_RE = re.compile(
-        r"^\s+list\[\d+\] = LF_BCLASS, (?P<scope>\w+), type = (?P<type>.*), offset = (?P<offset>\d+)"
+        r"list\[\d+\] = LF_BCLASS, (?P<scope>\w+), type = (?P<type>.*), offset = (?P<offset>\d+)"
     )
 
-    # LF_FIELDLIST virtual direct/indirect base pointer, line 1/2
+    # LF_FIELDLIST virtual direct/indirect base pointer
     VBCLASS_RE = re.compile(
-        r"^\s+list\[\d+\] = LF_(?P<indirect>I?)VBCLASS, .* base type = (?P<type>.*)$"
+        r"list\[\d+\] = LF_(?P<indirect>I?)VBCLASS, .* base type = (?P<type>.*)\n\s+virtual base ptr = .+, vbpoff = (?P<vboffset>\d+), vbind = (?P<vbindex>\d+)"
     )
-
-    # LF_FIELDLIST virtual direct/indirect base pointer, line 2/2
-    VBCLASS_LINE_2_RE = re.compile(
-        r"^\s+virtual base ptr = .+, vbpoff = (?P<vboffset>\d+), vbind = (?P<vbindex>\d+)$"
-    )
-
-    # LF_FIELDLIST member name (2/2)
-    MEMBER_RE = re.compile(r"^\s+member name = '(?P<name>.*)'$")
 
     LF_FIELDLIST_ENUMERATE = re.compile(
-        r"^\s+list\[\d+\] = LF_ENUMERATE,.*value = (?P<value>\d+), name = '(?P<name>[^']+)'$"
+        r"list\[\d+\] = LF_ENUMERATE,.*value = (?P<value>\d+), name = '(?P<name>[^']+)'"
     )
 
-    # LF_ARRAY element type
-    ARRAY_ELEMENT_RE = re.compile(r"^\s+Element type = (?P<type>.*)")
-
-    # LF_ARRAY total array size
-    ARRAY_LENGTH_RE = re.compile(
-        r"^\s+length = (?P<number_type>\([\w_]+\) )?(?P<length>\d+)"
+    LF_ARRAY_RE = re.compile(
+        r"\s+Element type = (?P<type>[^\n]+)\n\s+Index type = [^\n]+\n\s+length = (?:[\w()]+ )?(?P<length>\d+)\n"
     )
 
     # LF_CLASS/LF_STRUCTURE field list reference
     CLASS_FIELD_RE = re.compile(
-        r"^\s+# members = \d+,  field list type (?P<field_type>0x\w+),"
+        r"\s+# members = \d+,  field list type (?P<field_type>0x\w+),"
     )
 
     # LF_CLASS/LF_STRUCTURE name and other info
     CLASS_NAME_RE = re.compile(
-        r"^\s+Size = (?P<size>\d+), class name = (?P<name>(?:[^,]|,\S)+)(?:, unique name = [^,]+)?(?:, UDT\((?P<udt>0x\w+)\))?"
+        r"\s+Size = (?P<size>\d+), class name = (?P<name>(?:[^\n,]|,\S)+)(?:, unique name = [^\n,]+)?(?:, UDT\((?P<udt>0x\w+)\))?"
     )
 
     # LF_MODIFIER, type being modified
-    MODIFIES_RE = re.compile(r".*modifies type (?P<type>.*)$")
+    MODIFIES_RE = re.compile(r"\s+modifies type (?P<type>.*)")
 
     # LF_ARGLIST number of entries
-    LF_ARGLIST_ARGCOUNT = re.compile(r".*argument count = (?P<argcount>\d+)$")
+    LF_ARGLIST_ARGCOUNT = re.compile(r".*argument count = (?P<argcount>\d+)")
 
     # LF_ARGLIST list entry
-    LF_ARGLIST_ENTRY = re.compile(
-        r"^\s+list\[(?P<index>\d+)\] = (?P<arg_type>[?\w()]+)$"
+    LF_ARGLIST_ENTRY = re.compile(r"list\[(?P<index>\d+)\] = (?P<arg_type>[?\w()]+)")
+
+    LF_POINTER_RE = re.compile(
+        r"\s+(?P<type>.+\S) \(\w+\), Size: \d+\n\s+Element type : (?P<element_type>.+)"
     )
 
-    # LF_POINTER element
-    LF_POINTER_ELEMENT = re.compile(r"^\s+Element type : (?P<element_type>.+)$")
+    LF_PROCEDURE_RE = re.compile(
+        (
+            r"\s+Return type = (?P<return_type>[^,]+), Call type = (?P<call_type>[^\n]+)\n"
+            r"\s+Func attr = (?P<func_attr>[^\n]+)\n"
+            r"\s+# Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+)"
+        )
+    )
 
-    # LF_MFUNCTION attribute key-value pairs
-    LF_MFUNCTION_ATTRIBUTES = [
-        re.compile(r"\s*Return type = (?P<return_type>[^,]+)$"),
-        re.compile(r"\s*Class type = (?P<class_type>[\w()]+)$"),
-        re.compile(r"\s*This type = (?P<this_type>[\w()]+)$"),
-        # Call type may contain whitespace
-        re.compile(r"\s*Call type = (?P<call_type>[\w()\s]+)$"),
-        re.compile(r"\s*Parms = (?P<num_params>[\w()]+)$"),  # LF_MFUNCTION only
-        re.compile(r"\s*# Parms = (?P<num_params>[\w()]+)$"),  # LF_PROCEDURE only
-        re.compile(r"\s*Arg list type = (?P<arg_list_type>[\w()]+)$"),
-        re.compile(
-            r"\s*This adjust = (?P<this_adjust>[\w()]+)$"
-        ),  # By how much the incoming pointers are shifted in virtual inheritance; hex value without `0x` prefix
-        re.compile(r"\s*Func attr = (?P<func_attr>.+)$"),
-    ]
+    LF_MFUNCTION_RE = re.compile(
+        (
+            r"\s+Return type = (?P<return_type>[^,]+), Class type = (?P<class_type>[^,]+), This type = (?P<this_type>[^,]+),\s*\n"
+            r"\s+Call type = (?P<call_type>[^,]+), Func attr = (?P<func_attr>[^\n]+)\n"
+            r"\s+Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+), This adjust = (?P<this_adjust>[0-9a-f]+)"
+        )
+    )
 
     LF_ENUM_ATTRIBUTES = [
         re.compile(r"^\s*# members = (?P<num_members>\d+)$"),
@@ -245,7 +232,7 @@ class CvdumpTypesParser:
     )
     LF_ENUM_UDT = re.compile(r"^\s*UDT\((?P<udt>0x\w+)\)$")
     LF_UNION_LINE = re.compile(
-        r"^.*field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^,]|,\S)+)(?:, unique name = [^,]+)?(?:,\s.*UDT\((?P<udt>0x\w+)\))?$"
+        r"\s+field list type (?P<field_type>0x\w+),.*Size = (?P<size>\d+)\s*,class name = (?P<name>(?:[^\n,]|,\S)+)(?:, unique name = [^\n,]+)?(?:,\s.*UDT\((?P<udt>0x\w+)\))?"
     )
 
     MODES_OF_INTEREST = {
@@ -264,36 +251,7 @@ class CvdumpTypesParser:
 
     def __init__(self) -> None:
         self.mode: str | None = None
-        self.last_key = ""
         self.keys: dict[str, dict[str, Any]] = {}
-
-    def _new_type(self):
-        """Prepare a new dict for the type we just parsed.
-        The id is self.last_key and the "type" of type is self.mode.
-        e.g. LF_CLASS"""
-        self.keys[self.last_key] = {"type": self.mode}
-
-    def _set(self, key: str, value):
-        self.keys[self.last_key][key] = value
-
-    def _add_member(self, offset: int, type_: str):
-        obj = self.keys[self.last_key]
-        if "members" not in obj:
-            obj["members"] = []
-
-        obj["members"].append({"offset": offset, "type": type_})
-
-    def _set_member_name(self, name: str):
-        """Set name for most recently added member."""
-        obj = self.keys[self.last_key]
-        obj["members"][-1]["name"] = name
-
-    def _add_variant(self, name: str, value: int):
-        obj = self.keys[self.last_key]
-        if "variants" not in obj:
-            obj["variants"] = []
-        variants: list[dict[str, Any]] = obj["variants"]
-        variants.append({"name": name, "value": value})
 
     def _get_field_list(self, type_obj: dict[str, Any]) -> list[FieldListItem]:
         """Return the field list for the given LF_CLASS/LF_STRUCTURE reference"""
@@ -475,91 +433,99 @@ class CvdumpTypesParser:
         members = self.get_scalars_gapless(type_key)
         return member_list_to_struct_string(members)
 
-    def read_line(self, line: str):
-        if line.endswith("\n"):
-            line = line[:-1]
-        if len(line) == 0:
-            return
+    def read_all(self, section: str):
+        r_leafsplit = re.compile(r"\n(?=0x\w{4} : )")
+        for leaf in r_leafsplit.split(section):
+            if (match := self.INDEX_RE.match(leaf)) is None:
+                continue
 
-        if (match := self.INDEX_RE.match(line)) is not None:
-            type_ = match.group(2)
-            if type_ not in self.MODES_OF_INTEREST:
+            (leaf_id, leaf_type) = match.groups()
+            if leaf_type not in self.MODES_OF_INTEREST:
                 self.mode = None
-                return
+                continue
 
-            # Don't need to normalize, it's already in the format we want
-            self.last_key = match.group(1)
-            self.mode = type_
-            self._new_type()
+            # Add the leaf to our dictionary and add details specific to the leaf type.
+            self.mode = leaf_type
+            self.keys[leaf_id] = {"type": leaf_type}
 
-            if type_ == "LF_ARGLIST":
-                submatch = self.LF_ARGLIST_ARGCOUNT.match(line)
-                assert submatch is not None
-                self.keys[self.last_key]["argcount"] = int(submatch.group("argcount"))
-                # TODO: This should be validated in another pass
-            return
+            this_key = self.keys[leaf_id]
 
-        if self.mode is None:
-            return
+            try:
+                if self.mode == "LF_MODIFIER":
+                    this_key.update(self.read_modifier(leaf))
 
-        if self.mode == "LF_MODIFIER":
-            if (match := self.MODIFIES_RE.match(line)) is not None:
-                # For convenience, because this is essentially the same thing
-                # as an LF_CLASS forward ref.
-                self._set("is_forward_ref", True)
-                self._set("modifies", normalize_type_id(match.group("type")))
+                elif self.mode == "LF_ARRAY":
+                    this_key.update(self.read_array(leaf))
 
-        elif self.mode == "LF_ARRAY":
-            if (match := self.ARRAY_ELEMENT_RE.match(line)) is not None:
-                self._set("array_type", normalize_type_id(match.group("type")))
+                elif self.mode == "LF_FIELDLIST":
+                    this_key.update(self.read_fieldlist(leaf))
 
-            elif (match := self.ARRAY_LENGTH_RE.match(line)) is not None:
-                self._set("size", int(match.group("length")))
+                elif self.mode == "LF_ARGLIST":
+                    this_key.update(self.read_arglist(leaf))
 
-        elif self.mode == "LF_FIELDLIST":
-            self.read_fieldlist_line(line)
+                elif self.mode == "LF_MFUNCTION":
+                    this_key.update(self.read_mfunction(leaf))
 
-        elif self.mode == "LF_ARGLIST":
-            self.read_arglist_line(line)
+                elif self.mode == "LF_PROCEDURE":
+                    this_key.update(self.read_procedure(leaf))
 
-        elif self.mode in ["LF_MFUNCTION", "LF_PROCEDURE"]:
-            self.read_mfunction_line(line)
+                elif self.mode in ["LF_CLASS", "LF_STRUCTURE"]:
+                    this_key.update(self.read_class_or_struct(leaf))
 
-        elif self.mode in ["LF_CLASS", "LF_STRUCTURE"]:
-            self.read_class_or_struct_line(line)
+                elif self.mode == "LF_POINTER":
+                    this_key.update(self.read_pointer(leaf))
 
-        elif self.mode == "LF_POINTER":
-            self.read_pointer_line(line)
+                elif self.mode == "LF_ENUM":
+                    this_key.update(self.read_enum(leaf))
 
-        elif self.mode == "LF_ENUM":
-            self.read_enum_line(line)
+                elif self.mode == "LF_UNION":
+                    this_key.update(self.read_union(leaf))
+                else:
+                    # Check for exhaustiveness
+                    logger.error("Unhandled data in mode: %s", self.mode)
 
-        elif self.mode == "LF_UNION":
-            self.read_union_line(line)
+            except AssertionError:
+                logger.error("Failed to parse PDB types leaf:\n%s", leaf)
 
-        else:
-            # Check for exhaustiveness
-            logger.error("Unhandled data in mode: %s", self.mode)
+    def read_modifier(self, leaf: str) -> dict[str, Any]:
+        match = self.MODIFIES_RE.search(leaf)
+        assert match is not None
 
-    def read_fieldlist_line(self, line: str):
+        # For convenience, because this is essentially the same thing
+        # as an LF_CLASS forward ref.
+        return {
+            "is_forward_ref": True,
+            "modifies": normalize_type_id(match.group("type")),
+        }
+
+    def read_array(self, leaf: str) -> dict[str, Any]:
+        match = self.LF_ARRAY_RE.search(leaf)
+        assert match is not None
+
+        return {
+            "array_type": normalize_type_id(match.group("type")),
+            "size": int(match.group("length")),
+        }
+
+    def read_fieldlist(self, leaf: str) -> dict[str, Any]:
+        obj: dict[str, Any] = {}
+        members = []
+
         # If this class has a vtable, create a mock member at offset 0
-        if (match := self.VTABLE_RE.match(line)) is not None:
+        if self.VTABLE_RE.search(leaf) is not None:
             # For our purposes, any pointer type will do
-            self._add_member(0, "T_32PVOID")
-            self._set_member_name("vftable")
+            members.append({"offset": 0, "type": "T_32PVOID", "name": "vftable"})
 
         # Superclass is set here in the fieldlist rather than in LF_CLASS
-        elif (match := self.SUPERCLASS_RE.match(line)) is not None:
-            superclass_list: dict[str, int] = self.keys[self.last_key].setdefault(
-                "super", {}
-            )
+        for match in self.SUPERCLASS_RE.finditer(leaf):
+            superclass_list: dict[str, int] = obj.setdefault("super", {})
             superclass_list[normalize_type_id(match.group("type"))] = int(
                 match.group("offset")
             )
 
         # virtual base class (direct or indirect)
-        elif (match := self.VBCLASS_RE.match(line)) is not None:
-            virtual_base_pointer = self.keys[self.last_key].setdefault(
+        for match in self.VBCLASS_RE.finditer(leaf):
+            virtual_base_pointer = obj.setdefault(
                 "vbase",
                 VirtualBasePointer(
                     vboffset=-1,  # default to -1 until we parse the correct value
@@ -578,11 +544,6 @@ class CvdumpTypesParser:
                 )
             )
 
-        elif (match := self.VBCLASS_LINE_2_RE.match(line)) is not None:
-            virtual_base_pointer = self.keys[self.last_key].get("vbase", None)
-            assert isinstance(
-                virtual_base_pointer, VirtualBasePointer
-            ), "Parsed the second line of an (I)VBCLASS without the first one"
             vboffset = int(match.group("vboffset"))
 
             if virtual_base_pointer.vboffset == -1:
@@ -602,114 +563,114 @@ class CvdumpTypesParser:
             # these come out of order, and the lists are so short that it's fine to sort them every time
             virtual_base_pointer.bases.sort(key=lambda x: x.index)
 
-        # Member offset and type given on the first of two lines.
-        elif (match := self.LIST_RE.match(line)) is not None:
-            self._add_member(
-                int(match.group("offset")), normalize_type_id(match.group("type"))
-            )
+        members += [
+            {
+                "offset": int(offset),
+                "type": normalize_type_id(type_),
+                "name": name,
+            }
+            for (_, type_, offset, name) in self.LIST_RE.findall(leaf)
+        ]
 
-        # Name of the member read on the second of two lines.
-        elif (match := self.MEMBER_RE.match(line)) is not None:
-            self._set_member_name(match.group("name"))
+        if members:
+            obj["members"] = members
 
-        elif (match := self.LF_FIELDLIST_ENUMERATE.match(line)) is not None:
-            self._add_variant(match.group("name"), int(match.group("value")))
+        variants = [
+            {"name": name, "value": int(value)}
+            for value, name in self.LF_FIELDLIST_ENUMERATE.findall(leaf)
+        ]
+        if variants:
+            obj["variants"] = variants
 
-    def read_class_or_struct_line(self, line: str):
+        return obj
+
+    def read_class_or_struct(self, leaf: str) -> dict[str, Any]:
+        obj: dict[str, Any] = {}
         # Match the reference to the associated LF_FIELDLIST
-        if (match := self.CLASS_FIELD_RE.match(line)) is not None:
-            if match.group("field_type") == "0x0000":
-                # Not redundant. UDT might not match the key.
-                # These cases get reported as UDT mismatch.
-                self._set("is_forward_ref", True)
-            else:
-                field_list_type = normalize_type_id(match.group("field_type"))
-                self._set("field_list_type", field_list_type)
-
-        elif line.lstrip().startswith("Derivation list type"):
-            # We do not care about the second line, but we still match it so we see an error
-            # when another line fails to match
-            pass
-        elif (match := self.CLASS_NAME_RE.match(line)) is not None:
-            # Last line has the vital information.
-            # If this is a FORWARD REF, we need to follow the UDT pointer
-            # to get the actual class details.
-            self._set("name", match.group("name"))
-            udt = match.group("udt")
-            if udt is not None:
-                self._set("udt", normalize_type_id(udt))
-            self._set("size", int(match.group("size")))
+        match = self.CLASS_FIELD_RE.search(leaf)
+        assert match is not None
+        if match.group("field_type") == "0x0000":
+            # Not redundant. UDT might not match the key.
+            # These cases get reported as UDT mismatch.
+            obj["is_forward_ref"] = True
         else:
-            logger.error("Unmatched line in class: %s", line[:-1])
+            field_list_type = normalize_type_id(match.group("field_type"))
+            obj["field_list_type"] = field_list_type
 
-    def read_arglist_line(self, line: str):
-        if (match := self.LF_ARGLIST_ENTRY.match(line)) is not None:
-            obj = self.keys[self.last_key]
-            arglist: list = obj.setdefault("args", [])
-            assert int(match.group("index")) == len(
-                arglist
-            ), "Argument list out of sync"
-            arglist.append(match.group("arg_type"))
-        else:
-            logger.error("Unmatched line in arglist: %s", line[:-1])
+        match = self.CLASS_NAME_RE.search(leaf)
+        assert match is not None
+        # Last line has the vital information.
+        # If this is a FORWARD REF, we need to follow the UDT pointer
+        # to get the actual class details.
+        obj["name"] = match.group("name")
+        udt = match.group("udt")
+        if udt is not None:
+            obj["udt"] = normalize_type_id(udt)
 
-    def read_pointer_line(self, line: str):
-        if (match := self.LF_POINTER_ELEMENT.match(line)) is not None:
-            self._set("element_type", match.group("element_type"))
-        else:
-            stripped_line = line.strip()
-            # We don't parse these lines, but we still want to check for exhaustiveness
-            # in case we missed some relevant data
-            if not any(
-                stripped_line.startswith(prefix)
-                for prefix in [
-                    "R-value Reference",
-                    "Pointer",
-                    "const Pointer",
-                    "L-value",
-                    "volatile",
-                ]
-            ):
-                logger.error("Unrecognized pointer attribute: %s", line[:-1])
+        obj["size"] = int(match.group("size"))
 
-    def read_mfunction_line(self, line: str):
-        """
-        The layout is not consistent, so we want to be as robust as possible here.
-        - Example 1:
-            Return type = T_LONG(0012), Call type = C Near
-            Func attr = none
-        - Example 2:
-                Return type = T_CHAR(0010), Class type = 0x101A, This type = 0x101B,
-            Call type = ThisCall, Func attr = none
-        """
+        return obj
 
-        obj = self.keys[self.last_key]
+    def read_arglist(self, leaf: str) -> dict[str, Any]:
+        match = self.LF_ARGLIST_ARGCOUNT.match(leaf)
+        assert match is not None
+        argcount = int(match.group("argcount"))
 
-        key_value_pairs = line.split(",")
-        for pair in key_value_pairs:
-            if pair.isspace():
+        arglist = [arg_type for (_, arg_type) in self.LF_ARGLIST_ENTRY.findall(leaf)]
+        assert len(arglist) == argcount
+
+        obj: dict[str, Any] = {"argcount": argcount}
+        # Set the arglist only when argcount > 0
+        if arglist:
+            obj["args"] = arglist
+
+        return obj
+
+    def read_pointer(self, leaf: str) -> dict[str, Any]:
+        match = self.LF_POINTER_RE.search(leaf)
+        assert match is not None
+
+        # We don't use the pointer type, but we still want to check for exhaustiveness
+        # in case we missed some relevant data
+        assert match.group("type") in (
+            "R-value Reference",
+            "Pointer",
+            "const Pointer",
+            "L-value Reference",
+            "volatile Pointer",
+            "volatile const Pointer",
+        )
+
+        return {"element_type": match.group("element_type")}
+
+    def read_mfunction(self, leaf: str) -> dict[str, Any]:
+        match = self.LF_MFUNCTION_RE.search(leaf)
+        assert match is not None
+        return match.groupdict()
+
+    def read_procedure(self, leaf: str) -> dict[str, Any]:
+        match = self.LF_PROCEDURE_RE.search(leaf)
+        assert match is not None
+        return match.groupdict()
+
+    def read_enum(self, leaf: str) -> dict[str, Any]:
+        obj: dict[str, Any] = {}
+
+        # TODO: still parsing each line for now
+        for line in leaf.splitlines()[1:]:
+            if not line:
                 continue
-            obj |= self.parse_function_attribute(pair)
+            # We need special comma handling because commas may appear in the name.
+            # Splitting by "," yields the wrong result.
+            enum_attributes = line.split(", ")
+            for pair in enum_attributes:
+                if pair.endswith(","):
+                    pair = pair[:-1]
+                if pair.isspace():
+                    continue
+                obj |= self.parse_enum_attribute(pair)
 
-    def parse_function_attribute(self, pair: str) -> dict[str, str]:
-        for attribute_regex in self.LF_MFUNCTION_ATTRIBUTES:
-            if (match := attribute_regex.match(pair)) is not None:
-                return match.groupdict()
-        logger.error("Unknown attribute in function: %s", pair)
-        return {}
-
-    def read_enum_line(self, line: str):
-        obj = self.keys[self.last_key]
-
-        # We need special comma handling because commas may appear in the name.
-        # Splitting by "," yields the wrong result.
-        enum_attributes = line.split(", ")
-        for pair in enum_attributes:
-            if pair.endswith(","):
-                pair = pair[:-1]
-            if pair.isspace():
-                continue
-            obj |= self.parse_enum_attribute(pair)
+        return obj
 
     def parse_enum_attribute(self, attribute: str) -> dict[str, Any]:
         for attribute_regex in self.LF_ENUM_ATTRIBUTES:
@@ -730,15 +691,19 @@ class CvdumpTypesParser:
         logger.error("Unknown attribute in enum: %s", attribute)
         return {}
 
-    def read_union_line(self, line: str):
+    def read_union(self, leaf: str) -> dict[str, Any]:
         """This is a rather barebones handler, only parsing the size"""
-        if (match := self.LF_UNION_LINE.match(line)) is None:
-            raise AssertionError(f"Unhandled in union: {line}")
-        self._set("name", match.group("name"))
-        if match.group("field_type") == "0x0000":
-            self._set("is_forward_ref", True)
+        match = self.LF_UNION_LINE.search(leaf)
+        assert match is not None
 
-        self._set("field_list_type", match.group("field_type"))
-        self._set("size", int(match.group("size")))
+        obj: dict[str, Any] = {"name": match.group("name")}
+
+        if match.group("field_type") == "0x0000":
+            obj["is_forward_ref"] = True
+
+        obj["field_list_type"] = match.group("field_type")
+        obj["size"] = int(match.group("size"))
         if match.group("udt") is not None:
-            self._set("udt", normalize_type_id(match.group("udt")))
+            obj["udt"] = normalize_type_id(match.group("udt"))
+
+        return obj

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -825,3 +825,17 @@ def test_two_formats_for_array_length(empty_parser: CvdumpTypesParser):
 
     assert empty_parser.keys["0x62c1"]["size"] == 50
     assert empty_parser.keys["0x62c5"]["size"] == 131328
+
+
+LF_POINTER_TO_MEMBER = """
+0x1646 : Length = 18, Leaf = 0x1002 LF_POINTER
+    Pointer to member function (NEAR32), Size: 0
+    Element type : 0x1645, Containing class = 0x12BD,
+    Type of pointer to member = Not specified
+"""
+
+
+def test_pointer_to_member(empty_parser: CvdumpTypesParser):
+    """LF_POINTER with optional 'Containing class' attribute."""
+    empty_parser.read_all(LF_POINTER_TO_MEMBER)
+    assert empty_parser.keys["0x1646"]["element_type"] == "0x1645"

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -359,8 +359,7 @@ NESTED,     enum name = JukeBox::JukeBoxScript, UDT(0x00003cc2)
 @pytest.fixture(name="parser")
 def types_parser_fixture():
     parser = CvdumpTypesParser()
-    for line in TEST_LINES.split("\n"):
-        parser.read_line(line)
+    parser.read_all(TEST_LINES)
 
     return parser
 
@@ -702,8 +701,7 @@ UNNAMED_UNION_DATA = """
 
 def test_unnamed_union(empty_parser: CvdumpTypesParser):
     """Make sure we can parse anonymous union types without a UDT"""
-    for line in UNNAMED_UNION_DATA.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(UNNAMED_UNION_DATA)
 
     # Make sure we can parse the members line
     union = empty_parser.keys["0x369e"]
@@ -725,8 +723,7 @@ ARGLIST_UNKNOWN_TYPE = """
 
 def test_arglist_unknown_type(empty_parser: CvdumpTypesParser):
     """Should parse the ??? types and not fail with an assert."""
-    for line in ARGLIST_UNKNOWN_TYPE.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(ARGLIST_UNKNOWN_TYPE)
 
     t = empty_parser.keys["0x11f3"]
     assert len(t["args"]) == t["argcount"]
@@ -752,8 +749,7 @@ FUNC_ATTR_EXAMPLES = """
 
 def test_mfunction_func_attr(empty_parser: CvdumpTypesParser):
     """Should parse "Func attr" values other than 'none'"""
-    for line in FUNC_ATTR_EXAMPLES.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(FUNC_ATTR_EXAMPLES)
 
     assert empty_parser.keys["0x1216"]["func_attr"] == "return UDT (C++ style)"
     assert empty_parser.keys["0x122b"]["func_attr"] == "instance constructor"
@@ -771,8 +767,7 @@ UNION_UNNAMED_TAG = """
 
 def test_union_without_udt(empty_parser: CvdumpTypesParser):
     """Should parse union that is missing the UDT attribute"""
-    for line in UNION_UNNAMED_TAG.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(UNION_UNNAMED_TAG)
 
     assert "udt" not in empty_parser.keys["0x3352"]
     assert empty_parser.keys["0x3352"]["name"] == "<unnamed-tag>"
@@ -788,8 +783,7 @@ MFUNCTION_UNK_RETURN_TYPE = """
 
 def test_mfunction_unk_return_type(empty_parser: CvdumpTypesParser):
     """Should parse unknown return type as-is"""
-    for line in MFUNCTION_UNK_RETURN_TYPE.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(MFUNCTION_UNK_RETURN_TYPE)
 
     assert empty_parser.keys["0x11d8"]["return_type"] == "???(047C)"
 
@@ -805,8 +799,7 @@ CLASS_WITH_UNIQUE_NAME = """
 
 def test_class_unique_name(empty_parser: CvdumpTypesParser):
     """Make sure we can parse the UDT when the 'unique name' attribute is present"""
-    for line in CLASS_WITH_UNIQUE_NAME.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(CLASS_WITH_UNIQUE_NAME)
 
     assert empty_parser.keys["0x1cf0"]["udt"] == "0x1cf0"
 
@@ -828,8 +821,7 @@ TWO_FORMATS_FOR_ARRAY_LENGTH = """
 
 def test_two_formats_for_array_length(empty_parser: CvdumpTypesParser):
     """Make sure we can parse the UDT when the 'unique name' attribute is present"""
-    for line in TWO_FORMATS_FOR_ARRAY_LENGTH.split("\n"):
-        empty_parser.read_line(line)
+    empty_parser.read_all(TWO_FORMATS_FOR_ARRAY_LENGTH)
 
     assert empty_parser.keys["0x62c1"]["size"] == 50
     assert empty_parser.keys["0x62c5"]["size"] == 131328


### PR DESCRIPTION
The output from cvdump looks like this:

```
*** MODULES

0001 "RelWithDebInfo\LEGO1.exp"
0002 "CMakeFiles\lego1.dir\RelWithDebInfo\LEGO1\define.cpp.obj"
(...)

*** PUBLICS

S_PUB32: [0001:000AA3F0], Flags: 00000000, ??1MxFrequencyMeter@@QAE@XZ
S_PUB32: [0001:00049DA0], Flags: 00000000, ??_ELegoEndAnimNotificationParam@@UAEPAXI@Z
(...)
```

Each section begins on its own line with three asterisks and the section name.[^1]

Until now we've parsed this entire text one line at a time, which requires a state machine to keep track of where we are. The `TYPES` section has its own state machine to parse each type leaf. For example:

```
0x10b4 : Length = 34, Leaf = 0x1504 LF_CLASS
    # members = 55,  field list type 0x10b2, CONSTRUCTOR, OVERLOAD, 
    Derivation list type 0x0000, VT shape type 0x10b3
    Size = 148, class name = MxDSAction, UDT(0x00006529)

0x10b5 : Length = 30, Leaf = 0x1504 LF_CLASS
    # members = 0,  field list type 0x0000, FORWARD REF, 
    Derivation list type 0x0000, VT shape type 0x0000
    Size = 0, class name = MxParam, UDT(0x00002bed)
```

To eliminate most of the state variables in `CvdumpTypesParser`, I changed the code in `runner.py` to load an entire cvdump section at a time. This required changing most of the regular expressions so we could match in the middle of the text (with `re.search()`) instead of clamping to the start of each line. In cases where we had to match one line first, then a second, I combined the two regular expression to match both items.

Microsoft has made some[^2] of the code for cvdump available. If we look at [cvinfo.h](https://github.com/microsoft/microsoft-pdb/blob/master/include/cvinfo.h) we can see what data is there for each kind of type leaf. For example:

```cpp
typedef struct lfEnum_16t {
    unsigned short  leaf;           // LF_ENUM_16t
    unsigned short  count;          // count of number of elements in class
    CV_typ16_t      utype;          // underlying type of the enum
    CV_typ16_t      field;          // type index of LF_FIELD descriptor list
    CV_prop_t       property;       // property attribute field
    unsigned char   Name[1];        // length prefixed name of enum
} lfEnum_16t;
```

Not that aren't still surprises to be found, but I think we can be a bit more confident in how we parse the leaves by anticipating which items _could_ appear. For example: the similar layouts for `LF_MFUNCTION` and `LF_PROCEDURE`.

If one of our regular expressions doesn't match, we now raise an assert error. This is caught by the `except` trap so we continue parsing but dump the leaf contents using the `logger`. This should make it easier to react to new parsing issues as they come up.

As for performance: it is better if you read the input from a file -- i.e. eliminating the `subprocess` overhead. On non-Windows platforms where we need to use `wine`, it is about 20%[^3] slower. I'm not really sure why: None of the profiling I've done can point to the bottleneck. Waiting for a buffer to get filled maybe?

The benefit for doing this is that the code is a lot simpler to reason about, and we are now separating type parsing from managing the type database (#106). I dumped the output of `cvdump.types.keys` and we get the same data before and after for both `LEGO1` and `BETA10`. We are still using the original unit tests for the `TYPES` section but we could start to break this out into leaf-specific items in later updates.

Code to dump the finished type database for testing/comparison:
```python
def dump(pdbfile):
    cv = (
        Cvdump(pdbfile)
        .lines()
        .globals()
        .publics()
        .symbols()
        .section_contributions()
        .types()
        .run()
    )

    for key, value in cv.types.keys.items():
        print(key, value)

```


[^1]: We must be careful when parsing `TYPES` to not start a new section on the line `*** Converting 16-bit types to 32-bit equivalents`.
[^2]: The file `type7.cpp` is blank.
[^3]: This sounds worse than it is. On my M3 Macbook it is 200ms slower.