### PR TITLE
Support loading (some) data from CSV

### DIFF
--- a/reccmp/isledecomp/compare/csv.py
+++ b/reccmp/isledecomp/compare/csv.py
@@ -1,0 +1,116 @@
+"""Parsing files in csv format.
+The python csv.DictReader class does the heavy lifting.
+We begin with a pre-processing step that removes blank lines or "comment" lines that begin with # or //.
+The delimiter is decided based on the first line (following pre-processing). Options are: pipe, comma, tab
+"""
+
+import csv
+from csv import Error as PythonCsvError
+from typing import Iterable, Iterator
+
+
+class ReccmpCsvParserError(Exception):
+    """Catch-all for csv parsing errors."""
+
+
+class CsvNoAddressError(ReccmpCsvParserError):
+    """This row does not have an address attribute."""
+
+
+class CsvMultipleAddressError(ReccmpCsvParserError):
+    """This row has more than one address attribute
+    (and it's not clear which one we should use)."""
+
+
+class CsvInvalidAddressError(ReccmpCsvParserError):
+    """The address value is not a valid hex number."""
+
+
+class CsvNoDelimiterError(ReccmpCsvParserError):
+    """No obvious delimiter on the first line."""
+
+
+CsvValueOptions = int | str | bool
+CsvValuesType = dict[str, CsvValueOptions]
+
+
+def _boolify(text: str) -> bool:
+    """str to bool conversion. If the string is not in the exclusion list, resolve to True."""
+    return text.strip().lower() not in ("false", "off", "no", "0", "")
+
+
+def _csv_preprocess(lines: Iterable[str]) -> Iterator[str]:
+    """Pre-processing of CSV file."""
+    for line in lines:
+        strip = line.strip()
+        # Skip comment lines
+        if strip.startswith("#") or strip.startswith("//"):
+            continue
+
+        # Skip blank lines.
+        if strip == "":
+            continue
+
+        yield line
+
+
+def _convert_attrs(
+    values: Iterable[tuple[str, str]],
+) -> Iterator[tuple[str, CsvValueOptions]]:
+    """Both a filter and a conversion step for the row values.
+    For the incoming iterable of key/value pairs, only output the ones we want set
+    in the reccmp database. Some keys have their value converted to a different type."""
+    for key, value in values:
+        if key == "symbol":
+            yield (key, value)
+
+        if key == "skip":
+            yield (key, _boolify(value))
+
+
+def _csv_convert(row: dict[str, str]) -> tuple[int, CsvValuesType]:
+    """Pull out the address from the CSV row and convert the remaining key/value pairs."""
+    for key in ("address", "addr"):
+        if key in row:
+            addr_value = row[key]
+            break
+
+    # Addr is always a hex number
+    try:
+        addr = int(addr_value, 16)
+    except ValueError as ex:
+        raise CsvInvalidAddressError from ex
+
+    attrs = list(_convert_attrs(row.items()))
+    return (addr, dict(attrs))
+
+
+def csv_parse(lines: str | Iterable[str]) -> Iterator[tuple[int, CsvValuesType]]:
+    """Read each line from the csv file and output each address and its key/value pairs."""
+    if isinstance(lines, str):
+        lines = lines.split("\n")
+
+    preprocessed = list(_csv_preprocess(lines))
+
+    try:
+        # Use the first line (only) to find the delimiter
+        dialect = csv.Sniffer().sniff(preprocessed[0], delimiters="|,\t")
+    except PythonCsvError as ex:
+        raise CsvNoDelimiterError from ex
+
+    reader = csv.DictReader(preprocessed, dialect=dialect)
+
+    # Could this happen?
+    if reader.fieldnames is None:
+        raise CsvNoDelimiterError
+
+    # We support multiple options for address key, but exactly one must appear.
+    addrs = [key for key in ("address", "addr") if key in reader.fieldnames]
+    if not addrs:
+        raise CsvNoAddressError
+
+    if len(addrs) > 1:
+        raise CsvMultipleAddressError
+
+    for row in reader:
+        yield _csv_convert(row)

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -53,6 +53,10 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("source-root", "source_root")
     )
     hash: Hash
+    csv_files: list[Path] = Field(
+        validation_alias=AliasChoices("csv", "csv_files", "csv-files"),
+        default_factory=list,
+    )
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
 
 

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -117,6 +117,9 @@ class RecCmpPartialTarget:
     recompiled_path: Path | None = None
     recompiled_pdb: Path | None = None
 
+    # Data to set directly in the database (addresses refer to orig binary)
+    csv_files: list[Path] | None = None
+
 
 @dataclass
 class RecCmpTarget:
@@ -146,6 +149,9 @@ class RecCmpTarget:
     original_path: Path
     recompiled_path: Path
     recompiled_pdb: Path
+
+    # Data to set directly in the database (addresses refer to orig binary)
+    csv_files: list[Path] = field(default_factory=list)
 
 
 class RecCmpProject:
@@ -204,6 +210,8 @@ class RecCmpProject:
         else:
             ghidra = GhidraConfig()
 
+        csv_files = target.csv_files or []
+
         return RecCmpTarget(
             target_id=target.target_id,
             filename=target.filename,
@@ -213,6 +221,7 @@ class RecCmpProject:
             recompiled_pdb=target.recompiled_pdb,
             source_root=target.source_root,
             ghidra_config=ghidra,
+            csv_files=csv_files,
         )
 
     def find_build_config(self, search_path: Path) -> BuildFile | None:
@@ -297,7 +306,10 @@ class RecCmpProject:
             else:
                 ghidra = None
 
+            # Assumes these are relative paths. If they are not, the second path
+            # will replace the first instead of adding onto it.
             source_root = project_directory / target.source_root
+            csv_files = [project_directory / csv_path for csv_path in target.csv_files]
 
             project.targets[target_id] = RecCmpPartialTarget(
                 target_id=target_id,
@@ -305,6 +317,7 @@ class RecCmpProject:
                 sha256=target.hash.sha256,
                 source_root=source_root,
                 ghidra_config=ghidra,
+                csv_files=csv_files,
             )
 
         # Apply reccmp-user.yml

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,0 +1,258 @@
+from textwrap import dedent
+import pytest
+from reccmp.isledecomp.compare.csv import (
+    csv_parse,
+    CsvNoAddressError,
+    CsvMultipleAddressError,
+    CsvInvalidAddressError,
+    CsvNoDelimiterError,
+)
+
+
+def test_no_delimiter():
+    """Must have a delimiter. Having just one column isn't very useful."""
+    with pytest.raises(CsvNoDelimiterError):
+        list(csv_parse("addr"))
+
+
+def test_valid_addr_column():
+    """The only requirement is that there is a single address column and a delimiter."""
+    list(csv_parse("addr|symbol"))
+    list(csv_parse("address|symbol"))
+
+
+def test_no_address_column():
+    """Cannot parse any rows if there is no address column."""
+    with pytest.raises(CsvNoAddressError):
+        list(csv_parse("symbol|test"))
+
+
+def test_multiple_address_column():
+    """Cannot parse any rows if there is not a single address column."""
+    with pytest.raises(CsvMultipleAddressError):
+        list(csv_parse("address|symbol|addr"))
+
+
+def test_value_includes_delimiter():
+    """If the value contains the delimiter, we can still parse it correctly
+    if the value is quoted. This is a feature of the python csv module."""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+        address,symbol
+        1000,"hello,world"
+    """
+            )
+        )
+    ]
+
+    assert values == [(0x1000, {"symbol": "hello,world"})]
+
+
+def test_ignore_columns():
+    """We only parse certain columns that correspond to attribute names in the database."""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+        address|symbol|test
+        1000|hello|123
+    """
+            )
+        )
+    ]
+
+    assert values == [(0x1000, {"symbol": "hello"})]
+
+
+def test_address_not_hex():
+    """Raise an exception if we cannot parse the address on one of the rows."""
+    with pytest.raises(CsvInvalidAddressError):
+        list(
+            csv_parse(
+                dedent(
+                    """\
+            addr|symbol
+            wrong|test
+        """
+                )
+            )
+        )
+
+
+def test_too_many_columns():
+    """Should ignore extra values in a row."""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+        addr|symbol
+        1000|hello|world
+    """
+            )
+        )
+    ]
+
+    assert values == [(0x1000, {"symbol": "hello"})]
+
+
+def test_should_output_bool():
+    """Return bool for certain column values, with some flexibility around possible text values."""
+
+    # Using "skip" as an example of a columm where we convert from str to bool:
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+                addr|skip
+                1000|1
+                2000|yes
+                3000|no
+                4000|FALSE
+                5000|0
+                6000|
+            """
+            )
+        )
+    ]
+
+    # To make the following code cleaner
+    skip_map = {addr: row["skip"] for addr, row in values}
+
+    # Any text is considered true...
+    assert skip_map[0x1000] is True
+    assert skip_map[0x2000] is True
+
+    # except the values for these columns
+    assert skip_map[0x3000] is False
+    assert skip_map[0x4000] is False
+    assert skip_map[0x5000] is False
+
+    # Empty string considered false
+    assert skip_map[0x6000] is False
+
+
+def test_ignore_blank_lines():
+    """Parsing should ignore blank lines.
+    n.b. make sure the triple quote string and dedent() remove leading spaces."""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+
+                addr|symbol
+
+                1000|test
+
+                2000|test
+
+
+                3000|test
+            """
+            )
+        )
+    ]
+
+    assert values == [
+        (0x1000, {"symbol": "test"}),
+        (0x2000, {"symbol": "test"}),
+        (0x3000, {"symbol": "test"}),
+    ]
+
+
+def test_ignore_comments():
+    """We ignore any line starting with // or #."""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+                # Test CSV file
+                addr|symbol
+                # 1000|test
+                2000|test
+                // 3000|test
+            """
+            )
+        )
+    ]
+
+    assert values == [(0x2000, {"symbol": "test"})]
+
+
+def test_tab_delimiter():
+    """We support tab as an option for delimiter. (It is not covered in the other tests.)"""
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+                addr\tsymbol
+                1000\ttest
+                2000\ttest
+                3000\ttest
+            """
+            )
+        )
+    ]
+
+    assert values == [
+        (0x1000, {"symbol": "test"}),
+        (0x2000, {"symbol": "test"}),
+        (0x3000, {"symbol": "test"}),
+    ]
+
+
+def test_emulate_file_reads():
+    """The tests thus far have used a string, which is split on the newline.
+    This means each line is *missing* the newline. Make sure we can still parse if
+    we are reading line-by-line, as from a file."""
+
+    # Mix of comments and blank lines
+    file = iter(
+        ["# Comment\n", "\n", "addr|symbol\n", "\n", "1000|test\n", "\n", "2000|test\n"]
+    )
+    values = [*csv_parse(file)]
+
+    assert values == [
+        (0x1000, {"symbol": "test"}),
+        (0x2000, {"symbol": "test"}),
+    ]
+
+
+def test_address_not_first():
+    """Since the address is the unique id for the annotation, it will probably appear first in most cases.
+    However, this is not required."""
+
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+                symbol|skip|addr
+                test|1|1000
+                test|0|2000
+            """
+            )
+        )
+    ]
+
+    addrs = [addr for addr, _ in values]
+    assert addrs == [0x1000, 0x2000]
+
+
+def test_address_repeated():
+    """The address can appear more than once and we will parse it correctly.
+    It's up to the caller to decide how to handle this."""
+
+    values = [
+        *csv_parse(
+            dedent(
+                """\
+                addr|skip
+                1000|1
+                1000|0
+            """
+            )
+        )
+    ]
+
+    assert values == [(0x1000, {"skip": True}), (0x1000, {"skip": False})]

--- a/tests/test_project_yml.py
+++ b/tests/test_project_yml.py
@@ -1,0 +1,41 @@
+"""Testing items specific to YML parsing/pydantic validation"""
+
+from pathlib import Path
+from reccmp.project.config import ProjectFile
+
+
+def test_project_without_csv():
+    """Make sure we can parse a target even if the 'csv' field is not defined."""
+
+    p = ProjectFile.from_str(
+        """\
+        targets:
+            TEST:
+                source-root: test
+                hash:
+                    sha256: test
+                filename: test.exe
+        """
+    )
+
+    assert p.targets["TEST"].csv_files == []
+
+
+def test_project_with_csv_list():
+    """Parse the list of csv paths."""
+
+    p = ProjectFile.from_str(
+        """\
+        targets:
+            TEST:
+                source-root: test
+                hash:
+                    sha256: test
+                filename: test.exe
+                csv:
+                - file0.csv
+                - file1.csv
+        """
+    )
+
+    assert p.targets["TEST"].csv_files == [Path("file0.csv"), Path("file1.csv")]


### PR DESCRIPTION
This adds support for loading annotations for the original binary from a CSV text file. This initial PR supports only limited data as I'll explain in a moment.

## YML

The list of files goes in your `reccmp-project.yml` file like so:

```yml
  BETA10:
    filename: BETA10.DLL
    source-root: LEGO1
    hash:
      sha256: d91435a40fa31f405fba33b03bd3bd40dcd4ca36ccf8ef6162c6c5ca0d7190e7
    csv:
      - LEGO1/annotations/mxatom.csv
```

You can use the keys `csv`, `csv-files` or `csv_files`. We expect a list of paths relative to the project root even if there is only one file to load. The paths should point to each CSV file directly. We don't support globs or loading all files from a directory yet.

## CSV format

When reading the file, we ignore blank lines and lines that begin with comment indicators `#` or `//`.

The options for delimiter in the CSV file are: pipe, comma, or tab. The delimiter is chosen by reading the first (non-blank and non-commented) line.

For example:

```
# STL functions for MxAtom set (BETA10)

addr|symbol
0x101237a0|??Dconst_iterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@QBEABQAVMxAtom@@XZ
0x101237d0|?_Value@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@KAAAPAVMxAtom@@PAU_Node@1@@Z
0x101237f0|?end@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@QBE?AVconst_iterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@XZ
...
```

The CSV file must contain the address as one of the columns, and it must appear only once. You can use either `address` or `addr` as the name for the column. The address is required to be a hex number. The `0x` prefix is optional. I expect that the address will appear as the first column in most cases, but this is not required. (If for example you wanted to sort by alphabetical order.)


## Limitations

To get this out quickly, we only support two column values: `symbol` and `skip`. All other columns are ignored and we don't set anything in the database.

This means that there are only two real use cases at the start:

- Marking templated functions best (or only) identified by symbol, as in the above STL example.
- Specifying that a function should not be be compared or considered for the final accuracy calculation, beyond what is possible in the current code annotation language. (See #167)

