### PR TITLE
Unify size for string entities

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -195,13 +195,21 @@ class Compare:
                     except UnicodeDecodeError:
                         pass
 
-                batch.set_recomp(
-                    addr,
-                    type=sym.node_type,
-                    name=sym.name(),
-                    symbol=sym.decorated_name,
-                    size=sym.size(),
-                )
+                    batch.set_recomp(
+                        addr,
+                        type=sym.node_type,
+                        name=sym.name(),
+                        symbol=sym.decorated_name,
+                        size=len(rstrip_string) + 1,
+                    )
+                else:
+                    batch.set_recomp(
+                        addr,
+                        type=sym.node_type,
+                        name=sym.name(),
+                        symbol=sym.decorated_name,
+                        size=sym.size(),
+                    )
 
         for filename, values in self.cvdump_analysis.lines.items():
             lines = [
@@ -312,7 +320,7 @@ class Compare:
                     string.offset,
                     name=string.name,
                     type=EntityType.STRING,
-                    size=len(string.name),
+                    size=len(string.name) + 1,
                 )
 
             for line in codebase.iter_line_symbols():
@@ -449,13 +457,19 @@ class Compare:
                 for addr, string in self.orig_bin.iter_string("latin1"):
                     if is_real_string(string):
                         batch.insert_orig(
-                            addr, type=EntityType.STRING, name=string, size=len(string)
+                            addr,
+                            type=EntityType.STRING,
+                            name=string,
+                            size=len(string) + 1,
                         )
 
                 for addr, string in self.recomp_bin.iter_string("latin1"):
                     if is_real_string(string):
                         batch.insert_recomp(
-                            addr, type=EntityType.STRING, name=string, size=len(string)
+                            addr,
+                            type=EntityType.STRING,
+                            name=string,
+                            size=len(string) + 1,
                         )
 
     def _find_float_const(self):

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -195,6 +195,8 @@ class Compare:
                     except UnicodeDecodeError:
                         pass
 
+                    # Special handling for string entities.
+                    # Make sure the entity size includes the string null-terminator.
                     batch.set_recomp(
                         addr,
                         type=sym.node_type,
@@ -203,6 +205,7 @@ class Compare:
                         size=len(rstrip_string) + 1,
                     )
                 else:
+                    # Non-string entities.
                     batch.set_recomp(
                         addr,
                         type=sym.node_type,


### PR DESCRIPTION
A small change as part of a larger refactor involving string entities and how we detect and match them.

The reported size for a string entity now includes the null terminator. The ASCII string "Pizza" would now have an entity size of 6 instead of the string length of 5.

The goal here is to be consistent about adding string data from multiple sources. The size should represent the memory footprint for that entity, irrespective of string encoding. If this were a UTF-16 string, the size should be 12. (2-byte null terminator). If it were a pascal string, the size would still be 6, but the data would be `b"\x05Pizza"` instead of `b"Pizza\x00"`.

I used this code as a manual test:
```python
isle_compare = go(origfile, recompfile, pdbfile, codepath)
for (orig_addr, recomp_addr, size, name) in isle_compare._db.sql.execute(
    """SELECT orig_addr, recomp_addr,
    coalesce(json_extract(kvstore,'$.size'), 0),
    coalesce(json_extract(kvstore,'$.name'), '')
    FROM entities WHERE coalesce(json_extract(kvstore,'$.type'), 0) = ?
    """,
    (EntityType.STRING,)
):
    assert size is not None
    orig_raw = origfile.read(orig_addr, size) if orig_addr is not None else None
    recomp_raw = recompfile.read(recomp_addr, size) if recomp_addr is not None else None

    if name:
        assert name[-1] != "\x00"

    if orig_raw and recomp_raw:
        assert orig_raw == recomp_raw

    try:
        if orig_raw is not None:
            try:
                assert orig_raw[-1] == 0
                assert orig_raw[-2] != 0
            except IndexError:
                pass
            assert orig_raw.decode("latin1").rstrip("\x00") == name

        if recomp_raw is not None:
            try:
                assert recomp_raw[-1] == 0
                assert recomp_raw[-2] != 0
            except IndexError:
                pass
            assert recomp_raw.decode("latin1").rstrip("\x00") == name
    except AssertionError as ex:
        print(orig_raw, recomp_raw)
        #raise ex
```