### PR TITLE
New query to detect overloaded functions

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -39,6 +39,7 @@ from .match_msvc import (
 from .db import EntityDb, ReccmpEntity, ReccmpMatch
 from .diff import DiffReport, combined_diff
 from .lines import LinesDb
+from .queries import get_overloaded_functions
 
 
 # pylint: disable=too-many-lines
@@ -710,36 +711,24 @@ class Compare:
         """Our asm sanitize will use the "friendly" name of a function.
         Overloaded functions will all have the same name. This function detects those
         cases and gives each one a unique name in the db."""
-        repeat_names: dict[str, list[tuple[int, str | None]]] = {}
-
-        # Select addresses and symbols for all repeated function names
-        for recomp_addr, name, symbol in self._db.sql.execute(
-            """SELECT recomp_addr, json_extract(kvstore,'$.name') as name, json_extract(kvstore,'$.symbol')
-            from entities where name in (
-                select json_extract(kvstore,'$.name') as name from entities
-                where json_extract(kvstore,'$.type') = ?
-                group by name having count(name) > 1
-            )""",
-            (EntityType.FUNCTION,),
-        ):
-            # TODO: Thunk's link to the original function is lost once the record is created.
-            if "Thunk of" in name:
-                continue
-
-            repeat_names.setdefault(name, []).append((recomp_addr, symbol))
-
         with self._db.batch() as batch:
-            for name, items in repeat_names.items():
-                for i, (recomp_addr, symbol) in enumerate(items, start=1):
-                    # Just number it to start, in case we don't have a symbol.
-                    new_name = f"{name}({i})"
+            for func in get_overloaded_functions(self._db):
+                # TODO: Thunk's link to the original function is lost once the record is created.
+                if "Thunk of" in func.name:
+                    continue
 
-                    if symbol is not None:
-                        dm_args = get_function_arg_string(symbol)
-                        if dm_args is not None:
-                            new_name = f"{name}{dm_args}"
+                # Just number it to start, in case we don't have a symbol.
+                new_name = f"{func.name}({func.sequence})"
 
-                    batch.set_recomp(recomp_addr, computed_name=new_name)
+                if func.symbol is not None:
+                    dm_args = get_function_arg_string(func.symbol)
+                    if dm_args is not None:
+                        new_name = f"{func.name}{dm_args}"
+
+                if func.orig_addr is not None:
+                    batch.set_orig(func.orig_addr, computed_name=new_name)
+                elif func.recomp_addr is not None:
+                    batch.set_recomp(func.recomp_addr, computed_name=new_name)
 
     def _compare_vtable(self, match: ReccmpMatch) -> DiffReport:
         vtable_size = match.size

--- a/reccmp/isledecomp/compare/queries.py
+++ b/reccmp/isledecomp/compare/queries.py
@@ -1,0 +1,38 @@
+from typing import Iterable, NamedTuple
+from reccmp.isledecomp.types import EntityType
+from .db import EntityDb
+
+
+class OverloadedFunctionEntity(NamedTuple):
+    orig_addr: int | None
+    recomp_addr: int | None
+    name: str
+    symbol: str | None
+    # The number for this repeated name, starting at 1, ordered by orig_addr (nulls last), then recomp_addr.
+    sequence: int
+
+
+def get_overloaded_functions(db: EntityDb) -> Iterable[OverloadedFunctionEntity]:
+    """Find each function that has a non-unique name shared with other function entities.
+    Uses a SQL window function to get the number for the repeated name so the caller
+    doesn't need to keep track. We assume that a better name can be derived from
+    the entity's symbol so we return that too."""
+    for orig_addr, recomp_addr, name, symbol, sequence in db.sql.execute(
+        """SELECT orig_addr, recomp_addr,
+        json_extract(kvstore,'$.name') as name,
+        json_extract(kvstore,'$.symbol'),
+        Row_number() OVER (partition BY json_extract(kvstore,'$.name') ORDER BY orig_addr nulls last, recomp_addr)
+        from entities where json_extract(kvstore,'$.type') = ?
+            and name in (
+            select json_extract(kvstore,'$.name') as name from entities
+            where json_extract(kvstore,'$.type') = ?
+            and name is not null
+            group by name having count(name) > 1
+        )""",
+        (EntityType.FUNCTION, EntityType.FUNCTION),
+    ):
+        assert isinstance(orig_addr, int) or isinstance(recomp_addr, int)
+        assert isinstance(name, str)
+        assert isinstance(symbol, str) or symbol is None
+        assert isinstance(sequence, int)
+        yield OverloadedFunctionEntity(orig_addr, recomp_addr, name, symbol, sequence)

--- a/tests/test_compare_db_queries.py
+++ b/tests/test_compare_db_queries.py
@@ -1,0 +1,62 @@
+"""Testing results of complex queries on the entity database"""
+
+import pytest
+from reccmp.isledecomp.compare.db import EntityDb
+from reccmp.isledecomp.compare.queries import get_overloaded_functions
+from reccmp.isledecomp.types import EntityType
+
+
+@pytest.fixture(name="db")
+def fixture_db():
+    return EntityDb()
+
+
+def test_overloaded_functions_all_unique(db: EntityDb):
+    # Should start with nothing
+    assert len([*get_overloaded_functions(db)]) == 0
+
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+        batch.set_orig(200, name="Test", type=EntityType.FUNCTION)
+        batch.set_recomp(300, name="xyz", type=EntityType.FUNCTION)
+
+    # All entities are functions, but their names are unique.
+    assert len([*get_overloaded_functions(db)]) == 0
+
+
+def test_overloaded_functions_ignore_non_functions(db: EntityDb):
+    with db.batch() as batch:
+        batch.set_orig(100, name="Hello")
+        batch.set_orig(200, name="Hello")
+        batch.set_recomp(300, name="Hello")
+
+    # Name reused, but no entities are functions.
+    assert len([*get_overloaded_functions(db)]) == 0
+
+    with db.batch() as batch:
+        batch.set_orig(400, name="Hello", type=EntityType.FUNCTION)
+
+    # The name is not shared with *other* functions
+    assert len([*get_overloaded_functions(db)]) == 0
+
+    with db.batch() as batch:
+        batch.set_recomp(400, name="Hello", type=EntityType.FUNCTION)
+
+    # Now we have two entities that are functions and have the same name.
+    # Don't count the other entities that are *not* functions.
+    assert [func.sequence for func in get_overloaded_functions(db)] == [1, 2]
+
+
+def test_overloaded_functions(db: EntityDb):
+    with db.batch() as batch:
+        # Inserted in reverse order to test sequence numbering
+        batch.set_recomp(300, name="Hello", type=EntityType.FUNCTION)
+        batch.set_recomp(200, name="Hello", type=EntityType.FUNCTION)
+        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+        batch.match(200, 200)
+
+    # Should have three entities, one matched, all functions and all with the name "Hello".
+    overloaded = list(get_overloaded_functions(db))
+    assert [func.sequence for func in overloaded] == [1, 2, 3]
+    assert [func.orig_addr for func in overloaded] == [100, 200, None]
+    assert [func.recomp_addr for func in overloaded] == [None, 200, 300]


### PR DESCRIPTION
More thoroughly addresses the specific regression indicated in #152 and #153.

The type fix in #161 was needed for `mypy` to alert to the code calling `set_orig` or `set_recomp` where the address parameter might be null. This isn't caught if the assumed type is `Any`, hence the reason for moving this query into its own module.

I'm not sure why the old query only considered functions that had a recomp address, but now we can update using whatever address we have.

If the intended effect is to halt if our typing assert  fails (as shown here) then we should repurpose #153 to do the same but at the sqlite level.