### PR TITLE
Consistent order for `get_all()` query

### DIFF
--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -347,7 +347,7 @@ class EntityDb:
 
     def get_all(self) -> Iterator[ReccmpEntity]:
         cur = self._sql.execute(
-            "SELECT orig_addr, recomp_addr, kvstore FROM entities ORDER BY orig_addr NULLS LAST"
+            "SELECT orig_addr, recomp_addr, kvstore FROM entities ORDER BY orig_addr NULLS LAST, recomp_addr"
         )
         cur.row_factory = entity_factory
         yield from cur
@@ -356,7 +356,7 @@ class EntityDb:
         cur = self._sql.execute(
             """SELECT orig_addr, recomp_addr, kvstore FROM entities
             WHERE matched = 1
-            ORDER BY orig_addr NULLS LAST
+            ORDER BY orig_addr
             """,
         )
         cur.row_factory = matched_entity_factory
@@ -420,7 +420,7 @@ class EntityDb:
             """SELECT orig_addr, recomp_addr, kvstore FROM entities
             WHERE json_extract(kvstore, '$.type') = ?
             AND matched = 1
-            ORDER BY orig_addr NULLS LAST
+            ORDER BY orig_addr
             """,
             (entity_type,),
         )

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -46,6 +46,32 @@ def test_db_count(db):
     assert db.count() == 1
 
 
+def test_db_all_order(db):
+    """get_all() returns matched and unmatched entities. The order should be:
+    1. Matched and unmatched entities by orig_addr, ascending.
+    2. Unmatched entities with only a recomp_addr. Order by recomp_addr, ascending."""
+    with db.batch() as batch:
+        for addr in (600, 500, 300, 200):
+            batch.set_recomp(addr)
+
+        for addr in (400, 300, 200, 100):
+            batch.set_orig(addr)
+
+        batch.match(200, 200)
+        batch.match(300, 300)
+
+    addrs = [(e.orig_addr, e.recomp_addr) for e in db.get_all()]
+
+    assert addrs == [
+        (100, None),
+        (200, 200),
+        (300, 300),
+        (400, None),
+        (None, 500),
+        (None, 600),
+    ]
+
+
 #### Testing new batch API ####
 
 


### PR DESCRIPTION
A small change to the database `get_all()` function. The main consumer is `reccmp-roadmap`.

This is the only generator that returns both matched and unmatched entities. The order is:
1. orig_addr, ascending (be they matched or unmatched)
2. unmatched entities with only a recomp_addr, in insertion order (by row ID)

This second group of unmatched entities are now sorted by recomp_addr.

I use `roadmap` to evaluate db/entity changes and the inconsistent order creates diffs where there aren't any.

I also removed the `NULLS LAST` hint from the `get_matches()` and `get_matches_by_type()` queries. There should not be any nulls here because we grab only matched entities.