### PR TITLE
Match entities via `ref` attributes

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -36,6 +36,7 @@ from .match_msvc import (
     match_static_variables,
     match_variables,
     match_strings,
+    match_ref,
 )
 from .db import EntityDb, ReccmpEntity, ReccmpMatch
 from .diff import DiffReport, combined_diff
@@ -102,6 +103,7 @@ class Compare:
         self._match_thunks()
         self._match_vtordisp()
         self._check_vtables()
+        match_ref(self._db, report)
         self._unique_names_for_overloaded_functions()
 
         match_strings(self._db, report)

--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -388,3 +388,21 @@ def match_lines(
                     orig_addr,
                     f"Found no matching debug symbol for {filename}:{line}",
                 )
+
+
+def match_ref(
+    db: EntityDb,
+    _: ReccmpReportProtocol = reccmp_report_nop,
+):
+    """Matches entities that refer to the same parent entity
+    via the ref_orig and ref_recomp attributes."""
+    with db.batch() as batch:
+        for orig_addr, recomp_addr in db.sql.execute(
+            """
+            SELECT x.orig_addr, y.recomp_addr
+            FROM orig_refs x
+            INNER JOIN recomp_refs y
+            ON x.ref_id = y.ref_id and x.nth = y.nth
+            """
+        ):
+            batch.match(orig_addr, recomp_addr)


### PR DESCRIPTION
I left out some code from #177 that should have been there. Here it is. Fixes #179.

For import thunks, the `ref_orig` and `ref_recomp` attributes point back to the import entity. We can match these and any other entities (i.e. `BETA10` incremental thunks) where each side's `ref` attribute points to the same matched parent entity.