### PR TITLE
Improve output for ambiguous matches

### DIFF
--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -141,14 +141,17 @@ def match_functions(
                 # If this name was ever matched non-uniquely
                 if name in non_unique_names:
                     matched_symbol = recomp_symbols.get(recomp_addr, "None")
-                    other_symbols = [recomp_symbols.get(recomp_addr, "None") for recomp_addr in name_index.get(name)]
+                    other_symbols = [
+                        recomp_symbols.get(recomp_addr, "None")
+                        for recomp_addr in name_index.get(name)
+                    ]
                     report(
                         ReccmpEvent.AMBIGUOUS_MATCH,
                         orig_addr,
-                        msg=f"Ambiguous match 0x{orig_addr:x} on name '{name}' to\n" +
-                        f"'{matched_symbol}'\n" +
-                        "Other candidates:\n" +
-                        f"{",\n".join(f"'{candidate}'" for candidate in other_symbols)}",
+                        msg=f"Ambiguous match 0x{orig_addr:x} on name '{name}' to\n"
+                        + f"'{matched_symbol}'\n"
+                        + "Other candidates:\n"
+                        + ",\n".join(f"'{candidate}'" for candidate in other_symbols),
                     )
 
                 batch.match(orig_addr, recomp_addr)

--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -22,6 +22,9 @@ class EntityIndex:
     def add(self, key: str, value: int):
         self._dict.setdefault(key, []).append(value)
 
+    def get(self, key: str) -> list[int]:
+        return self._dict.get(key, [])
+
     def count(self, key: str) -> int:
         return len(self._dict.get(key, []))
 
@@ -137,11 +140,15 @@ def match_functions(
 
                 # If this name was ever matched non-uniquely
                 if name in non_unique_names:
-                    symbol = recomp_symbols.get(recomp_addr, "None")
+                    matched_symbol = recomp_symbols.get(recomp_addr, "None")
+                    other_symbols = [recomp_symbols.get(recomp_addr, "None") for recomp_addr in name_index.get(name)]
                     report(
                         ReccmpEvent.AMBIGUOUS_MATCH,
                         orig_addr,
-                        msg=f"Ambiguous match 0x{orig_addr:x} on name '{name}' to '{symbol}'",
+                        msg=f"Ambiguous match 0x{orig_addr:x} on name '{name}' to\n" +
+                        f"'{matched_symbol}'\n" +
+                        "Other candidates:\n" +
+                        f"{",\n".join(f"'{candidate}'" for candidate in other_symbols)}",
                     )
 
                 batch.match(orig_addr, recomp_addr)


### PR DESCRIPTION
Small improvement for the log output in case of ambiguous matches. New example output:
```
[WARNING] Ambiguous match 0x10021dc0 on name 'Set<LegoPathActor *,LegoPathActorSetCompare>::Set<LegoPathActor *,LegoPathActorSetCompare>' to
'??0?$Set@PAVLegoPathActor@@ULegoPathActorSetCompare@@@@QAE@ABV0@@Z'
Other candidates:
'??0?$Set@PAVLegoPathActor@@ULegoPathActorSetCompare@@@@QAE@ABULegoPathActorSetCompare@@@Z'
```
This makes it much less tedious to fix these issues.