### PR TITLE
Redesign string search and matching

### DIFF
--- a/reccmp/isledecomp/analysis/__init__.py
+++ b/reccmp/isledecomp/analysis/__init__.py
@@ -1,2 +1,3 @@
 from .float_const import find_float_consts
+from .string_const import is_likely_latin1
 from .vtordisp import find_vtordisp

--- a/reccmp/isledecomp/analysis/string_const.py
+++ b/reccmp/isledecomp/analysis/string_const.py
@@ -1,10 +1,10 @@
 import re
 
-r_likely_string = re.compile(r"([\t\r\n\x20-\x7f][\t\r\n\x20-\x7f\xa0-\xff]*)")
+r_likely_string = re.compile(r"[\t\r\n\x20-\x7f][\t\r\n\x20-\x7f\xa0-\xff]*")
 
 
 def is_likely_latin1(string) -> bool:
     """Heuristic to eliminate data streams that are not real strings.
-    We exclude bytes not in the Latin1 (ISO/IEC 8859-1) characte set
+    We exclude bytes not in the Latin1 (ISO/IEC 8859-1) character set
     and also assume the string begins with an ASCII character."""
     return r_likely_string.fullmatch(string) is not None

--- a/reccmp/isledecomp/analysis/string_const.py
+++ b/reccmp/isledecomp/analysis/string_const.py
@@ -1,0 +1,10 @@
+import re
+
+r_likely_string = re.compile(r"([\t\r\n\x20-\x7f][\t\r\n\x20-\x7f\xa0-\xff]*)")
+
+
+def is_likely_latin1(string) -> bool:
+    """Heuristic to eliminate data streams that are not real strings.
+    We exclude bytes not in the Latin1 (ISO/IEC 8859-1) characte set
+    and also assume the string begins with an ASCII character."""
+    return r_likely_string.fullmatch(string) is not None

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -20,7 +20,11 @@ from reccmp.isledecomp.compare.event import (
     reccmp_report_nop,
     create_logging_wrapper,
 )
-from reccmp.isledecomp.analysis import find_float_consts, find_vtordisp
+from reccmp.isledecomp.analysis import (
+    find_float_consts,
+    find_vtordisp,
+    is_likely_latin1,
+)
 from .match_msvc import (
     match_lines,
     match_symbols,
@@ -83,19 +87,20 @@ class Compare:
         match_vtables(self._db, report)
         match_static_variables(self._db, report)
         match_variables(self._db, report)
-        match_strings(self._db, report)
         match_lines(self._db, self._lines_db, report)
 
         self._match_array_elements()
         # Detect floats first to eliminate potential overlap with string data
         self._find_float_const()
-        self._find_original_strings()
+        self._find_strings()
         self._match_imports()
         self._match_exports()
         self._match_thunks()
         self._match_vtordisp()
         self._check_vtables()
         self._unique_names_for_overloaded_functions()
+
+        match_strings(self._db, report)
 
         self.function_comparator = FunctionComparator(
             self._db, self.orig_bin, self.recomp_bin, report
@@ -210,6 +215,7 @@ class Compare:
                         name=sym.name(),
                         symbol=sym.decorated_name,
                         size=len(rstrip_string) + 1,
+                        verified=True,
                     )
                 else:
                     # Non-string entities.
@@ -331,6 +337,7 @@ class Compare:
                     name=string.name,
                     type=EntityType.STRING,
                     size=len(string.name) + 1,
+                    verified=True,
                 )
 
             for line in codebase.iter_line_symbols():
@@ -427,60 +434,29 @@ class Compare:
 
         batch.commit()
 
-    def _find_original_strings(self):
-        """Go to the original binary and look for the specified string constants
-        to find a match. This is a (relatively) expensive operation so we only
-        look at strings that we have not already matched via a STRING annotation."""
-        # Release builds give each de-duped string a symbol so they are easy to find and match.
-        for string in self._db.get_unmatched_strings():
-            addr = self.orig_bin.find_string(string.encode("latin1"))
-            if addr is None:
-                escaped = repr(string)
-                logger.debug("Failed to find this string in the original: %s", escaped)
-                continue
+    def _find_strings(self):
+        """Search both binaries for Latin1 strings.
+        We use the insert_() method so that thse strings will not overwrite
+        an existing entity. It's possible that some variables or pointers
+        will be mistakenly identified as short strings."""
+        with self._db.batch() as batch:
+            for addr, string in self.orig_bin.iter_string("latin1"):
+                if is_likely_latin1(string):
+                    batch.insert_orig(
+                        addr,
+                        type=EntityType.STRING,
+                        name=string,
+                        size=len(string) + 1,
+                    )
 
-            self._db.match_string(addr, string)
-
-        def is_real_string(s: str) -> bool:
-            """Heuristic to ignore values that only look like strings.
-            This is mostly about short strings (len <= 4) that could be byte or word values.
-            """
-            # 0x10 is the MSB of the address space for DLLs (LEGO1), so this is a pointer
-            if len(s) == 0 or "\x10" in s:
-                return False
-
-            # assert(0) is common
-            if len(s) == 1 and s[0] != "0":
-                return False
-
-            # Hack because str.isprintable() will fail on strings with newlines or tabs
-            if len(s) <= 4 and "\\x" in repr(s):
-                return False
-
-            return True
-
-        # Debug builds do not de-dupe the strings, so we need to find them via brute force scan.
-        # We could try to match the string addrs if there is only one in orig and recomp.
-        # When we sanitize the asm, the result is the same regardless.
-        if self.orig_bin.is_debug:
-            with self._db.batch() as batch:
-                for addr, string in self.orig_bin.iter_string("latin1"):
-                    if is_real_string(string):
-                        batch.insert_orig(
-                            addr,
-                            type=EntityType.STRING,
-                            name=string,
-                            size=len(string) + 1,
-                        )
-
-                for addr, string in self.recomp_bin.iter_string("latin1"):
-                    if is_real_string(string):
-                        batch.insert_recomp(
-                            addr,
-                            type=EntityType.STRING,
-                            name=string,
-                            size=len(string) + 1,
-                        )
+            for addr, string in self.recomp_bin.iter_string("latin1"):
+                if is_likely_latin1(string):
+                    batch.insert_recomp(
+                        addr,
+                        type=EntityType.STRING,
+                        name=string,
+                        size=len(string) + 1,
+                    )
 
     def _find_float_const(self):
         """Add floating point constants in each binary to the database.

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -461,6 +461,10 @@ class Compare:
         will be mistakenly identified as short strings."""
         with self._db.batch() as batch:
             for addr, string in self.orig_bin.iter_string("latin1"):
+                # If the address is the site of a relocation, this is a pointer, not a string.
+                if addr in self.orig_bin.relocations:
+                    continue
+
                 if is_likely_latin1(string):
                     batch.insert_orig(
                         addr,
@@ -470,6 +474,9 @@ class Compare:
                     )
 
             for addr, string in self.recomp_bin.iter_string("latin1"):
+                if addr in self.recomp_bin.relocations:
+                    continue
+
                 if is_likely_latin1(string):
                     batch.insert_recomp(
                         addr,

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -356,7 +356,7 @@ class Compare:
                     string.offset,
                     name=string.name,
                     type=EntityType.STRING,
-                    size=len(string.name) + 1,
+                    size=len(string.name) + 1,  # including null-terminator
                     verified=True,
                 )
 
@@ -470,7 +470,7 @@ class Compare:
                         addr,
                         type=EntityType.STRING,
                         name=string,
-                        size=len(string) + 1,
+                        size=len(string) + 1,  # including null-terminator
                     )
 
             for addr, string in self.recomp_bin.iter_string("latin1"):
@@ -482,7 +482,7 @@ class Compare:
                         addr,
                         type=EntityType.STRING,
                         name=string,
-                        size=len(string) + 1,
+                        size=len(string) + 1,  # including null-terminator
                     )
 
     def _find_float_const(self):

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -250,7 +250,6 @@ class EntityDb:
     def __init__(self):
         self._sql = sqlite3.connect(":memory:")
         self._sql.executescript(_SETUP_SQL)
-        self._indexed = set()
 
     @property
     def sql(self) -> sqlite3.Connection:
@@ -470,80 +469,6 @@ class EntityDb:
 
         return cur.rowcount > 0
 
-    def search_symbol(self, symbol: str) -> Iterator[ReccmpEntity]:
-        if "symbol" not in self._indexed:
-            self._sql.execute(
-                "CREATE index idx_symbol on entities(json_extract(kvstore, '$.symbol'))"
-            )
-            self._indexed.add("symbol")
-
-        cur = self._sql.execute(
-            """SELECT orig_addr, recomp_addr, kvstore FROM entities
-            WHERE json_extract(kvstore, '$.symbol') = ?""",
-            (symbol,),
-        )
-        cur.row_factory = entity_factory
-        yield from cur
-
-    def search_name(self, name: str, entity_type: EntityType) -> Iterator[ReccmpEntity]:
-        if "name" not in self._indexed:
-            self._sql.execute(
-                "CREATE index idx_name on entities(json_extract(kvstore, '$.name'))"
-            )
-            self._indexed.add("name")
-
-        # n.b. If the name matches and the type is not set, we will return the row.
-        # Ideally we would have perfect information on the recomp side and not need to do this
-        cur = self._sql.execute(
-            """SELECT orig_addr, recomp_addr, kvstore FROM entities
-            WHERE json_extract(kvstore, '$.name') = ?
-            AND (json_extract(kvstore, '$.type') IS NULL OR json_extract(kvstore, '$.type') = ?)""",
-            (name, entity_type),
-        )
-        cur.row_factory = entity_factory
-        yield from cur
-
-    def _match_on(self, entity_type: EntityType, addr: int, name: str) -> bool:
-        """Search the program listing for the given name and type, then assign the
-        given address to the first unmatched result."""
-        # If we identify the name as a linker symbol, search for that instead.
-        # TODO: Will need a customizable "name_is_symbol" function for other platforms
-        if entity_type != EntityType.STRING and name.startswith("?"):
-            for obj in self.search_symbol(name):
-                if obj.orig_addr is None and obj.recomp_addr is not None:
-                    return self.set_pair(addr, obj.recomp_addr, entity_type)
-
-            return False
-
-        # Truncate the name to 255 characters. It will not be possible to match a name
-        # longer than that because MSVC truncates to this length.
-        # See also: warning C4786.
-        name = name[:255]
-
-        for obj in self.search_name(name, entity_type):
-            if obj.orig_addr is None and obj.recomp_addr is not None:
-                matched = self.set_pair(addr, obj.recomp_addr, entity_type)
-
-                # Type field has been set by set_pair, so we can use it in our count query:
-                (count,) = self._sql.execute(
-                    """SELECT count(rowid) from entities
-                    where json_extract(kvstore,'$.name') = ?
-                    AND json_extract(kvstore,'$.type') = ?""",
-                    (name, entity_type),
-                ).fetchone()
-
-                if matched and count > 1:
-                    logger.warning(
-                        "Ambiguous match 0x%x on name '%s' to '%s'",
-                        addr,
-                        name,
-                        obj.get("symbol"),
-                    )
-
-                return matched
-
-        return False
-
     def get_next_orig_addr(self, addr: int) -> int | None:
         """Return the original address (matched or not) that follows
         the one given. If our recomp function size would cause us to read
@@ -564,35 +489,3 @@ class EntityDb:
         ).fetchone()
 
         return result[0] if result is not None else None
-
-    def match_string(self, addr: int, value: str) -> bool:
-        did_match = self._match_on(EntityType.STRING, addr, value)
-        if not did_match:
-            already_present = self.get_by_orig(addr, exact=True)
-            escaped = repr(value)
-
-            if already_present is None:
-                logger.error(
-                    "Failed to find string annotated with 0x%x: %s", addr, escaped
-                )
-            elif (
-                already_present.entity_type == EntityType.STRING
-                and already_present.name == value
-            ):
-                logger.debug(
-                    "String annotated with 0x%x is annotated multiple times: %s",
-                    addr,
-                    escaped,
-                )
-            else:
-                logger.error(
-                    "Multiple annotations of 0x%x disagree: %s (STRING) vs. %s (%s)",
-                    addr,
-                    escaped,
-                    repr(already_present.name),
-                    repr(EntityType(already_present.entity_type))
-                    if already_present.entity_type is not None
-                    else "<None>",
-                )
-
-        return did_match

--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -324,8 +324,9 @@ def match_strings(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
         string_index.add(text, recomp_addr)
 
     with db.batch() as batch:
-        for orig_addr, text in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.name') as name
+        for orig_addr, text, verified in db.sql.execute(
+            """SELECT orig_addr, json_extract(kvstore, '$.name') as name,
+            coalesce(json_extract(kvstore,'$.verified'), 0)
             from orig_unmatched where name is not null
             and json_extract(kvstore,'$.type') = ?""",
             (EntityType.STRING,),
@@ -334,11 +335,12 @@ def match_strings(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
                 recomp_addr = string_index.pop(text)
                 batch.match(orig_addr, recomp_addr)
             else:
-                report(
-                    ReccmpEvent.NO_MATCH,
-                    orig_addr,
-                    msg=f"Failed to match string {repr(text)} at 0x{orig_addr:x}",
-                )
+                if verified:
+                    report(
+                        ReccmpEvent.NO_MATCH,
+                        orig_addr,
+                        msg=f"Failed to match string {repr(text)} at 0x{orig_addr:x}",
+                    )
 
 
 def match_lines(

--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -334,13 +334,12 @@ def match_strings(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
             if text in string_index:
                 recomp_addr = string_index.pop(text)
                 batch.match(orig_addr, recomp_addr)
-            else:
-                if verified:
-                    report(
-                        ReccmpEvent.NO_MATCH,
-                        orig_addr,
-                        msg=f"Failed to match string {repr(text)} at 0x{orig_addr:x}",
-                    )
+            elif verified:
+                report(
+                    ReccmpEvent.NO_MATCH,
+                    orig_addr,
+                    msg=f"Failed to match string {repr(text)} at 0x{orig_addr:x}",
+                )
 
 
 def match_lines(

--- a/reccmp/isledecomp/formats/image.py
+++ b/reccmp/isledecomp/formats/image.py
@@ -7,6 +7,3 @@ class Image:
     filepath: Path
     view: memoryview = dataclasses.field(repr=False)
     data: bytes = dataclasses.field(repr=False)
-
-    def prepare_string_search(self):
-        pass

--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -120,7 +120,6 @@ STRING_ADDRESSES = (
 def test_strings(addr: int, string: bytes, binfile: PEImage):
     """Test string read utility function and the string search feature"""
     assert binfile.read_string(addr) == string
-    assert binfile.find_string(string) == addr
 
 
 def test_relocation(binfile: PEImage):

--- a/tests/test_match_msvc.py
+++ b/tests/test_match_msvc.py
@@ -598,12 +598,22 @@ def test_match_strings_type_required(db):
 
 
 def test_match_strings_no_match_report(db, report):
-    """Should report if we cannot match a string on the orig side."""
+    """Should report if we cannot match a string on the orig side.
+    However: only alert if the string is 'verified' by user input,
+    a symbol in the PDB, or some (future) heuristic."""
     with db.batch() as batch:
         batch.set_orig(123, name="test", type=EntityType.STRING)
 
     match_strings(db, report)
 
+    # Not verified: no alert for failed match
+    report.assert_not_called()
+
+    # Should alert after we mark the string as verified
+    with db.batch() as batch:
+        batch.set_orig(123, verified=True)
+
+    match_strings(db, report)
     report.assert_called_with(ReccmpEvent.NO_MATCH, 123, msg=ANY)
 
 


### PR DESCRIPTION
For detecting and matching string data, we do two things:

1. Identify "verified" strings using any information at our disposal. This includes `// STRING` annotations and symbols in the PDB that begin with `??_C@`.
2. Using the binary's relocation table, test each address from a non-code section to see if it resembles a string.

Until now, we only matched the verified strings. It's not vital to match a string entity for the sake of generating asm output, but it is helpful for analysis using `reccmp-roadmap`.

Method 2 was only applied for debug binaries (i.e. `BETA10`) because we assumed that binaries built with string pooling enabled would give each deduped string a symbol. This is generally true, but some strings are missed if we don't cover every address.

With this change, we apply method 2 for every binary. We take the following steps to not create invalid string entities:
1. Match strings in the Latin1[^1] character set, but only where the first character is regular ASCII.
2. Ignore addresses that are the site of a relocation. This helps to avoid vtable offsets referenced by an indirect call.
3. Run this step last and do not overwrite an existing entity. This helps to avoid situations where a variable entity is mistaken for a string.

The `match_string()` function is now run after this step so we can match the newly-created entities. To avoid a deluge of "failed to match" alerts (e.g. for code file paths used in `assert` calls) we only alert if a "verified" string in the original binary cannot be matched.

The biggest change is actually removing a lot of now unneeded code. The PE module identified possible strings in a roundabout way, and this new approach is better. The DB had a function specifically for matching strings, and it gave a specific error report if you tried to match a string entity with an existing variable. I think we avoid these problems with the above changes, but maybe I've overlooked something. (attn: @jonschz)

For testing, I have been diffing the output of `reccmp-roadmap --verbose` between master and this branch. I think we're in good shape and not dropping any strings that we should have. It isn't 100% perfect, though. For example, it creates an entity for this substring:

```diff
 0002:00000418   0002:0000042c         20  str  23      '<program name unknown>'
+0002:00000428                             str  7       'known>'
```

[^1]: I had forgotten why I chose Latin1 instead of just ASCII for the string encoding. It must have been done to support strings with the registered trademark symbol ® in `ISLE`.