### PR TITLE
Use `pydemumble` module for MSVC demangling

### DIFF
--- a/reccmp/isledecomp/cvdump/demangler.py
+++ b/reccmp/isledecomp/cvdump/demangler.py
@@ -5,7 +5,7 @@ https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling
 
 import re
 from typing import NamedTuple
-import pydemangler  # type: ignore
+from pydemumble import demangle  # type: ignore
 
 
 class InvalidEncodedNumberError(Exception):
@@ -61,8 +61,8 @@ def get_vtordisp_name(symbol: str) -> str | None:
     """For adjuster thunk functions, the PDB will sometimes use a name
     that contains "vtordisp" but often will just reuse the name of the
     function being thunked. We want to use the vtordisp name if possible."""
-    name = pydemangler.demangle(symbol)
-    if name is None:
+    name = demangle(symbol)
+    if not name:
         return None
 
     if "`vtordisp" not in name:
@@ -83,8 +83,8 @@ def get_function_arg_string(symbol: str) -> str | None:
     # pylint: disable=c-extension-no-member
     """Demangle the given symbol and return its parameters.
     We can use this to distinguish functions with the same name."""
-    raw = pydemangler.demangle(symbol)
-    if raw is None:
+    raw = demangle(symbol)
+    if not raw:
         return None
 
     try:
@@ -97,9 +97,9 @@ def get_function_arg_string(symbol: str) -> str | None:
 def demangle_vtable(symbol: str) -> str:
     # pylint: disable=c-extension-no-member
     """Get the class name referenced in the vtable symbol."""
-    raw = pydemangler.demangle(symbol)
+    raw = demangle(symbol)
 
-    if raw is None:
+    if not raw:
         pass  # TODO: This shouldn't happen if MSVC behaves
 
     # Remove storage class and other stuff we don't care about

--- a/reccmp/isledecomp/cvdump/demangler.py
+++ b/reccmp/isledecomp/cvdump/demangler.py
@@ -5,7 +5,14 @@ https://en.wikiversity.org/wiki/Visual_C%2B%2B_name_mangling
 
 import re
 from typing import NamedTuple
-from pydemumble import demangle  # type: ignore
+from pydemumble import demangle as _demangle  # type: ignore
+
+
+def msvc_demangle(symbol: str) -> str:
+    """Wrapper for demumbler. Converts MSVC C++ symbol to a name
+    more similar to what appears in the code.
+    If no conversion is possible, return empty string."""
+    return _demangle(symbol) or ""
 
 
 class InvalidEncodedNumberError(Exception):
@@ -61,7 +68,7 @@ def get_vtordisp_name(symbol: str) -> str | None:
     """For adjuster thunk functions, the PDB will sometimes use a name
     that contains "vtordisp" but often will just reuse the name of the
     function being thunked. We want to use the vtordisp name if possible."""
-    name = demangle(symbol)
+    name = msvc_demangle(symbol)
     if not name:
         return None
 
@@ -83,7 +90,7 @@ def get_function_arg_string(symbol: str) -> str | None:
     # pylint: disable=c-extension-no-member
     """Demangle the given symbol and return its parameters.
     We can use this to distinguish functions with the same name."""
-    raw = demangle(symbol)
+    raw = msvc_demangle(symbol)
     if not raw:
         return None
 
@@ -97,7 +104,7 @@ def get_function_arg_string(symbol: str) -> str | None:
 def demangle_vtable(symbol: str) -> str:
     # pylint: disable=c-extension-no-member
     """Get the class name referenced in the vtable symbol."""
-    raw = demangle(symbol)
+    raw = msvc_demangle(symbol)
 
     if not raw:
         pass  # TODO: This shouldn't happen if MSVC behaves

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama>=0.4.6
 pystache
 pydantic==2.9.2
 ruamel.yaml
-pydemangler @ git+https://github.com/wbenny/pydemangler.git
+pydemumble==0.0.1
 # requirement of capstone due to python dropping distutils.
 # see: https://github.com/capstone-engine/capstone/issues/2223
 setuptools ; python_version >= "3.12"

--- a/tests/test_demumble.py
+++ b/tests/test_demumble.py
@@ -1,0 +1,65 @@
+"""Smoke tests for MSVC C++ symbol demangler, based on the demumble library.
+This is here to spot changes for the functions that depend on this output."""
+
+import pytest
+from reccmp.isledecomp.cvdump.demangler import msvc_demangle
+
+# pylint:disable=line-too-long
+MSVC_DEMANGLE_SAMPLES = (
+    (
+        # Symbol longer than 255 chars
+        "??0?$reverse_bidirectional_iterator@Viterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@PAVMxAtom@@AAPAV3@PAPAV3@H@@QAE@Viterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@@Z",
+        "public: __thiscall reverse_bidirectional_iterator<class _Tree<class MxAtom *, class MxAtom *, struct set<class MxAtom *, struct MxAtomCompare, class allocator<class MxAtom *>>::_Kfn, struct MxAtomCompare, class allocator<class MxAtom *>>::iterator, class MxAtom *, class MxAtom *&, class MxAtom **, int>::reverse_bidirectional_iterator<class _Tree<class MxAtom *, class MxAtom *, struct set<class MxAtom *, struct MxAtomCompare, class allocator<class MxAtom *>>::_Kfn, struct MxAtomCompare, class allocator<class MxAtom *>>::iterator, class MxAtom *, class MxAtom *&, class MxAtom **, int>(class _Tree<class MxAtom *, class MxAtom *, struct set<class MxAtom *, struct MxAtomCompare, class allocator<class MxAtom *>>::_Kfn, struct MxAtomCompare, class allocator<class MxAtom *>>::iterator)",
+    ),
+    (
+        # Truncated version of above symbol. Long symbols are only available in .cpp.s generated asm.
+        "??0?$reverse_bidirectional_iterator@Viterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$set@PAVMxAtom@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@UMxAtomCompare@@V?$allocator@PAVMxAtom@@@@@@PAVMxAtom@@AAPAV3@PAPAV3@H@@QAE@Viterator@?$_Tree@PAVMxAtom@@PAV1@U_Kfn@?$",
+        "",
+    ),
+    (
+        # vtordisp
+        "?ClassName@LegoExtraActor@@$4PPPPPPPM@A@BEPBDXZ",
+        "[thunk]: public: virtual char const * __thiscall LegoExtraActor::ClassName`vtordisp{-4, 0}'(void) const",
+    ),
+    (
+        "??8MxPalette@@QAEEAAV0@@Z",
+        "public: unsigned char __thiscall MxPalette::operator==(class MxPalette &)",
+    ),
+    (
+        "??_G?$MxListCursor@PAVLegoPathController@@@@UAEPAXI@Z",
+        "public: virtual void * __thiscall MxListCursor<class LegoPathController *>::`scalar deleting dtor'(unsigned int)",
+    ),
+    (
+        "?ConvertHSVToRGB@@YAXMMMPAM00@Z",
+        "void __cdecl ConvertHSVToRGB(float, float, float, float *, float *, float *)",
+    ),
+    (
+        # C symbol
+        "_MemPoolCheck@4",
+        "",
+    ),
+    (
+        # C symbol
+        "_fopen",
+        "",
+    ),
+    (
+        # vtable
+        "??_7PizzaMissionState@@6B@",
+        "const PizzaMissionState::`vftable'",
+    ),
+    (
+        # vtable with namespace
+        "??_7AlphaMask@MxVideoPresenter@@6B@",
+        "const MxVideoPresenter::AlphaMask::`vftable'",
+    ),
+    (
+        "??0AlphaMask@MxVideoPresenter@@QAE@ABVMxBitmap@@@Z",
+        "public: __thiscall MxVideoPresenter::AlphaMask::AlphaMask(class MxBitmap const &)",
+    ),
+)
+
+
+@pytest.mark.parametrize("symbol, result", MSVC_DEMANGLE_SAMPLES)
+def test_demangle_samples(symbol, result):
+    assert msvc_demangle(symbol) == result


### PR DESCRIPTION
We have been using the [`pydemangler`](https://github.com/wbenny/pydemangler) module for converting so-called mangled MSVC linked symbols into a more usable format. The three use cases are:
- Deriving the virtual inheritance class for a vtable, as in ``Act2Actor::`vftable'{for `LegoPathActor'}``.
- Getting the list of parameter types for an overloaded function so we can assign a more unique name.
- Getting the name of a vtordisp function. (This is no longer called as of #111)

`pydemangler` is downloaded from github; it is not published to pypi. I came across the [`pydemumble`](https://pypi.org/project/pydemumble/) module as a potential drop-in replacement. Both are based on the [`demumble`](https://github.com/nico/demumble) utility.

The only difference seems to be that a failure to demangle results in `None` with `pydemangler` but an empty string with `pydemumble`. That's easy enough to handle.

I don't see any regressions on the isledecomp binaries but I'll leave this as draft until we can do a more exhaustive comparison. (maybe throw every symbol from cvdump at both and compare what comes back)