### PR TITLE
Improve documentation for 'exact' parameter in address lookups

### DIFF
--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -4,6 +4,10 @@ from reccmp.isledecomp.compare.db import ReccmpEntity
 from reccmp.isledecomp.types import EntityType
 
 
+class AddrLookupProtocol(Protocol):
+    def __call__(self, addr: int, *, exact: bool) -> ReccmpEntity | None: ...
+
+
 class AddrTestProtocol(Protocol):
     def __call__(self, addr: int, /) -> bool: ...
 
@@ -15,7 +19,7 @@ class NameReplacementProtocol(Protocol):
 
 
 def create_name_lookup(
-    db_getter: Callable[[int, bool], ReccmpEntity | None],
+    db_getter: AddrLookupProtocol,
     bin_read: Callable[[int], int | None],
     addr_attribute: str,
 ) -> NameReplacementProtocol:
@@ -25,7 +29,7 @@ def create_name_lookup(
         """Read the pointer address and open the entity (if it exists) at the indirect location."""
         addr = bin_read(pointer)
         if addr is not None:
-            return db_getter(addr, True)
+            return db_getter(addr, exact=True)
 
         return None
 
@@ -48,7 +52,7 @@ def create_name_lookup(
         """Same as regular lookup but aware of the fact that the address is a pointer.
         Indirect implies exact search, so we drop both parameters from the lookup entry point.
         """
-        entity = db_getter(addr, True)
+        entity = db_getter(addr, exact=True)
         if entity is not None:
             # If the indirect call points at a variable initialized to a function,
             # prefer the variable name as this is more useful.
@@ -88,7 +92,7 @@ def create_name_lookup(
         if indirect:
             return indirect_lookup(addr)
 
-        entity = db_getter(addr, exact)
+        entity = db_getter(addr, exact=exact)
 
         if entity is None:
             return None

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -374,7 +374,11 @@ class EntityDb:
         cur.row_factory = matched_entity_factory
         return cur.fetchone()
 
-    def get_by_orig(self, addr: int, exact: bool = True) -> ReccmpEntity | None:
+    def get_by_orig(self, addr: int, *, exact: bool = True) -> ReccmpEntity | None:
+        """Return the ReccmpEntity at the given orig address.
+        If there is no entry for the address and exact=True (default), return None.
+        Otherwise, return the entity at the preceding orig address if it exists.
+        The caller should check the entity's size to make sure it covers the address."""
         if exact:
             query = "SELECT * FROM entity_factory WHERE orig_addr = ?"
         else:
@@ -384,7 +388,11 @@ class EntityDb:
         cur.row_factory = entity_factory
         return cur.fetchone()
 
-    def get_by_recomp(self, addr: int, exact: bool = True) -> ReccmpEntity | None:
+    def get_by_recomp(self, addr: int, *, exact: bool = True) -> ReccmpEntity | None:
+        """Return the ReccmpEntity at the given recomp address.
+        If there is no entry for the address and exact=True (default), return None.
+        Otherwise, return the entity at the preceding recomp address if it exists.
+        The caller should check the entity's size to make sure it covers the address."""
         if exact:
             query = "SELECT * FROM entity_factory WHERE recomp_addr = ?"
         else:

--- a/reccmp/isledecomp/compare/functions.py
+++ b/reccmp/isledecomp/compare/functions.py
@@ -7,8 +7,11 @@ from itertools import pairwise
 from typing import Callable, Iterator, NamedTuple
 from reccmp.isledecomp.compare.asm.fixes import assert_fixup, find_effective_match
 from reccmp.isledecomp.compare.asm.parse import AsmExcerpt, ParseAsm
-from reccmp.isledecomp.compare.asm.replacement import create_name_lookup
-from reccmp.isledecomp.compare.db import EntityDb, ReccmpEntity, ReccmpMatch
+from reccmp.isledecomp.compare.asm.replacement import (
+    AddrLookupProtocol,
+    create_name_lookup,
+)
+from reccmp.isledecomp.compare.db import EntityDb, ReccmpMatch
 from reccmp.isledecomp.compare.diff import CombinedDiffOutput, DiffReport, combined_diff
 from reccmp.isledecomp.compare.event import ReccmpEvent, ReccmpReportProtocol
 from reccmp.isledecomp.formats.exceptions import (
@@ -31,7 +34,7 @@ def timestamp_string() -> str:
 
 
 def create_valid_addr_lookup(
-    db_getter: Callable[[int, bool], ReccmpEntity | None],
+    db_getter: AddrLookupProtocol,
     is_recomp: bool,
     bin_file: PEImage,
 ) -> Callable[[int], bool]:
@@ -47,7 +50,7 @@ def create_valid_addr_lookup(
             return True
 
         # Check whether the address points to valid data
-        entity = db_getter(addr, False)
+        entity = db_getter(addr, exact=False)
         if entity is None:
             return False
         base_addr = entity.recomp_addr if is_recomp else entity.orig_addr

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -72,6 +72,63 @@ def test_db_all_order(db):
     ]
 
 
+def test_get_by_exact(db):
+    """get_by_orig and get_by_recomp have two parameters: the address and the 'exact' option.
+    If exact=False, we return the entity at the address OR one at the preceding address if it exists.
+    """
+
+    with db.batch() as batch:
+        batch.set_orig(100)
+        batch.set_recomp(100)
+
+    # If there is an exact addr match, return the entity.
+    assert db.get_by_orig(100) is not None
+    assert db.get_by_orig(100, exact=True) is not None
+    assert db.get_by_orig(100, exact=False) is not None
+    assert db.get_by_recomp(100) is not None
+    assert db.get_by_recomp(100, exact=True) is not None
+    assert db.get_by_recomp(100, exact=False) is not None
+
+    # If there is no exact match, return None.
+    assert db.get_by_orig(200) is None
+    assert db.get_by_orig(200, exact=True) is None
+    assert db.get_by_recomp(200) is None
+    assert db.get_by_recomp(200, exact=True) is None
+
+    # Return the preceding entity if exact=False.
+    assert db.get_by_orig(200, exact=False) is not None
+    assert db.get_by_recomp(200, exact=False) is not None
+
+    # Should only return the preceding entity if one exists.
+    assert db.get_by_orig(50, exact=False) is None
+    assert db.get_by_recomp(50, exact=False) is None
+
+
+def test_get_by_exact_keyword(db):
+    """For get_by_orig and get_by_recomp, the 'exact' keyword must be used to set its value."""
+
+    # Fails without 'exact' keyword
+    with pytest.raises(TypeError):
+        db.get_by_orig(100, False)
+
+    with pytest.raises(TypeError):
+        db.get_by_orig(100, True)
+
+    with pytest.raises(TypeError):
+        db.get_by_recomp(100, True)
+
+    with pytest.raises(TypeError):
+        db.get_by_recomp(100, False)
+
+    # Succeeds with 'exact' keyword or if it the parameter is omitted.
+    db.get_by_orig(100)
+    db.get_by_orig(100, exact=False)
+    db.get_by_orig(100, exact=True)
+    db.get_by_recomp(100)
+    db.get_by_recomp(100, exact=False)
+    db.get_by_recomp(100, exact=True)
+
+
 #### Testing new batch API ####
 
 

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -104,21 +104,22 @@ def test_get_by_exact(db):
     assert db.get_by_recomp(50, exact=False) is None
 
 
-def test_get_by_exact_keyword(db):
+def test_get_by_exact_keyword(db: EntityDb):
     """For get_by_orig and get_by_recomp, the 'exact' keyword must be used to set its value."""
 
-    # Fails without 'exact' keyword
+    # Should fail if called without the 'exact' keyword.
+    # Disable mypy checking for these calls because we've intentionally created a typing error.
     with pytest.raises(TypeError):
-        db.get_by_orig(100, False)
+        db.get_by_orig(100, False)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_orig(100, True)
+        db.get_by_orig(100, True)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_recomp(100, True)
+        db.get_by_recomp(100, True)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_recomp(100, False)
+        db.get_by_recomp(100, False)  # type: ignore
 
     # Succeeds with 'exact' keyword or if it the parameter is omitted.
     db.get_by_orig(100)


### PR DESCRIPTION
Fixes #155. The code reads better with `exact` as a required keyword arg.

The behavior of `exact` was not covered thoroughly or directly by the existing tests, so I added two new ones.