### PR TITLE
Improved handling for import entities

### DIFF
--- a/reccmp/isledecomp/analysis/__init__.py
+++ b/reccmp/isledecomp/analysis/__init__.py
@@ -1,3 +1,4 @@
 from .float_const import find_float_consts
+from .imports import find_import_thunks
 from .string_const import is_likely_latin1
 from .vtordisp import find_vtordisp

--- a/reccmp/isledecomp/analysis/imports.py
+++ b/reccmp/isledecomp/analysis/imports.py
@@ -1,0 +1,56 @@
+import re
+import struct
+from typing import Iterator, NamedTuple
+from reccmp.isledecomp.formats import PEImage
+
+
+# Match 6 byte absolute jump instructions.
+ABS_JUMP_RE = re.compile(rb"(?<=\xff\x25).{4}", flags=re.S)
+
+
+class ImportThunk(NamedTuple):
+    addr: int
+    import_addr: int
+    # The size of the JMP instruction for the thunk
+    # (i.e. the size of the thunk function)
+    size: int
+    dll_name: str
+    func_name: str
+
+
+def find_absolute_jumps_in_bytes(
+    raw: bytes, base_addr: int = 0
+) -> Iterator[tuple[int, int]]:
+    """Search the given binary blob for 6-byte JMP instructions.
+    Return the address/offset of the jump and its destination.
+    If the base addr is given, add it to the offset of the instruction to get an absolute address.
+    """
+    for match in ABS_JUMP_RE.finditer(raw):
+        (jmp_dest,) = struct.unpack("<I", match.group(0))
+        yield (base_addr + match.start() - 2, jmp_dest)
+
+
+def find_import_thunks(image: PEImage) -> Iterator[ImportThunk]:
+    """Imported functions may generate a thunk function somewhere in the code section.
+    These are 6-byte JMP instructions with absolute offset.
+    The functions given may or may not be thunks. For example: MSVC  _getSystemCP function
+    """
+
+    import_addrs = {i[2]: i for i in image.get_imports()}
+    if not import_addrs:
+        return
+
+    # TODO: Should check all code sections.
+    code_sections = (image.get_section_by_name(".text"),)
+
+    for sect in code_sections:
+        for addr, jmp_dest in find_absolute_jumps_in_bytes(
+            sect.view, sect.virtual_address
+        ):
+            if addr + 2 not in image.relocations:
+                continue
+
+            if jmp_dest in import_addrs:
+                (dll_name, func_name, _) = import_addrs[jmp_dest]
+
+                yield ImportThunk(addr, jmp_dest, 6, dll_name, func_name)

--- a/reccmp/isledecomp/compare/asm/replacement.py
+++ b/reccmp/isledecomp/compare/asm/replacement.py
@@ -60,11 +60,13 @@ def create_name_lookup(
                 return entity.match_name()
 
             if entity.entity_type == EntityType.IMPORT:
-                import_name = entity.get("import_name")
+                import_name = entity.match_name()
                 if import_name is not None:
-                    return "->" + import_name + " (FUNCTION)"
+                    return "->" + import_name
 
-                return entity.match_name()
+                # If there's no name for the import, don't bother going further.
+                # The pointer is a dead end.
+                return None
 
         # No suitable entity at the base address. Read the pointer and see what we get.
         entity = follow_indirect(addr)

--- a/tests/test_analysis_imports.py
+++ b/tests/test_analysis_imports.py
@@ -1,0 +1,35 @@
+"""Test find_import_thunks for PE images"""
+
+import pytest
+from reccmp.isledecomp.formats import PEImage
+from reccmp.isledecomp.analysis.imports import (
+    find_absolute_jumps_in_bytes,
+    find_import_thunks,
+)
+
+
+def test_absolute_jumps_overlap():
+    code = b"\xff\x25\x00\x10\xff\x25\x00\x00\x00\x10"
+    jumps = list(find_absolute_jumps_in_bytes(code))
+    assert len(jumps) == 2
+
+
+def test_lego1_import_thunks(binfile: PEImage):
+    thunks = [(thunk.addr, thunk.import_addr) for thunk in find_import_thunks(binfile)]
+    # D3DRMCreateColorRGBA
+    assert (0x100D373A, 0x1010B590) in thunks
+    # DirectDrawCreate
+    assert (0x100D3728, 0x1010B32C) in thunks
+    # RtlUnwind
+    assert (0x10098F9E, 0x1010B3D4) in thunks
+
+
+@pytest.mark.xfail(reason="Acknowledged limitation of this search.")
+def test_should_ignore_get_system_cp(binfile: PEImage):
+    """The MSVC Library function _getSystemCP is at 0x10091c50.
+    It contains a jump to GetOEMCP from KERNEL32.DLL, but this itself is not a thunk.
+    This function only searches for 6-byte JMPs an cannot tell whether the
+    address is the start of a function. We can't use the relocation table to eliminate
+    non-thunks because CALL instructions are relative (and not relocated)."""
+    thunk_addrs = [thunk.addr for thunk in find_import_thunks(binfile)]
+    assert 0x10091C6D not in thunk_addrs

--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -146,18 +146,6 @@ def test_imports(import_ref: tuple[str, str, int], binfile: PEImage):
     assert import_ref in binfile.imports
 
 
-# Location of the JMP instruction and the import address.
-THUNKS = (
-    (0x100D3728, 0x1010B32C),  # DirectDrawCreate
-    (0x10098F9E, 0x1010B3D4),  # RtlUnwind
-)
-
-
-@pytest.mark.parametrize("thunk_ref", THUNKS)
-def test_thunks(thunk_ref: tuple[int, int], binfile: PEImage):
-    assert thunk_ref in binfile.thunks
-
-
 def test_exports(binfile: PEImage):
     assert len(binfile.exports) == 130
     assert (0x1003BFB0, b"??0LegoBackgroundColor@@QAE@PBD0@Z") in binfile.exports

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -182,36 +182,34 @@ def test_indirect_import(db):
     attribute used in the result. This will probably contain the DLL and function name.
     """
     with db.batch() as batch:
-        batch.set_orig(100, import_name="Hello", name="Test", type=EntityType.IMPORT)
+        batch.set_orig(100, name="Hello", type=EntityType.IMPORT)
 
     # No mock needed here because we will not need to read any data.
     lookup = create_lookup(db)
 
-    # Should use import name with arrow to suggest indirect call.
+    # Should use arrow to suggest indirect call.
     name = lookup(100, indirect=True)
     assert name is not None
     assert "Hello" in name
     assert "->" in name
 
-    # Show the entity name instead. (e.g. __imp__ symbol)
+    # No arrow.
     name = lookup(100, indirect=False)
     assert name is not None
-    assert "Test" in name
+    assert "Hello" in name
     assert "->" not in name
 
 
-def test_indirect_import_missing_data(db):
-    """Edge cases for indirect lookup on an IMPORT entity.."""
+def test_import_without_name(db):
+    """If the import entity doesn't have a name, the lookup should return None."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test", type=EntityType.IMPORT)
+        batch.set_orig(100, type=EntityType.IMPORT)  # No name
 
     lookup = create_lookup(db)
 
-    # No import name. Use the regular entity name instead (i.e. match indirect=False lookup)
-    name = lookup(100, indirect=True)
-    assert name is not None
-    assert "Test" in name
-    assert "->" not in name
+    # Should not follow the pointer because it is an RVA, not a real virtual address.
+    assert lookup(100, indirect=True) is None
+    assert lookup(100, indirect=False) is None
 
 
 def test_indirect_failed_lookup(db):


### PR DESCRIPTION
Improved handling for import entities

### Background

Import entities are entries in the Import Address Table (IAT) for each imported DLL. They look like this in Ghidra:


```
                    ********************************************
                    *       POINTER to EXTERNAL FUNCTION       *
                    ********************************************
                    undefined Direct3DRMCreate()
         undefined    AL:1      <RETURN>
                    20  Direct3DRMCreate  <<not bound>>
                    PTR_Direct3DRMCreate_1010b594     XREF[1]: Direct3DRMCreate:100d3
   1010b594 d0 bf      addr    D3DRM.DLL::Direct3DRMCreate
            10 00

```

When the image is loaded this location is changed so it points to the virtual address of the imported function. On disk, the value is an RVA to the name of the imported function. Adding the imagebase to `0x10bfd0` we get:

```
                    ********************************************
                    * IMAGE_IMPORT_BY_NAME                     *
                    ********************************************
   1010bfd0 14 00      dw      14h
   1010bfd2 44 69      ds      "Direct3DRMCreate"
            72 65 
            63 74 
```

Some (but not all) imported functions also have thunks that look like this:


```
                    ********************************************
                    *              THUNK FUNCTION              *
                    ********************************************
                    thunk undefined Direct3DRMCreate()
                      Thunked-Function: D3DRM.DLL:
         undefined    AL:1      <RETURN>
                    D3DRM.DLL::Direct3DRMCreate       XREF[1]: CreateRenderer:100a166
   100d3734 ff 25      JMP     dword ptr [->D3DRM.DLL::Direct3D
            94 b5 
            10 10
```

### Changes

We now detect import thunks more efficiently. We can search for all absolute jump instructions (`FF 25`) and limit the results to the IAT addresses we already know. In `LEGO1` this mistakenly includes part of the library function `_getSystemCP`, but we acknowledge this limitation in the unit test file. I don't expect this to cause any disruption to users.

The function that finds import functions is under the `analysis` module instead of in `pe.py`. The `_populate_thunks` function is now only concerned with incremental build thunks. My rationale is that if we are just reading data structures from the PE image, the function should go in `pe.py`. If we are making an educated guess about the image contents or combining data from multiple sources, it should go under `analysis`.

The names for the import entities followed the convention used in the PDB: `__imp__Direct3DRMCreate`. The import thunks followed a similar pattern: `_Direct3DRMCreate`. We now use the library name plus the function name for both: `d3drm.dll::Direct3DRMCreate`, same as Ghidra. The entity type separates the two kinds of entities when we do asm sanitize. For example:

```asm
; 1.
100a166c: call d3drm.dll::Direct3DRMCreate (FUNCTION)

; 2.
100abc1c: mov ebx, dword ptr [KERNEL32.dll::QueryPerformanceFrequency (IMPORT)]
; ...
100abc2e: call ebx

; 3.
100ac013: call dword ptr [->KERNEL32.dll::QueryPerformanceCounter (IMPORT)]
```
