### PR TITLE
Match and name thunks using ref attribute

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -41,7 +41,7 @@ from .match_msvc import (
 from .db import EntityDb, ReccmpEntity, ReccmpMatch
 from .diff import DiffReport, combined_diff
 from .lines import LinesDb
-from .queries import get_overloaded_functions, get_thunks_and_name
+from .queries import get_overloaded_functions, get_named_thunks
 
 
 # pylint: disable=too-many-lines
@@ -593,7 +593,7 @@ class Compare:
 
     def _name_thunks(self):
         with self._db.batch() as batch:
-            for thunk in get_thunks_and_name(self._db):
+            for thunk in get_named_thunks(self._db):
                 if thunk.orig_addr is not None:
                     batch.set_orig(thunk.orig_addr, name=f"Thunk of '{thunk.name}'")
 

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -710,10 +710,6 @@ class Compare:
         cases and gives each one a unique name in the db."""
         with self._db.batch() as batch:
             for func in get_overloaded_functions(self._db):
-                # TODO: Thunk's link to the original function is lost once the record is created. See #176.
-                if "Thunk of" in func.name:
-                    continue
-
                 # Just number it to start, in case we don't have a symbol.
                 new_name = f"{func.name}({func.nth})"
 

--- a/reccmp/isledecomp/compare/queries.py
+++ b/reccmp/isledecomp/compare/queries.py
@@ -27,8 +27,11 @@ def get_overloaded_functions(db: EntityDb) -> Iterable[OverloadedFunctionEntity]
             select json_extract(kvstore,'$.name') as name from entities
             where json_extract(kvstore,'$.type') = ?
             and name is not null
+            and ref_orig is null and ref_recomp is null
             group by name having count(name) > 1
-        )""",
+        )
+        and ref_orig is null and ref_recomp is null
+        """,
         (EntityType.FUNCTION, EntityType.FUNCTION),
     ):
         assert isinstance(orig_addr, int) or isinstance(recomp_addr, int)

--- a/reccmp/isledecomp/compare/queries.py
+++ b/reccmp/isledecomp/compare/queries.py
@@ -24,12 +24,18 @@ def get_overloaded_functions(db: EntityDb) -> Iterable[OverloadedFunctionEntity]
         Row_number() OVER (partition BY json_extract(kvstore,'$.name') ORDER BY orig_addr nulls last, recomp_addr)
         from entities where json_extract(kvstore,'$.type') = ?
             and name in (
+            -- Subquery: build a list of names that are
+            -- repeated among FUNCTION entities.
             select json_extract(kvstore,'$.name') as name from entities
             where json_extract(kvstore,'$.type') = ?
             and name is not null
+            -- Ignore thunks (ref entities) because we only consider a name
+            -- to be non-unique if it is used by 2 or more real functions.
             and ref_orig is null and ref_recomp is null
             group by name having count(name) > 1
         )
+        -- Ignore any thunks using a name from our list of non-unique names.
+        -- We don't want to rename them at this stage.
         and ref_orig is null and ref_recomp is null
         """,
         (EntityType.FUNCTION, EntityType.FUNCTION),
@@ -50,10 +56,10 @@ class ThunkWithName(NamedTuple):
     name: str
 
 
-def get_thunks_and_name(db: EntityDb):
+def get_named_thunks(db: EntityDb):
     """For each entity with a ref_orig or ref_recomp attribute,
     if the parent entity is a function, return:
-        - one or both addresses
+        - one or both addresses of the referencing entity
         - the name (or computed name) of the parent entity"""
     for orig_addr, recomp_addr, name in db.sql.execute(
         """SELECT e.orig_addr, e.recomp_addr,
@@ -64,8 +70,8 @@ def get_thunks_and_name(db: EntityDb):
         WHERE name is not null
         -- Do not return rows where (for example) orig_addr and ref_recomp are set.
         -- If the entity has both ref_orig and ref_recomp, they must point to the same (matched) entity.
-        AND (e.orig_addr is null and e.ref_orig is null or e.ref_orig = r.orig_addr)
-        AND (e.recomp_addr is null and e.ref_recomp is null or e.ref_recomp = r.recomp_addr)
+        AND ((e.orig_addr is null and e.ref_orig is null) or e.ref_orig = r.orig_addr)
+        AND ((e.recomp_addr is null and e.ref_recomp is null) or e.ref_recomp = r.recomp_addr)
         AND json_extract(r.kvstore, '$.type') = ?
     """,
         (EntityType.FUNCTION,),

--- a/tests/test_compare_db_queries.py
+++ b/tests/test_compare_db_queries.py
@@ -4,7 +4,7 @@ import pytest
 from reccmp.isledecomp.compare.db import EntityDb
 from reccmp.isledecomp.compare.queries import (
     get_overloaded_functions,
-    get_thunks_and_name,
+    get_named_thunks,
 )
 from reccmp.isledecomp.types import EntityType
 
@@ -93,7 +93,7 @@ def test_named_thunks_unmatched(db: EntityDb):
         batch.set_recomp(500, name="Test", type=EntityType.FUNCTION)
         batch.set_recomp(600, ref_recomp=500)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 2
     assert names[0].orig_addr == 200
     assert names[0].name == "Hello"
@@ -113,7 +113,7 @@ def test_named_thunks_matched(db: EntityDb):
         batch.match(100, 500)
         batch.match(200, 600)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 1
     assert names[0].name == "Test"  # Prefer recomp value
 
@@ -126,7 +126,7 @@ def test_named_thunks_no_name(db: EntityDb):
         batch.set_recomp(500, type=EntityType.FUNCTION)
         batch.set_recomp(600, ref_recomp=500)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 0
 
 
@@ -140,7 +140,7 @@ def test_named_thunks_prefer_computed_name(db: EntityDb):
         batch.set_recomp(500, name="X", computed_name="Test", type=EntityType.FUNCTION)
         batch.set_recomp(600, ref_recomp=500)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 2
     assert names[0].name == "Hello"
     assert names[1].name == "Test"
@@ -156,20 +156,20 @@ def test_named_thunks_crossed_ref_attr(db: EntityDb):
         batch.set_recomp(500, name="Test", type=EntityType.FUNCTION)
         batch.set_recomp(600, ref_orig=100)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 0
 
 
 def test_named_thunks_crossed_same_addr(db: EntityDb):
     """The same should be true even if the address values are the same
-    in both virtual address sapces."""
+    in both virtual address spaces."""
     with db.batch() as batch:
         batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
         batch.set_orig(200, ref_recomp=100)
         batch.set_recomp(100, name="Test", type=EntityType.FUNCTION)
         batch.set_recomp(200, ref_orig=100)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 0
 
 
@@ -184,7 +184,7 @@ def test_named_thunks_ignore_incomplete_ref(db: EntityDb):
         # Only thunk is matched
         batch.match(200, 600)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 0
 
 
@@ -206,5 +206,5 @@ def test_named_thunks_ignore_incomplete_if_matched(db: EntityDb):
         batch.set_recomp(200, ref_recomp=2002)
         batch.match(100, 200)
 
-    names = list(get_thunks_and_name(db))
+    names = list(get_named_thunks(db))
     assert len(names) == 0


### PR DESCRIPTION
Continued from #177 and #180. We now establish entities for each incremental build thunk, but we don't provide a name right away. Because we now retain the link back to the parent entity, we can provide a name _after_ each overloaded function has been assigned a more unique name. This means that thunks to overloaded functions will use the unique name so they can be distinguished. (For example: on `BETA10` this has created new diffs in 36 functions, mostly surrounding 3D geometry functions.)

Fixes #176.

`roadmap` now shows that we establish an entity for each thunk whether we have annotated the parent or not. If we want to exclude these unnamed entities from the output, we can do that with a PR on `roadmap` specifically.

No new diffs on the retail builds on `isledecomp` because none of those were/are built incrementally.