### PR TITLE
Fix false negatives in jump tables

### DIFF
--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -189,6 +189,17 @@ def instruction_alters_regs(inst: str, regs: set[str]) -> bool:
     )
 
 
+def _is_relocatable(instr: str) -> bool:
+    """
+    Excludes certain instructions whose relocation will always change the logic
+    to be considered for an effective match.
+    """
+    # Do not relocate jump table entries (this most likely influences the behaviour)
+    if instr.startswith("start +"):
+        return False
+    return True
+
+
 def relocate_instructions(
     codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
 ) -> set[int]:
@@ -211,6 +222,8 @@ def relocate_instructions(
 
     for j in inserts:
         line = recomp_asm[j]
+        if not _is_relocatable(line):
+            continue
         recomp_regs_used = set(find_regs_used(line))
         for i in deletes:
             # Check for exact match.

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -210,7 +210,7 @@ def test_skip_small_instructions(code: bytes):
     (1 for the opcode, 4 for the operand)"""
     with patch("reccmp.isledecomp.compare.asm.parse.ParseAsm.sanitize") as mock:
         p = ParseAsm()
-        p.parse_asm(code)
+        p.parse_asm(code, 0)
         mock.assert_not_called()
 
 
@@ -220,8 +220,8 @@ def test_should_skip_regardless_of_register():
     changes the size of the instruction. Ideally we are consistent."""
     with patch("reccmp.isledecomp.compare.asm.parse.ParseAsm.sanitize") as mock:
         p = ParseAsm()
-        p.parse_asm(b"\x66\x3d\x00\x01")  # cmp ax, 0x100
-        p.parse_asm(b"\x66\x81\xf9\x00\x01")  # cmp cx, 0x100
+        p.parse_asm(b"\x66\x3d\x00\x01", 0)  # cmp ax, 0x100
+        p.parse_asm(b"\x66\x81\xf9\x00\x01", 0)  # cmp cx, 0x100
         mock.assert_not_called()
 
 
@@ -439,7 +439,7 @@ def test_consistent_numbering():
 
     # Run without name lookup
     p = ParseAsm()
-    p.parse_asm(code)
+    p.parse_asm(code, 0)
     assert p.replacements[0x1000] == "<OFFSET1>"
     assert p.replacements[0x1234] == "<OFFSET2>"
     assert p.replacements[0x2000] == "<OFFSET3>"
@@ -454,7 +454,7 @@ def test_consistent_numbering():
     assert len(p.replacements) == 0
 
     # Expect the two addresses to get the same placeholder
-    p.parse_asm(code)
+    p.parse_asm(code, 0)
     assert p.replacements[0x1000] == "<OFFSET1>"
     assert p.replacements[0x1234] == "<OFFSET2>"
     assert p.replacements[0x2000] == "<OFFSET3>"


### PR DESCRIPTION
Fixes #135, though we need to agree if this is the best way forward. This is able to catch the issue at https://github.com/isledecomp/isle/issues/1548:
```diff
---
+++
@@ -,18 +,18 @@
 : Jump table:
0x100756c8 : start + 0x65
0x100756cc : start + 0x113
0x100756d0 : start + 0x151
0x100756d4 : start + 0x88f
0x100756d8 : start + 0x88f
0x100756dc : start + 0x151
0x100756e0 : start + 0x198
0x100756e4 : start + 0x82d
0x100756e8 : start + 0x88f
+           : +start + 0x84b
0x100756ec : start + 0x8a7
-0x100756f0 : -start + 0x84b
 : Jump table:
0x100756f4 : start + 0x1b3
0x100756f8 : start + 0x2fe
0x100756fc : start + 0x449
0x10075700 : start + 0x590
0x10075704 : start + 0x6db
```
We have a few "regressions" on LEGO1:
```
Decreased (9):
0x10004a60 - GasStation::Notify (80.41% -> 74.23%)
0x10019b90 - Act2Actor::FUN_10019b90 (73.80% -> 70.93%)
0x10041050 - Act3Brickster::Animate (98.57% -> 97.62%)
0x1004b450 - LegoAnimMMPresenter::FUN_1004b450 (92.41% -> 83.54%)
0x10050380 - LegoAct2::Notify (71.79% -> 71.02%)
0x10055a60 - LegoNavController::Notify (96.44% -> 93.43%)
0x1006f080 - Infocenter::HandleEndAction (95.92% -> 91.98%)
0x1006fda0 - Infocenter::HandleKeyPress (84.92% -> 79.33%)
0x100a1cf0 - TglImpl::RendererImpl::CreateLight (80.68% -> 79.32%)
```
- I took a look at a few of those regressions, most of them are off by a few bytes, likely due to different instructions being used in the recompile, or due to other instructions not being in the correct order.
- Luckily, nothing went down from 100 % or 100 % effective, suggesting that there are no other bugs like https://github.com/isledecomp/isle/issues/1548 in LEGO1 at the moment.
- I also tried to write the jumps relative to the position in the jump table, which yielded a very similar result (and the same overall match percentage). It performed better on a few of the regressions and worse on others, but the list of functions with regressions was the same.

If we agree to merge this, I'll implement a few tests.