### PR TITLE
Separate modules for project yml schemas and internal structures

### DIFF
--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -4,6 +4,25 @@ from pathlib import Path
 from dataclasses import dataclass
 
 from pydantic import AliasChoices, BaseModel, Field
+import ruamel.yaml
+
+
+_yaml = ruamel.yaml.YAML()
+
+
+class YmlFileModel(BaseModel):
+    @classmethod
+    def from_file(cls, filename: Path):
+        with filename.open("r") as f:
+            return cls.model_validate(_yaml.load(f))
+
+    @classmethod
+    def from_str(cls, yaml: str):
+        return cls.model_validate(_yaml.load(yaml))
+
+    def write_file(self, filename: Path):
+        with filename.open("w") as f:
+            _yaml.dump(data=self.model_dump(mode="json"), stream=f)
 
 
 class YmlGhidraConfig(BaseModel):
@@ -37,7 +56,7 @@ class ProjectFileTarget(BaseModel):
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
 
 
-class ProjectFile(BaseModel):
+class ProjectFile(YmlFileModel):
     """File schema for project.yml"""
 
     targets: dict[str, ProjectFileTarget]
@@ -50,7 +69,7 @@ class UserFileTarget:
     path: Path
 
 
-class UserFile(BaseModel):
+class UserFile(YmlFileModel):
     """File schema for user.yml"""
 
     targets: dict[str, UserFileTarget]
@@ -64,7 +83,7 @@ class BuildFileTarget:
     pdb: Path
 
 
-class BuildFile(BaseModel):
+class BuildFile(YmlFileModel):
     """File schema for build.yml"""
 
     project: Path

--- a/reccmp/project/create.py
+++ b/reccmp/project/create.py
@@ -4,8 +4,6 @@ from pathlib import Path
 import shutil
 import textwrap
 
-import ruamel.yaml
-
 from reccmp.assets import get_asset_file
 from .config import (
     Hash,
@@ -230,9 +228,7 @@ def create_project(
 
     # Write project YAML file
     logger.debug("Creating %s...", project_config_path)
-    with project_config_path.open("w") as f:
-        yaml = ruamel.yaml.YAML()
-        yaml.dump(data=project_config_data.model_dump(mode="json"), stream=f)
+    project_config_data.write_file(project_config_path)
 
     # The user YAML file has the path to the original binary for each target
     user_config_data = UserFile(
@@ -242,10 +238,8 @@ def create_project(
     )
 
     # Write user YAML file
-    logger.debug("Creating %s...", user_config_data)
-    with user_config_path.open("w") as f:
-        yaml = ruamel.yaml.YAML()
-        yaml.dump(data=user_config_data.model_dump(mode="json"), stream=f)
+    logger.debug("Creating %s...", user_config_path)
+    user_config_data.write_file(user_config_path)
 
     if scm:
         # Update existing .gitignore to skip build.yml and user.yml.


### PR DESCRIPTION
The `config.py` module now has only the classes used for converting the user/build/project files to and from yaml. The `detect.py` module has the sets of `Project` and `Target` classes we use internally.

The overlap was `GhidraConfig`. This has `pydantic`- specific attributes and so it needs to extend `BaseModel`. I renamed this to `YmlGhidraConfig` and created a duplicate dataclass `GhidraConfig` with the two lists. The structure is the same for the moment, but the idea is that we could support multiple schemas (e.g. my example from #7) and only have to write simple conversion functions.

I also created some helper functions to load/dump yaml that eliminate some repeated code. `pydantic` has built-in methods for this, but for json, not yaml.