### PR TITLE
Match widechar strings, improve PDB string detection

### DIFF
--- a/tests/test_image_raw.py
+++ b/tests/test_image_raw.py
@@ -134,3 +134,9 @@ def test_raw_all_uninitialized():
     # Reading from any valid address results in the empty string.
     assert img.read_string(0) == b""
     assert img.read_string(6) == b""
+
+
+def test_widechar():
+    img = RawImage.from_memory(b"t\x00e\x00s\x00t\x00\x00\x00")
+    data = img.read_widechar(0)
+    assert data.decode("utf-16-le") == "test"

--- a/tests/test_islebin.py
+++ b/tests/test_islebin.py
@@ -119,6 +119,10 @@ def test_strings(addr: int, string: bytes, binfile: PEImage):
     assert binfile.read_string(addr) == string
 
 
+def test_widechar(binfile: PEImage):
+    assert binfile.read_widechar(0x100DAAA0) == "(null)".encode("utf-16-le")
+
+
 def test_relocation(binfile: PEImage):
     # n.b. This is not the number of *relocations* read from .reloc.
     # It is the set of unique addresses in the binary that get relocated.


### PR DESCRIPTION
Fixes #189.

This adds the `read_widechar` function to the `Image` base class for reading 2-byte character strings. The `core` module assumes UTF-16 LE encoding to start with, but this function should work if we need to support big endian with other image types. Now that we can read widechar data and get the intended text, we can match widechar strings annotated in code.

The second change is more subtle. To detect strings in the PDB, we rely on string symbols created for images built with the string pooling option enabled. This is the only thing I'm aware of that will tell whether a string is widechar or not. These symbols also include an approximation of the length of the string, but it does not consistently account for the null terminator. I realized that the section contribution data provides a more consistent length, so we now use that if we have it.

This enables us to include strings that include null bytes or are entirely null bytes. In the latter case, we had been reducing those strings to the empty string with `rstrip()`. Another reason they were ignored until now is that our JSON database does not support strings that contain nulls. The escaping added by #191 makes it possible to create these entities.

The strings `"\x00"` and `L"\x00"` are used in the library functions `___crtLCMapStringA` and `___crtGetStringTypeA`. You can see the strings in the `reccmp-roadmap` output with `--verbose` enabled.