### PR TITLE
cvdump symbols: ignore `S_LDATA32` outside of a function

### DIFF
--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -203,8 +203,8 @@ class CvdumpSymbolsParser:
                     type=match.group("type"),
                     name=match.group("name"),
                 )
-                assert self.current_function is not None
-                self.current_function.static_variables.append(new_var)
+                if self.current_function is not None:
+                    self.current_function.static_variables.append(new_var)
 
         elif symbol_type in self._unhandled_symbols:
             return

--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -203,6 +203,10 @@ class CvdumpSymbolsParser:
                     type=match.group("type"),
                     name=match.group("name"),
                 )
+
+                # An S_LDATA32 that appears between S_GPROC32 and S_END blocks then
+                # we consider it to be a static variable from the enclosing function.
+                # If S_LDATA32 appears outside a function, ignore it.
                 if self.current_function is not None:
                     self.current_function.static_variables.append(new_var)
 

--- a/tests/test_cvdump_symbols.py
+++ b/tests/test_cvdump_symbols.py
@@ -74,4 +74,5 @@ def test_ldata32_outside_function():
     )
 
     # ignored... for now.
+    # Should not crash with a failed assert. See GH issue #183.
     assert len(parser.symbols) == 0


### PR DESCRIPTION
Fixes #183.

MSVC 6 apparently puts const global variables in both the `SYMBOLS` section and `GLOBALS `section as `S_LDATA32` nodes.

Right now we only use non-const global variables (`S_GDATA32`) from the `GLOBALS` section. `S_LDATA32` from `SYMBOLS` is taken to be a static variable if it is inside a function. If we find it outside a function, we now just ignore it instead of crashing because of a failed assert.