### PR TITLE
Recognize widechar strings under `STRING` annotations

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -343,8 +343,11 @@ class Compare:
                 # Not that we don't trust you, but we're checking the string
                 # annotation to make sure it is accurate.
                 try:
-                    # TODO: would presumably fail for wchar_t strings
-                    orig = self.orig_bin.read_string(string.offset).decode("latin1")
+                    if string.is_unicode:
+                        orig = None  # TODO
+                    else:
+                        orig = self.orig_bin.read_string(string.offset).decode("latin1")
+
                     string_correct = string.name == orig
                 except UnicodeDecodeError:
                     string_correct = False

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -62,7 +62,7 @@ class ParserVtable(ParserSymbol):
 
 @dataclass
 class ParserString(ParserSymbol):
-    pass
+    is_unicode: bool = False
 
 
 @dataclass

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -10,6 +10,7 @@ from .util import (
     get_synthetic_name,
     remove_trailing_comment,
     get_string_contents,
+    ParserCodeString,
     sanitize_code_line,
     scopeDetectRegex,
 )
@@ -306,27 +307,24 @@ class DecompParser:
             self.state = ReaderState.IN_GLOBAL
 
     def _variable_done(
-        self,
-        variable_name: str | None = None,
-        string_value: str | None = None,
-        is_unicode: bool = False,
+        self, variable_name: str | None = None, string: ParserCodeString | None = None
     ):
-        if variable_name is None and string_value is None:
+        if variable_name is None and string is None:
             self._syntax_error(ParserError.NO_SUITABLE_NAME)
             return
 
         for marker in self.var_markers.iter():
             if marker.is_string():
-                assert string_value is not None
+                assert string is not None
                 self._symbols.append(
                     ParserString(
                         type=marker.type,
                         line_number=self.line_number,
                         module=marker.module,
                         offset=marker.offset,
-                        name=string_value,
+                        name=string.text,
                         filename=self.filename,
-                        is_unicode=is_unicode,
+                        is_unicode=string.is_unicode,
                     )
                 )
             else:
@@ -574,8 +572,8 @@ class DecompParser:
                 else:
                     variable_name = get_variable_name(line)
 
-            (string_name, is_unicode) = get_string_contents(line)
-            self._variable_done(variable_name, string_name, is_unicode)
+            string = get_string_contents(line)
+            self._variable_done(variable_name, string)
 
         elif self.state == ReaderState.IN_VTABLE:
             vtable_class = get_class_name(line)

--- a/reccmp/isledecomp/parser/parser.py
+++ b/reccmp/isledecomp/parser/parser.py
@@ -306,7 +306,10 @@ class DecompParser:
             self.state = ReaderState.IN_GLOBAL
 
     def _variable_done(
-        self, variable_name: str | None = None, string_value: str | None = None
+        self,
+        variable_name: str | None = None,
+        string_value: str | None = None,
+        is_unicode: bool = False,
     ):
         if variable_name is None and string_value is None:
             self._syntax_error(ParserError.NO_SUITABLE_NAME)
@@ -323,6 +326,7 @@ class DecompParser:
                         offset=marker.offset,
                         name=string_value,
                         filename=self.filename,
+                        is_unicode=is_unicode,
                     )
                 )
             else:
@@ -570,9 +574,8 @@ class DecompParser:
                 else:
                     variable_name = get_variable_name(line)
 
-            string_name = get_string_contents(line)
-
-            self._variable_done(variable_name, string_name)
+            (string_name, is_unicode) = get_string_contents(line)
+            self._variable_done(variable_name, string_name, is_unicode)
 
         elif self.state == ReaderState.IN_VTABLE:
             vtable_class = get_class_name(line)

--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -20,7 +20,7 @@ blockCommentRegex = re.compile(r"(/\*.*?\*/)")
 regularCommentRegex = re.compile(r"(//.*)")
 
 # Get string contents, ignore escape characters that might interfere
-doubleQuoteRegex = re.compile(r"(\"(?:[^\"\\]|\\.)*\")")
+doubleQuoteRegex = re.compile(r"(L)?(\"(?:[^\"\\]|\\.)*\")")
 
 # Detect a line that would cause us to enter a new scope
 scopeDetectRegex = re.compile(r"(?:class|struct|namespace) (?P<name>\w+).*(?:{)?")
@@ -117,7 +117,7 @@ def get_variable_name(line: str) -> str | None:
     return None
 
 
-def get_string_contents(line: str) -> str | None:
+def get_string_contents(line: str) -> tuple[str | None, bool]:
     """Return the first C string seen on this line.
     We have to unescape the string, and a simple way to do that is to use
     python's ast.literal_eval. I'm sure there are many pitfalls to doing
@@ -125,10 +125,12 @@ def get_string_contents(line: str) -> str | None:
 
     try:
         if (match := doubleQuoteRegex.search(line)) is not None:
-            return literal_eval(match.group(1))
+            is_unicode = match.group(1) is not None
+            text = literal_eval(match.group(2))
+            return (text, is_unicode)
     # pylint: disable=broad-exception-caught
     # No way to predict what kind of exception could occur.
     except Exception:
         pass
 
-    return None
+    return (None, False)

--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -20,7 +20,7 @@ blockCommentRegex = re.compile(r"(/\*.*?\*/)")
 regularCommentRegex = re.compile(r"(//.*)")
 
 # Get string contents, ignore escape characters that might interfere
-doubleQuoteRegex = re.compile(r"(L)?(\"(?:[^\"\\]|\\.)*\")")
+doubleQuoteRegex = re.compile(r'(L)?("(?:[^"\\]|\\.)*")')
 
 # Detect a line that would cause us to enter a new scope
 scopeDetectRegex = re.compile(r"(?:class|struct|namespace) (?P<name>\w+).*(?:{)?")

--- a/reccmp/isledecomp/parser/util.py
+++ b/reccmp/isledecomp/parser/util.py
@@ -1,6 +1,7 @@
 # C++ Parser utility functions and data structures
 import re
 from ast import literal_eval
+from typing import NamedTuple
 
 # The goal here is to just read whatever is on the next line, so some
 # flexibility in the formatting seems OK
@@ -117,7 +118,12 @@ def get_variable_name(line: str) -> str | None:
     return None
 
 
-def get_string_contents(line: str) -> tuple[str | None, bool]:
+class ParserCodeString(NamedTuple):
+    text: str
+    is_unicode: bool
+
+
+def get_string_contents(line: str) -> ParserCodeString | None:
     """Return the first C string seen on this line.
     We have to unescape the string, and a simple way to do that is to use
     python's ast.literal_eval. I'm sure there are many pitfalls to doing
@@ -127,10 +133,10 @@ def get_string_contents(line: str) -> tuple[str | None, bool]:
         if (match := doubleQuoteRegex.search(line)) is not None:
             is_unicode = match.group(1) is not None
             text = literal_eval(match.group(2))
-            return (text, is_unicode)
+            return ParserCodeString(text=text, is_unicode=is_unicode)
     # pylint: disable=broad-exception-caught
     # No way to predict what kind of exception could occur.
     except Exception:
         pass
 
-    return (None, False)
+    return None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -875,3 +875,21 @@ def test_issue_137(parser):
     assert len(parser.alerts) == 1
     assert parser.alerts[0].code == ParserError.UNEXPECTED_MARKER
     assert parser.alerts[0].code.name == "UNEXPECTED_MARKER"
+
+
+def test_unicode_string(parser):
+    """Should detect a unicode string with the L prefix."""
+    parser.read(
+        """\
+        // STRING: HELLO 0x1234
+        char* test = L"test";
+
+        // STRING: HELLO 0x5555
+        char* test = "test";
+        """
+    )
+
+    assert parser.strings[0].is_unicode is True
+    assert parser.strings[0].name == "test"
+    assert parser.strings[1].is_unicode is False
+    assert parser.strings[1].name == "test"

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -183,9 +183,10 @@ string_match_cases = [
 
 @pytest.mark.parametrize("line, expected", string_match_cases)
 def test_get_string_contents(line: str, expected: str):
-    (text, is_unicode) = get_string_contents(line)
-    assert text == expected
-    assert is_unicode is False
+    string = get_string_contents(line)
+    assert string is not None
+    assert string.text == expected
+    assert string.is_unicode is False
 
 
 def test_marker_extra_spaces():

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -181,9 +181,11 @@ string_match_cases = [
 ]
 
 
-@pytest.mark.parametrize("line, string", string_match_cases)
-def test_get_string_contents(line: str, string: str):
-    assert get_string_contents(line) == string
+@pytest.mark.parametrize("line, expected", string_match_cases)
+def test_get_string_contents(line: str, expected: str):
+    (text, is_unicode) = get_string_contents(line)
+    assert text == expected
+    assert is_unicode is False
 
 
 def test_marker_extra_spaces():


### PR DESCRIPTION
First stage of detecting and matching unicode strings. Actually reading the data and decoding to either UTF-16 LE or BE will come next. (Might move #173 up first to support it.)