### PR TITLE
Convert the other `Compare` constructors to use `from_target()`.

### DIFF
--- a/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
+++ b/reccmp/ghidra_scripts/import_functions_and_types_from_pdb.py
@@ -317,23 +317,7 @@ def main():
         logging.getLogger("isledecomp.cvdump.symbols").setLevel(logging.WARNING)
 
     logger.info("Starting comparison")
-
-    origfile = detect_image(target.original_path)
-    if not isinstance(origfile, PEImage):
-        raise ValueError
-
-    recompfile = detect_image(target.recompiled_path)
-    if not isinstance(recompfile, PEImage):
-        raise ValueError
-
-    isle_compare = IsleCompare(
-        origfile,
-        recompfile,
-        target.recompiled_pdb,
-        target.source_root,
-        target_id=target.target_id,
-    )
-
+    isle_compare = IsleCompare.from_target(target)
     logger.info("Comparison complete.")
 
     # try to acquire matched functions
@@ -361,11 +345,6 @@ try:
     from reccmp.project.common import RECCMP_BUILD_CONFIG, RECCMP_PROJECT_CONFIG
     from reccmp.project.detect import RecCmpBuiltProject, RecCmpBuiltTarget
     from reccmp.project.error import RecCmpProjectNotFoundException
-
-    reload_module("reccmp.isledecomp.formats")
-    reload_module("reccmp.isledecomp")
-    from reccmp.isledecomp import detect_image
-    from reccmp.isledecomp import PEImage
 
     reload_module("reccmp.isledecomp.compare")
     from reccmp.isledecomp.compare import Compare as IsleCompare

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -14,7 +14,7 @@ import statistics
 import bisect
 from typing import Iterator, NamedTuple
 import reccmp
-from reccmp.isledecomp import PEImage, detect_image
+from reccmp.isledecomp import PEImage
 from reccmp.isledecomp.compare.db import ReccmpEntity
 from reccmp.isledecomp.cvdump import Cvdump
 from reccmp.isledecomp.compare import Compare as IsleCompare
@@ -387,19 +387,9 @@ def main() -> int:
         logger.error(e.args[0])
         return 1
 
-    orig_bin = detect_image(target.original_path)
-    assert isinstance(orig_bin, PEImage)
-
-    recomp_bin = detect_image(target.recompiled_path)
-    assert isinstance(recomp_bin, PEImage)
-
-    engine = IsleCompare(
-        orig_bin,
-        recomp_bin,
-        target.recompiled_pdb,
-        target.source_root,
-        target_id=target.target_id,
-    )
+    engine = IsleCompare.from_target(target)
+    orig_bin = engine.orig_bin
+    recomp_bin = engine.recomp_bin
 
     module_map = ModuleMap(target.recompiled_pdb, recomp_bin)
 

--- a/reccmp/tools/vtable.py
+++ b/reccmp/tools/vtable.py
@@ -4,7 +4,6 @@ import argparse
 import logging
 import colorama
 import reccmp
-from reccmp.isledecomp import PEImage, detect_image
 from reccmp.isledecomp.compare import Compare as IsleCompare
 from reccmp.isledecomp.utils import print_combined_diff
 from reccmp.project.logging import argparse_add_logging_args, argparse_parse_logging
@@ -68,18 +67,7 @@ def main():
         logger.error(e.args[0])
         return 1
 
-    orig_bin = detect_image(target.original_path)
-    assert isinstance(orig_bin, PEImage)
-
-    recomp_bin = detect_image(target.recompiled_path)
-    assert isinstance(recomp_bin, PEImage)
-    engine = IsleCompare(
-        orig_bin,
-        recomp_bin,
-        target.recompiled_pdb,
-        target.source_root,
-        target_id=target.target_id,
-    )
+    engine = IsleCompare.from_target(target)
 
     for tbl_match in engine.compare_vtables():
         vtable_count += 1


### PR DESCRIPTION
I don't know why I skipped these in #143. This covers the remaining calls to the `Compare()` constructor in the Ghidra script, roadmap, and vtable tools.

My end goal here is to support situations where the code directory and PDB path are null. If we can handle those in one place, it will make it simpler to support projects with more or less data sources.

Remember to restart Ghidra before running the import script. It didn't detect the new `from_target()` method until I did that.