### PR TITLE
Fix #159 (`EntityBatch` type)

### DIFF
--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -243,7 +243,7 @@ class EntityBatch:
 
         self.reset()
 
-    def __enter__(self):
+    def __enter__(self) -> "EntityBatch":
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
Not sure what test (if any) would fit here. This is more of a fix for `mypy` than an actual bug.