### PR TITLE
Adds function filtering to the compare report

### DIFF
--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -40,6 +40,17 @@ class YmlGhidraConfig(BaseModel):
         return cls(ignore_types=[], ignore_functions=[])
 
 
+class YmlReportConfig(BaseModel):
+    ignore_functions: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("ignore-functions", "ignore_functions"),
+    )
+
+    @classmethod
+    def default(cls) -> "YmlReportConfig":
+        return cls(ignore_functions=[])
+
+
 @dataclass
 class Hash:
     sha256: str
@@ -54,6 +65,7 @@ class ProjectFileTarget(BaseModel):
     )
     hash: Hash
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
+    report: YmlReportConfig = Field(default_factory=YmlReportConfig.default)
 
 
 class ProjectFile(YmlFileModel):

--- a/reccmp/project/create.py
+++ b/reccmp/project/create.py
@@ -13,7 +13,7 @@ from .config import (
     UserFileTarget,
 )
 from .common import RECCMP_PROJECT_CONFIG, RECCMP_USER_CONFIG, RECCMP_BUILD_CONFIG
-from .detect import RecCmpProject, RecCmpPartialTarget, GhidraConfig
+from .detect import RecCmpProject, RecCmpPartialTarget, GhidraConfig, ReportConfig
 from .error import RecCmpProjectException
 from .util import get_path_sha256, unique_targets
 
@@ -225,6 +225,7 @@ def create_project(
             sha256=hash_sha256,
             source_root=project_directory,
             ghidra_config=GhidraConfig(),
+            report_config=ReportConfig(),
         )
 
     # Write project YAML file

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -237,6 +237,13 @@ def main():
     report = ReccmpStatusReport(filename=target.original_path.name.lower())
 
     for match in isle_compare.compare_all():
+        # if we are ignoring this function, skip to next one and don't add it to the entities list
+        if (
+            match.match_type == EntityType.FUNCTION
+            and match.name in target.report_config.ignore_functions
+        ):
+            continue
+
         if not args.silent and args.diff is None:
             print_match_oneline(
                 match, show_both_addrs=args.print_rec_addr, is_plain=args.no_color


### PR DESCRIPTION
Project file now supports an `ignore_functions` list for functions that should not appear in the final report, and paves the way for future report-specific fields

Example:
```
targets:
  CARM95:
    filename: carm95.exe
    source_root: src
    hash:
      sha256: c6040203856b71e6a22d2a29053a1eadd1a2ab41bce97b6031d745079bc07bdf
    report:
      ignore_functions: [
        "BrActorToActorMatrix34",
        "BrActorRelink",
        ...
     ]
```

In my case, some functions are coming from a now open source library (https://github.com/dethrace-labs/BRender-v1.3.2), and are not expected to be a binary match since the original was not compiled with MSVC 4.2.

Being able to ignore those functions makes the percentage complete numbers meaningful ✨ 