### PR TITLE
Fix false effective match for data table

### DIFF
--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -194,8 +194,11 @@ def _is_relocatable(instr: str) -> bool:
     Excludes certain instructions whose relocation will always change the logic
     to be considered for an effective match.
     """
-    # Do not relocate jump table entries (this most likely influences the behaviour)
     if instr.startswith("start +"):
+        # Do not relocate jump table entries (this most likely influences the behaviour)
+        return False
+    if instr.startswith("0x"):
+        # Do not relocate data table entries (this most likely influences the behaviour)
         return False
     return True
 

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -408,10 +408,15 @@ def test_jump_table_wrong_order(db: EntityDb, report: ReccmpReportProtocol):
     Jump tables with the correct entries in the wrong order.
     In particular, this must not become an accidental effective match.
     """
-    orig = b"\xff\x24\x85\x07\x02\x00\x00\x33\x04\x00\x00\x43\x04\x00\x00"
-    recm = b"\xff\x24\x85\x07\x04\x00\x00\x43\x06\x00\x00\x33\x06\x00\x00"
+    orig = (
+        # jmp dword ptr [eax * 4 + $jump_table]
+        b"\xff\x24\x85\x07\x02\x00\x00"
+        # $jump_table:
+        + b"\x33\x04\x00\x00\x43\x04\x00\x00"
+    )
+    recm = b"\xff\x24\x85\x07\x04\x00\x00" + b"\x43\x06\x00\x00\x33\x06\x00\x00"
 
-    # Required to get an `<OFFSET1> into the jump instruction`
+    # Required to get an `<OFFSET1>` into the jump instruction
     is_relocated_addr = Mock(return_value=True)
     diffreport = compare_functions(db, orig, recm, report, is_relocated_addr)
 
@@ -431,6 +436,59 @@ def test_jump_table_wrong_order(db: EntityDb, report: ReccmpReportProtocol):
                 {"orig": [], "recomp": [("0x407", "start + 0x243")]},
                 {"both": [("0x207", "start + 0x233", "0x40b")]},
                 {"orig": [("0x20b", "start + 0x243")], "recomp": []},
+            ],
+        )
+    ]
+
+
+def test_data_table_wrong_order(db: EntityDb, report: ReccmpReportProtocol):
+    """
+    Data tables with the correct entries in the wrong order.
+    In particular, this must not become an accidental effective match.
+    Inspired by LEGO1 0x10015e24.
+    """
+    orig = (
+        # mov al, byte ptr [ecx + $data_table]
+        b"\x8a\x81\x15\x02\x00\x00"
+        # jmp dword ptr [eax * 4 + $jump_table]
+        + b"\xff\x24\x85\x0d\x02\x00\x00"
+        # $jump_table:
+        + b"\x33\x02\x00\x00\x43\x02\x00\x00"
+        # $data_table:
+        + b"\x05\x02\x03\x00\x03"
+    )
+    recm = (
+        b"\x8a\x81\x15\x04\x00\x00"
+        + b"\xff\x24\x85\x0d\x04\x00\x00"
+        + b"\x33\x04\x00\x00\x43\x04\x00\x00"
+        + b"\x03\x02\x05\x00\x03"
+    )
+
+    # Required to get an `<OFFSET1>` into the jump instruction
+    is_relocated_addr = Mock(return_value=True)
+    diffreport = compare_functions(db, orig, recm, report, is_relocated_addr)
+
+    assert diffreport.ratio < 1.0
+    assert diffreport.is_effective_match is False
+
+    assert diffreport.udiff == [
+        (
+            "@@ -,11 +,11 @@",
+            [
+                {
+                    "both": [
+                        ("0x200", "mov al, byte ptr [ecx + <OFFSET1>]", "0x400"),
+                        ("0x206", "jmp dword ptr [eax*4 + <OFFSET2>]", "0x406"),
+                        ("", "Jump table:", ""),
+                        ("0x20d", "start + 0x33", "0x40d"),
+                        ("0x211", "start + 0x43", "0x411"),
+                        ("", "Data table:", ""),
+                    ]
+                },
+                {"orig": [], "recomp": [("0x415", "0x3"), ("0x416", "0x2")]},
+                {"both": [("0x215", "0x5", "0x417")]},
+                {"orig": [("0x216", "0x2"), ("0x217", "0x3")], "recomp": []},
+                {"both": [("0x218", "0x0", "0x418"), ("0x219", "0x3", "0x419")]},
             ],
         )
     ]


### PR DESCRIPTION
Closes #135 (again)

This fixes the false effective match we saw in LEGO1 at https://github.com/isledecomp/isle/pull/1601.

TODO:
- [x] Add test