### PR TITLE
Simplify naming for string entities

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -38,7 +38,7 @@ from .match_msvc import (
     match_strings,
     match_ref,
 )
-from .db import EntityDb, ReccmpEntity, ReccmpMatch
+from .db import EntityDb, ReccmpEntity, ReccmpMatch, entity_name_from_string
 from .diff import DiffReport, combined_diff
 from .lines import LinesDb
 from .queries import get_overloaded_functions, get_named_thunks
@@ -230,14 +230,16 @@ class Compare:
                         sym.friendly_name = rstrip_string
 
                     except UnicodeDecodeError:
-                        pass
+                        continue
 
                     # Special handling for string entities.
                     # Make sure the entity size includes the string null-terminator.
                     batch.set_recomp(
                         addr,
                         type=sym.node_type,
-                        name=sym.name(),
+                        name=entity_name_from_string(
+                            rstrip_string, wide=string_info.is_utf16
+                        ),
                         symbol=sym.decorated_name,
                         size=len(rstrip_string) + 1,
                         verified=True,
@@ -362,7 +364,7 @@ class Compare:
 
                 batch.set_orig(
                     string.offset,
-                    name=string.name,
+                    name=entity_name_from_string(string.name, wide=string.is_unicode),
                     type=EntityType.STRING,
                     size=len(string.name) + 1,  # including null-terminator
                     verified=True,
@@ -477,7 +479,7 @@ class Compare:
                     batch.insert_orig(
                         addr,
                         type=EntityType.STRING,
-                        name=string,
+                        name=entity_name_from_string(string),
                         size=len(string) + 1,  # including null-terminator
                     )
 
@@ -489,7 +491,7 @@ class Compare:
                     batch.insert_recomp(
                         addr,
                         type=EntityType.STRING,
-                        name=string,
+                        name=entity_name_from_string(string),
                         size=len(string) + 1,  # including null-terminator
                     )
 

--- a/reccmp/isledecomp/compare/db.py
+++ b/reccmp/isledecomp/compare/db.py
@@ -50,6 +50,13 @@ _SETUP_SQL = """
 """
 
 
+def entity_name_from_string(text: str, wide: bool = False) -> str:
+    """Create an entity name for the given string by escaping
+    control characters and double quotes, then wrapping in double quotes."""
+    escaped = text.encode("unicode_escape").decode("utf-8").replace('"', '\\"')
+    return f'{"L" if wide else ""}"{escaped}"'
+
+
 EntityTypeLookup: dict[int, str] = {
     value: name for name, value in EntityType.__members__.items()
 }
@@ -116,16 +123,6 @@ class ReccmpEntity:
         """Combination of the name and compare type.
         Intended for name substitution in the diff. If there is a diff,
         it will be more obvious what this symbol indicates."""
-
-        # Special handling for strings that might contain newlines.
-        if self.entity_type == EntityType.STRING:
-            if self.name is not None:
-                # Escape newlines so they do not interfere
-                # with asm sanitize and diff calculation.
-                return f"{repr(self.name)} (STRING)"
-
-            return None
-
         best_name = self.best_name()
         if best_name is None:
             return None

--- a/reccmp/isledecomp/compare/match_msvc.py
+++ b/reccmp/isledecomp/compare/match_msvc.py
@@ -338,7 +338,7 @@ def match_strings(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
                 report(
                     ReccmpEvent.NO_MATCH,
                     orig_addr,
-                    msg=f"Failed to match string {repr(text)} at 0x{orig_addr:x}",
+                    msg=f"Failed to match string {text} at 0x{orig_addr:x}",
                 )
 
 

--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -423,9 +423,6 @@ def main() -> int:
                 (_, module_name) = module_ref
 
         row_type = match_type_abbreviation(match.entity_type)
-        name = (
-            repr(match.name) if match.entity_type == EntityType.STRING else match.name
-        )
 
         if match.orig_addr is not None:
             orig_addr = match.orig_addr
@@ -454,7 +451,7 @@ def main() -> int:
             displacement,
             row_type,
             match.size,
-            name,
+            match.name,
             module_name,
         )
 

--- a/tests/test_entity_obj.py
+++ b/tests/test_entity_obj.py
@@ -46,27 +46,3 @@ def test_match_name_priority():
     name = create_entity(100, 200, computed_name="Hello", name="Test").match_name()
     assert name is not None
     assert "Hello" in name
-
-
-def test_computed_name_string():
-    """Ignore 'computed_name' if entity is a string"""
-
-    name = create_entity(
-        100, 200, computed_name="Hello", name="Test", type=EntityType.STRING
-    ).match_name()
-    assert name is not None
-    assert "Test" in name
-
-
-def test_match_name_string():
-    """We currently store the string value in the name field.
-    If the string includes newlines, we need to escape them before replacing the
-    value during asm sanitize. (It will interfere with diff calculation.)"""
-    string = """A string
-    with
-    newlines"""
-
-    name = create_entity(100, None, type=EntityType.STRING, name=string).match_name()
-    assert name is not None
-    assert "\n" not in name
-    assert "\\n" in name

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -69,21 +69,6 @@ def test_name_hierarchy(db):
     assert "Test" not in entity
 
 
-def test_string_escape_newlines(db):
-    """Make sure newlines are removed from the string.
-    This overlap with tests on the ReccmpEntity name functions, but it is more vital
-    to ensure there are no newlines at this stage because they will disrupt the asm diff.
-    """
-    with db.batch() as batch:
-        batch.set_orig(100, name="Test\nTest", type=EntityType.STRING)
-
-    lookup = create_lookup(db)
-    entity = lookup(100)
-
-    assert entity is not None
-    assert "\n" not in entity
-
-
 def test_offset_name(db):
     """For some entities (i.e. variables) we will return a name if the search address
     is inside the address range of the entity. This is determined by the size attribute.


### PR DESCRIPTION
For string entities, the `name` property contains the text of the string. We have been escaping special characters as needed by using `repr()`. For example, in the `match_name` function in `ReccmpEntity`. The main concern is that any newlines in the string will disrupt the appearance of the final asm.[^1]

Instead of depending on `repr()` we now intentionally escape the string before setting the entity name and always use double quotes as the wrapper.

Matching of strings should not be affected because we use the conversion function whenever a string entity is created.

Widechar strings will use the `L"` prefix to distinguish them from ASCII strings. Support for those is coming in the next update.

I removed some tests that I think are no longer relevant because we now ensure we have good data going in when we create string entities. When we have CSV/YML support it may be possible for newlines to appear in names for entities that are _not_ strings. We should figure out something to handle those in a more comprehensive way.

[^1]: The diff should not be impacted by a newline because each instruction is a separate entry in the list.