### PR TITLE
Improve `pathlib` usage in `test_lines.py`

### DIFF
--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -1,64 +1,83 @@
 """Testing lines database: mapping between (filename, line_number) to virtual address."""
 
-from pathlib import PurePath, PurePosixPath, PureWindowsPath
+from pathlib import PurePosixPath, PureWindowsPath
+import pytest
 from reccmp.isledecomp.compare.lines import LinesDb
 
-TEST_PATH = PurePath("test.cpp")
+# For tests that don't require path conversion, parametrize the
+# input local_path so that we test both Windows and Posix paths.
+PDB_PATH = PureWindowsPath("code\\test.cpp")
+LOCAL_PATHS = (
+    PureWindowsPath("code\\test.cpp"),
+    PurePosixPath("code/test.cpp"),
+)
 
 
-def test_lines():
-    """Basic demonstration of behavior"""
-    lines = LinesDb([TEST_PATH])
+def test_sample_path_variables():
+    """Verify PDB_PATH and LOCAL_PATHS sample values.
+    Each local path should resolve to the PDB path."""
+    assert PDB_PATH.parts == LOCAL_PATHS[0].parts
+    assert PDB_PATH.parts == LOCAL_PATHS[1].parts
 
-    # We haven't added any addresses yet.
-    assert lines.find_function(TEST_PATH, 1, 10) is None
 
-    # Test search on line 2 only
-    lines.add_line(TEST_PATH, 2, 0x1234)
+@pytest.mark.parametrize("local_path", LOCAL_PATHS)
+def test_lines(local_path: PureWindowsPath | PurePosixPath):
+    """Basic demonstration of behavior with a simple file path."""
+    # Start by adding the local code files for our project.
+    # These are the candidates for matching Windows paths from the PDB.
+    lines = LinesDb([local_path])
+
+    # No results: we haven't added any addresses yet.
+    assert lines.find_function(local_path, 1, 10) is None
+
+    # Attach line 2 of the file to this virtual address.
+    # The add_line function expects a Windows-like path from the PDB.
+    # All other functions use the local path.
+    lines.add_line(PDB_PATH, 2, 0x1234)
 
     # Should return nothing: we have not marked this addr as the start of a function
-    assert lines.find_function(TEST_PATH, 2) is None
+    assert lines.find_function(local_path, 2) is None
 
     # Now we get the function
     lines.mark_function_starts((0x1234,))
-    assert lines.find_function(TEST_PATH, 2) == 0x1234
+    assert lines.find_function(local_path, 2) == 0x1234
 
-    # Search window
-    assert lines.find_function(TEST_PATH, 1, 2) == 0x1234
+    # If the range of lines overlaps with the function start, we get a match.
+    assert lines.find_function(local_path, 1, 2) == 0x1234
 
-    # Outside of search window
-    assert lines.find_function(TEST_PATH, 1, 1) is None
-    assert lines.find_function(TEST_PATH, 3, 10) is None
+    # If the range does not include line 2: no match.
+    assert lines.find_function(local_path, 1, 1) is None
+    assert lines.find_function(local_path, 3, 10) is None
 
 
-def test_no_files_of_interest():
+@pytest.mark.parametrize("local_path", LOCAL_PATHS)
+def test_no_files_of_interest(local_path: PureWindowsPath | PurePosixPath):
     """Same as above test, but with no files declared up front.
     Calls to add_line do not alter the db."""
-
     lines = LinesDb([])
-    lines.add_line(TEST_PATH, 2, 0x1234)
+    lines.add_line(PDB_PATH, 2, 0x1234)
     lines.mark_function_starts((0x1234,))
     # The address is ignored because "test.cpp" is not part of the decomp code base.
-    assert lines.find_function(TEST_PATH, 2) is None
+    assert lines.find_function(local_path, 2) is None
 
 
-def test_multiple_match():
+@pytest.mark.parametrize("local_path", LOCAL_PATHS)
+def test_multiple_match(local_path: PureWindowsPath | PurePosixPath):
     """find_function looks for function starts in the range specified.
     If we find more than one address, the file does not match our data source (PDB or MAP).
     """
 
-    # TODO: Change this when we add *all* lines instead of just known function starts.
-    lines = LinesDb([TEST_PATH])
-    lines.add_line(TEST_PATH, 2, 0x1234)
-    lines.add_line(TEST_PATH, 3, 0x1235)
+    lines = LinesDb([local_path])
+    lines.add_line(PDB_PATH, 2, 0x1234)
+    lines.add_line(PDB_PATH, 3, 0x1235)
     lines.mark_function_starts((0x1234, 0x1235))
 
     # Both match on their own
-    assert lines.find_function(TEST_PATH, 2) == 0x1234
-    assert lines.find_function(TEST_PATH, 3) == 0x1235
+    assert lines.find_function(local_path, 2) == 0x1234
+    assert lines.find_function(local_path, 3) == 0x1235
 
     # Two addresses in this range of line numbers. return None.
-    assert lines.find_function(TEST_PATH, 2, 3) is None
+    assert lines.find_function(local_path, 2, 3) is None
 
 
 def test_db_hash_windows():
@@ -66,13 +85,15 @@ def test_db_hash_windows():
     the equality check for whichever platform you are running on.
     Windows paths are not case-sensitive."""
 
-    path = PureWindowsPath("test.cpp")
-    lines = LinesDb([path])
-    lines.add_line(path, 2, 0x1234)
+    local_path = PureWindowsPath("test.cpp")
+    lines = LinesDb([local_path])
+
+    pdb_path = PureWindowsPath("test.cpp")
+    lines.add_line(pdb_path, 2, 0x1234)
     lines.mark_function_starts((0x1234,))
 
     # Should match any variation
-    assert lines.find_function(path, 2) == 0x1234
+    assert lines.find_function(local_path, 2) == 0x1234
     assert lines.find_function(PureWindowsPath("Test.cpp"), 2) == 0x1234
     assert lines.find_function(PureWindowsPath("TEST.CPP"), 2) == 0x1234
 
@@ -82,40 +103,43 @@ def test_db_hash_posix():
     The goal here is to show that we are not taking liberties with PurePath
     and when it can be expected to match."""
 
-    path = PurePosixPath("test.cpp")
-    lines = LinesDb([path])
-    lines.add_line(path, 2, 0x1234)
+    local_path = PurePosixPath("test.cpp")
+    lines = LinesDb([local_path])
+
+    pdb_path = PureWindowsPath("test.cpp")
+    lines.add_line(pdb_path, 2, 0x1234)
     lines.mark_function_starts((0x1234,))
 
     # Should match only the exact path
-    assert lines.find_function(path, 2) == 0x1234
+    assert lines.find_function(local_path, 2) == 0x1234
     assert lines.find_function(PurePosixPath("Test.cpp"), 2) is None
     assert lines.find_function(PurePosixPath("TEST.CPP"), 2) is None
 
 
-def test_db_search_line():
+@pytest.mark.parametrize("local_path", LOCAL_PATHS)
+def test_db_search_line(local_path: PureWindowsPath | PurePosixPath):
     """search_line() will return any line in the given range
     unless you restrict to function starts only."""
 
-    lines = LinesDb([TEST_PATH])
+    lines = LinesDb([local_path])
 
     # We haven't added any addresses yet.
-    assert [*lines.search_line(TEST_PATH, 1, 10)] == []
+    assert [*lines.search_line(local_path, 1, 10)] == []
 
-    lines.add_line(TEST_PATH, 2, 0x1234)
-    lines.add_line(TEST_PATH, 5, 0x2000)
+    lines.add_line(PDB_PATH, 2, 0x1234)
+    lines.add_line(PDB_PATH, 5, 0x2000)
 
     # Return single line if no end range specified
-    assert [*lines.search_line(TEST_PATH, 2)] == [0x1234]
-    assert [*lines.search_line(TEST_PATH, 5)] == [0x2000]
+    assert [*lines.search_line(local_path, 2)] == [0x1234]
+    assert [*lines.search_line(local_path, 5)] == [0x2000]
 
     # Test line range
-    assert [*lines.search_line(TEST_PATH, 2, 4)] == [0x1234]
-    assert [*lines.search_line(TEST_PATH, 2, 5)] == [0x1234, 0x2000]
-    assert [*lines.search_line(TEST_PATH, 3, 5)] == [0x2000]
+    assert [*lines.search_line(local_path, 2, 4)] == [0x1234]
+    assert [*lines.search_line(local_path, 2, 5)] == [0x1234, 0x2000]
+    assert [*lines.search_line(local_path, 3, 5)] == [0x2000]
 
     # No lines marked as function starts
-    assert [*lines.search_line(TEST_PATH, 2, 5, start_only=True)] == []
+    assert [*lines.search_line(local_path, 2, 5, start_only=True)] == []
 
     lines.mark_function_starts((0x1234,))
-    assert [*lines.search_line(TEST_PATH, 2, 5, start_only=True)] == [0x1234]
+    assert [*lines.search_line(local_path, 2, 5, start_only=True)] == [0x1234]


### PR DESCRIPTION
The existing tests have two problems:

1. They use `PurePath` for the sample value.
2. They use that value with two different kinds of functions: those that expect a local path, and `add_line()` that expects the PDB path.

The value `test.cpp` is simple enough that this didn't matter (i.e. it worked through implicit conversion). Using `PurePath` means that you get either `PureWindowsPath` or `PurePosixPath` depending on where you run the test. Since we test both on Windows and Ubuntu hosts, we do test everything.

It's better to be explicit. We now use better sample values that are not specific to the test-runner platform. I also improved the comments and variable names so it's more clear what's happening at each stage. We also pass the `mypy` check for this file. (#132)