### PR TITLE
Fixes parsing global variables with underscores

### DIFF
--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -105,19 +105,13 @@ def get_class_name(line: str) -> str | None:
     return None
 
 
-global_regex = re.compile(r"(?P<name>(?:\w+::)*g_\w+)")
-less_strict_global_regex = re.compile(r"(?P<name>(?:\w+::)*\w+)(?:\)\(|\[.*|\s*=.*|;)")
+global_regex = re.compile(r"(?P<name>(?:\w+::)*\w+)(?:\)\(|\[.*|\s*=.*|;)")
 
 
 def get_variable_name(line: str) -> str | None:
-    """Grab the name of the variable annotated with the GLOBAL marker.
-    Correct syntax would have the variable start with the prefix "g_"
-    but we will try to match regardless."""
+    """Grab the name of the variable annotated with the GLOBAL marker."""
 
     if (match := global_regex.search(line)) is not None:
-        return match.group("name")
-
-    if (match := less_strict_global_regex.search(line)) is not None:
         return match.group("name")
 
     return None

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -162,6 +162,7 @@ variable_name_cases = [
     ("char hello[50];", "hello"),
     ("char hello[50] = {1234,", "hello"),
     ("int hello = 500;", "hello"),
+    ("char* gBoring_material_names[2];", "gBoring_material_names"),
 ]
 
 


### PR DESCRIPTION
The original `global_regex` made an assumption that all global variables follow a pattern like `g_xxx`. 

This assumption caused an incorrect result with a global variable like `char* gBoring_material_names[2];`, which was parsed as `g_material_names`.

This PR uses the original "less strict" regex in all cases, and adds a test which fails on current `master` but passes with this change.