### PR TITLE
Don't create unified diff in function comparator

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -835,10 +835,10 @@ class Compare:
             assert best_name is not None
 
             diff_result = self.function_comparator.compare_function(match)
-            if diff_result.diff:
-                grouped_codes = list(get_grouped_opcodes(diff_result.diff[0], n=10))
+            if diff_result.match_ratio != 1.0:
+                grouped_codes = list(get_grouped_opcodes(diff_result.codes, n=10))
                 udiff = combined_diff(
-                    grouped_codes, diff_result.diff[1], diff_result.diff[2]
+                    grouped_codes, diff_result.orig_inst, diff_result.recomp_inst
                 )
             else:
                 udiff = None

--- a/reccmp/isledecomp/compare/functions.py
+++ b/reccmp/isledecomp/compare/functions.py
@@ -5,6 +5,7 @@ import struct
 from itertools import pairwise
 from typing import Callable, Iterator, NamedTuple
 from reccmp.isledecomp.compare.lines import LinesDb
+from reccmp.isledecomp.difflib import DiffOpcode
 from reccmp.isledecomp.compare.pinned_sequences import SequenceMatcherWithPins
 from reccmp.isledecomp.compare.asm.fixes import assert_fixup, find_effective_match
 from reccmp.isledecomp.compare.asm.parse import AsmExcerpt, ParseAsm
@@ -13,22 +14,16 @@ from reccmp.isledecomp.compare.asm.replacement import (
     create_name_lookup,
 )
 from reccmp.isledecomp.compare.db import EntityDb, ReccmpMatch
-from reccmp.isledecomp.compare.diff import (
-    CombinedDiffOutput,
-    DiffReport,
-    combined_diff,
-)
 from reccmp.isledecomp.compare.event import ReccmpEvent, ReccmpReportProtocol
 from reccmp.isledecomp.formats.exceptions import (
     InvalidVirtualAddressError,
     InvalidVirtualReadError,
 )
 from reccmp.isledecomp.formats.pe import PEImage
-from reccmp.isledecomp.types import EntityType
 
 
 class FunctionCompareResult(NamedTuple):
-    diff: CombinedDiffOutput
+    diff: tuple[list[DiffOpcode], list[tuple[str, str]], list[tuple[str, str]]] | None
     is_effective_match: bool
     match_ratio: float
 
@@ -136,7 +131,7 @@ class FunctionComparator:
             return None
         return f"{path_line_pair[0].name}:{path_line_pair[1]}"
 
-    def compare_function(self, match: ReccmpMatch) -> DiffReport:
+    def compare_function(self, match: ReccmpMatch) -> FunctionCompareResult:
         # Detect when the recomp function size would cause us to read
         # enough bytes from the original function that we cross into
         # the next annotated function.
@@ -181,20 +176,8 @@ class FunctionComparator:
             orig_combined, recomp_combined, line_annotations
         )
 
-        diff_result = self._compare_function_assembly(
+        return self._compare_function_assembly(
             orig_combined, recomp_combined, split_points
-        )
-
-        best_name = match.best_name()
-        assert best_name is not None
-        return DiffReport(
-            match_type=EntityType.FUNCTION,
-            orig_addr=match.orig_addr,
-            recomp_addr=match.recomp_addr,
-            name=best_name,
-            udiff=diff_result.diff,
-            ratio=diff_result.match_ratio,
-            is_effective_match=diff_result.is_effective_match,
         )
 
     @staticmethod
@@ -251,13 +234,13 @@ class FunctionComparator:
                 for line_index, (addr, instruction) in enumerate(recomp)
             ]
 
-            unified_diff = combined_diff(
-                diff.get_grouped_opcodes(n=10),
+            unified_diff = (
+                diff.get_opcodes(),
                 orig_for_printing,
                 recomp_for_printing,
             )
         else:
-            unified_diff = []
+            unified_diff = None
             is_effective = False
 
         return FunctionCompareResult(

--- a/reccmp/isledecomp/difflib.py
+++ b/reccmp/isledecomp/difflib.py
@@ -1,0 +1,38 @@
+"""Wrappers and items related to the builtin python difflib module."""
+
+from typing import Iterator
+
+
+DiffOpcode = tuple[str, int, int, int, int]
+
+
+def get_grouped_opcodes(
+    codes: list[DiffOpcode], n: int = 3
+) -> Iterator[list[DiffOpcode]]:
+    """
+    Taken from the Python 3.12 standard library, `difflib.py`, published under PSF license, GPL compatible.
+    """
+
+    if not codes:
+        codes = [("equal", 0, 1, 0, 1)]
+    # Fixup leading and trailing groups if they show no changes.
+    if codes[0][0] == "equal":
+        tag, i1, i2, j1, j2 = codes[0]
+        codes[0] = tag, max(i1, i2 - n), i2, max(j1, j2 - n), j2
+    if codes[-1][0] == "equal":
+        tag, i1, i2, j1, j2 = codes[-1]
+        codes[-1] = tag, i1, min(i2, i1 + n), j1, min(j2, j1 + n)
+
+    nn = n + n
+    group = []
+    for tag, i1, i2, j1, j2 in codes:
+        # End the current group and start a new one whenever
+        # there is a large range with no changes.
+        if tag == "equal" and i2 - i1 > nn:
+            group.append((tag, i1, min(i2, i1 + n), j1, min(j2, j1 + n)))
+            yield group
+            group = []
+            i1, j1 = max(i1, i2 - n), max(j1, j2 - n)
+        group.append((tag, i1, i2, j1, j2))
+    if group and not (len(group) == 1 and group[0][0] == "equal"):
+        yield group

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -241,11 +241,64 @@ def test_impact_of_line_annotation(
     assert diffreport.codes == [
         ("equal", 0, 2, 0, 2),
         ("replace", 2, 9, 2, 3),
+        # Pinned line is in this "replace" section:
         ("replace", 9, 10, 3, 4),
         ("equal", 10, 11, 4, 5),
         ("replace", 11, 14, 5, 8),
         ("equal", 14, 15, 8, 9),
         ("replace", 15, 19, 9, 22),
+    ]
+
+    # The asm is the same as the previous function "test_example_where_diff_mismatches_lines"
+    # except for two instructions shown below:
+
+    assert diffreport.orig_inst == [
+        ("0x200", "sub ecx, eax"),
+        ("0x202", "dec ecx"),
+        ("0x203", "mov word ptr [ebp - 0x28], cx"),
+        ("0x207", "jmp 0x1d1"),
+        # LINE entity provides a name for this jump destination:
+        ("0x20c", "jmp cppfile.cpp:384 (LINE)"),
+        ("0x211", "movsx eax, word ptr [ebp - 0x18]"),
+        ("0x215", "movsx ecx, word ptr [ebp - 0x28]"),
+        ("0x219", "add eax, ecx"),
+        ("0x21b", "mov word ptr [ebp - 0x28], ax"),
+        ("0x21f", "mov eax, dword ptr [ebp - 0x14]"),
+        ("0x222", "mov ax, word ptr [eax]"),
+        ("0x225", "mov word ptr [ebp - 0x18], ax"),
+        ("0x229", "add dword ptr [ebp - 0x14], 2"),
+        ("0x22d", "movsx eax, word ptr [ebp - 0x18]"),
+        ("0x231", "test eax, eax"),
+        ("0x233", "jl 0xa"),
+        ("0x239", "jmp 0x19a"),
+        ("0x23e", "jmp 0x68"),
+        ("0x243", "test byte ptr [ebp - 0x17], 0x40"),
+    ]
+
+    assert diffreport.recomp_inst == [
+        ("0x400", "sub ecx, eax"),
+        ("0x402", "dec ecx"),
+        ("0x403", "mov word ptr [ebp - 4], cx"),
+        # line number and pin indicator:
+        ("0x407", "mov eax, dword ptr [ebp - 0xc] \t(test.cpp:123, pinned)"),
+        ("0x40a", "mov ax, word ptr [eax]"),
+        ("0x40d", "mov word ptr [ebp - 0x10], ax"),
+        ("0x411", "add dword ptr [ebp - 0xc], 2"),
+        ("0x415", "movsx eax, word ptr [ebp - 0x10]"),
+        ("0x419", "test eax, eax"),
+        ("0x41b", "jge 0x7e"),
+        ("0x421", "movsx eax, word ptr [ebp - 0x10]"),
+        ("0x425", "test ah, 0x40"),
+        ("0x428", "je 0x13"),
+        ("0x42e", "movsx eax, word ptr [ebp - 4]"),
+        ("0x432", "movsx ecx, word ptr [ebp - 0x10]"),
+        ("0x436", "add eax, ecx"),
+        ("0x438", "mov word ptr [ebp - 4], ax"),
+        ("0x43c", "jmp 0x161"),
+        ("0x441", "mov eax, dword ptr [ebp - 0x10]"),
+        ("0x444", "push eax"),
+        ("0x445", "mov eax, dword ptr [ebp - 4]"),
+        ("0x448", "push eax"),
     ]
 
 

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -3,9 +3,11 @@ from typing import Callable
 from unittest.mock import Mock
 import pytest
 from reccmp.isledecomp.compare.db import EntityDb, ReccmpMatch
-from reccmp.isledecomp.compare.diff import DiffReport
 from reccmp.isledecomp.compare.event import ReccmpEvent, ReccmpReportProtocol
-from reccmp.isledecomp.compare.functions import FunctionComparator
+from reccmp.isledecomp.compare.functions import (
+    FunctionComparator,
+    FunctionCompareResult,
+)
 from reccmp.isledecomp.compare.lines import LinesDb
 from reccmp.isledecomp.types import EntityType
 
@@ -37,7 +39,7 @@ def compare_functions(
     recomp: bytes,
     report: ReccmpReportProtocol,
     is_relocated_addr: Callable[[int], bool] | None = None,
-) -> DiffReport:
+) -> FunctionCompareResult:
     """Executes `FunctionComparator.compare_function` on the provided binary code."""
 
     # Do not use `spec=PEImage`. It may have default implementations that don't do what you expect
@@ -88,8 +90,8 @@ def test_simple_identical_diff(
 
     diffreport = compare_functions(db, lines_db, code, code, report)
 
-    assert diffreport.ratio == 1.0
-    assert diffreport.udiff == []
+    assert diffreport.match_ratio == 1.0
+    assert diffreport.diff is None
 
 
 def test_simple_nontrivial_diff(
@@ -101,24 +103,25 @@ def test_simple_nontrivial_diff(
 
     diffreport = compare_functions(db, lines_db, orig, recm, report)
 
-    assert diffreport.ratio < 1.0
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
 
-    assert diffreport.udiff == [
-        (
-            "@@ -0x200,3 +0x400,3 @@",
-            [
-                {
-                    "both": [
-                        ("0x200", "mov word ptr [ebp - 8], 0", "0x400"),
-                        ("0x206", "mov word ptr [ebp - 0x10], 0", "0x406"),
-                    ]
-                },
-                {
-                    "orig": [("0x20c", "mov eax, dword ptr [ebp + 0x14]")],
-                    "recomp": [("0x40c", "mov edx, dword ptr [ecx + 0x14]")],
-                },
-            ],
-        )
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+    assert codes == [
+        ("equal", 0, 2, 0, 2),
+        ("replace", 2, 3, 2, 3),
+    ]
+
+    assert orig_inst == [
+        ("0x200", "mov word ptr [ebp - 8], 0"),
+        ("0x206", "mov word ptr [ebp - 0x10], 0"),
+        ("0x20c", "mov eax, dword ptr [ebp + 0x14]"),
+    ]
+
+    assert recomp_inst == [
+        ("0x400", "mov word ptr [ebp - 8], 0"),
+        ("0x406", "mov word ptr [ebp - 0x10], 0"),
+        ("0x40c", "mov edx, dword ptr [ecx + 0x14]"),
     ]
 
 
@@ -142,71 +145,63 @@ def test_example_where_diff_mismatches_lines(
         db, lines_db, LINE_MISMATCH_EXAMPLE_ORIG, LINE_MISMATCH_EXAMPLE_RECOMP, report
     )
 
-    assert diffreport.ratio < 1.0
-    assert diffreport.udiff == [
-        (
-            "@@ -0x200,19 +0x400,22 @@",
-            [
-                {
-                    "both": [
-                        ("0x200", "sub ecx, eax", "0x400"),
-                        ("0x202", "dec ecx", "0x402"),
-                    ]
-                },
-                {
-                    "orig": [
-                        ("0x203", "mov word ptr [ebp - 0x28], cx"),
-                        ("0x207", "jmp 0x1d1"),
-                        ("0x20c", "jmp 0xe"),
-                        ("0x211", "movsx eax, word ptr [ebp - 0x18]"),
-                        ("0x215", "movsx ecx, word ptr [ebp - 0x28]"),
-                    ],
-                    "recomp": [
-                        ("0x403", "mov word ptr [ebp - 4], cx"),
-                        ("0x407", "mov eax, dword ptr [ebp - 0xc]"),
-                        ("0x40a", "mov ax, word ptr [eax]"),
-                        ("0x40d", "mov word ptr [ebp - 0x10], ax"),
-                        ("0x411", "add dword ptr [ebp - 0xc], 2"),
-                        ("0x415", "movsx eax, word ptr [ebp - 0x10]"),
-                        ("0x419", "test eax, eax"),
-                        ("0x41b", "jge 0x7e"),
-                        ("0x421", "movsx eax, word ptr [ebp - 0x10]"),
-                        ("0x425", "test ah, 0x40"),
-                        ("0x428", "je 0x13"),
-                        ("0x42e", "movsx eax, word ptr [ebp - 4]"),
-                        ("0x432", "movsx ecx, word ptr [ebp - 0x10]"),
-                    ],
-                },
-                {
-                    "both": [
-                        ("0x219", "add eax, ecx", "0x436"),
-                    ]
-                },
-                {
-                    "orig": [
-                        ("0x21b", "mov word ptr [ebp - 0x28], ax"),
-                        ("0x21f", "mov eax, dword ptr [ebp - 0x14]"),
-                        ("0x222", "mov ax, word ptr [eax]"),
-                        ("0x225", "mov word ptr [ebp - 0x18], ax"),
-                        ("0x229", "add dword ptr [ebp - 0x14], 2"),
-                        ("0x22d", "movsx eax, word ptr [ebp - 0x18]"),
-                        ("0x231", "test eax, eax"),
-                        ("0x233", "jl 0xa"),
-                        ("0x239", "jmp 0x19a"),
-                        ("0x23e", "jmp 0x68"),
-                        ("0x243", "test byte ptr [ebp - 0x17], 0x40"),
-                    ],
-                    "recomp": [
-                        ("0x438", "mov word ptr [ebp - 4], ax"),
-                        ("0x43c", "jmp 0x161"),
-                        ("0x441", "mov eax, dword ptr [ebp - 0x10]"),
-                        ("0x444", "push eax"),
-                        ("0x445", "mov eax, dword ptr [ebp - 4]"),
-                        ("0x448", "push eax"),
-                    ],
-                },
-            ],
-        )
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
+
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+
+    assert codes == [
+        ("equal", 0, 2, 0, 2),
+        ("replace", 2, 7, 2, 15),
+        ("equal", 7, 8, 15, 16),
+        ("replace", 8, 19, 16, 22),
+    ]
+
+    assert orig_inst == [
+        ("0x200", "sub ecx, eax"),
+        ("0x202", "dec ecx"),
+        ("0x203", "mov word ptr [ebp - 0x28], cx"),
+        ("0x207", "jmp 0x1d1"),
+        ("0x20c", "jmp 0xe"),
+        ("0x211", "movsx eax, word ptr [ebp - 0x18]"),
+        ("0x215", "movsx ecx, word ptr [ebp - 0x28]"),
+        ("0x219", "add eax, ecx"),
+        ("0x21b", "mov word ptr [ebp - 0x28], ax"),
+        ("0x21f", "mov eax, dword ptr [ebp - 0x14]"),
+        ("0x222", "mov ax, word ptr [eax]"),
+        ("0x225", "mov word ptr [ebp - 0x18], ax"),
+        ("0x229", "add dword ptr [ebp - 0x14], 2"),
+        ("0x22d", "movsx eax, word ptr [ebp - 0x18]"),
+        ("0x231", "test eax, eax"),
+        ("0x233", "jl 0xa"),
+        ("0x239", "jmp 0x19a"),
+        ("0x23e", "jmp 0x68"),
+        ("0x243", "test byte ptr [ebp - 0x17], 0x40"),
+    ]
+
+    assert recomp_inst == [
+        ("0x400", "sub ecx, eax"),
+        ("0x402", "dec ecx"),
+        ("0x403", "mov word ptr [ebp - 4], cx"),
+        ("0x407", "mov eax, dword ptr [ebp - 0xc]"),
+        ("0x40a", "mov ax, word ptr [eax]"),
+        ("0x40d", "mov word ptr [ebp - 0x10], ax"),
+        ("0x411", "add dword ptr [ebp - 0xc], 2"),
+        ("0x415", "movsx eax, word ptr [ebp - 0x10]"),
+        ("0x419", "test eax, eax"),
+        ("0x41b", "jge 0x7e"),
+        ("0x421", "movsx eax, word ptr [ebp - 0x10]"),
+        ("0x425", "test ah, 0x40"),
+        ("0x428", "je 0x13"),
+        ("0x42e", "movsx eax, word ptr [ebp - 4]"),
+        ("0x432", "movsx ecx, word ptr [ebp - 0x10]"),
+        ("0x436", "add eax, ecx"),
+        ("0x438", "mov word ptr [ebp - 4], ax"),
+        ("0x43c", "jmp 0x161"),
+        ("0x441", "mov eax, dword ptr [ebp - 0x10]"),
+        ("0x444", "push eax"),
+        ("0x445", "mov eax, dword ptr [ebp - 4]"),
+        ("0x448", "push eax"),
     ]
 
 
@@ -222,89 +217,17 @@ def test_impact_of_line_annotation(
         db, lines_db, LINE_MISMATCH_EXAMPLE_ORIG, LINE_MISMATCH_EXAMPLE_RECOMP, report
     )
 
-    assert diffreport.udiff == [
-        (
-            "@@ -0x200,19 +0x400,22 @@",
-            [
-                {
-                    "both": [
-                        ("0x200", "sub ecx, eax", "0x400"),
-                        ("0x202", "dec ecx", "0x402"),
-                    ]
-                },
-                {
-                    "orig": [
-                        ("0x203", "mov word ptr [ebp - 0x28], cx"),
-                        ("0x207", "jmp 0x1d1"),
-                        ("0x20c", "jmp cppfile.cpp:384 (LINE)"),
-                        ("0x211", "movsx eax, word ptr [ebp - 0x18]"),
-                        ("0x215", "movsx ecx, word ptr [ebp - 0x28]"),
-                        ("0x219", "add eax, ecx"),
-                        ("0x21b", "mov word ptr [ebp - 0x28], ax"),
-                    ],
-                    "recomp": [
-                        ("0x403", "mov word ptr [ebp - 4], cx"),
-                    ],
-                },
-                {
-                    "orig": [
-                        ("0x21f", "mov eax, dword ptr [ebp - 0x14]"),
-                    ],
-                    "recomp": [
-                        (
-                            "0x407",
-                            "mov eax, dword ptr [ebp - 0xc] \t(test.cpp:123, pinned)",
-                        ),
-                    ],
-                },
-                {
-                    "both": [
-                        ("0x222", "mov ax, word ptr [eax]", "0x40a"),
-                    ]
-                },
-                {
-                    # Note how these blocks correspond, but but without the // LINE annotation they do not
-                    "orig": [
-                        ("0x225", "mov word ptr [ebp - 0x18], ax"),
-                        ("0x229", "add dword ptr [ebp - 0x14], 2"),
-                        ("0x22d", "movsx eax, word ptr [ebp - 0x18]"),
-                    ],
-                    "recomp": [
-                        ("0x40d", "mov word ptr [ebp - 0x10], ax"),
-                        ("0x411", "add dword ptr [ebp - 0xc], 2"),
-                        ("0x415", "movsx eax, word ptr [ebp - 0x10]"),
-                    ],
-                },
-                {
-                    "both": [
-                        ("0x231", "test eax, eax", "0x419"),
-                    ]
-                },
-                {
-                    "orig": [
-                        ("0x233", "jl 0xa"),
-                        ("0x239", "jmp 0x19a"),
-                        ("0x23e", "jmp 0x68"),
-                        ("0x243", "test byte ptr [ebp - 0x17], 0x40"),
-                    ],
-                    "recomp": [
-                        ("0x41b", "jge 0x7e"),
-                        ("0x421", "movsx eax, word ptr [ebp - 0x10]"),
-                        ("0x425", "test ah, 0x40"),
-                        ("0x428", "je 0x13"),
-                        ("0x42e", "movsx eax, word ptr [ebp - 4]"),
-                        ("0x432", "movsx ecx, word ptr [ebp - 0x10]"),
-                        ("0x436", "add eax, ecx"),
-                        ("0x438", "mov word ptr [ebp - 4], ax"),
-                        ("0x43c", "jmp 0x161"),
-                        ("0x441", "mov eax, dword ptr [ebp - 0x10]"),
-                        ("0x444", "push eax"),
-                        ("0x445", "mov eax, dword ptr [ebp - 4]"),
-                        ("0x448", "push eax"),
-                    ],
-                },
-            ],
-        ),
+    assert diffreport.diff is not None
+    (codes, _, __) = diffreport.diff
+
+    assert codes == [
+        ("equal", 0, 2, 0, 2),
+        ("replace", 2, 9, 2, 3),
+        ("replace", 9, 10, 3, 4),
+        ("equal", 10, 11, 4, 5),
+        ("replace", 11, 14, 5, 8),
+        ("equal", 14, 15, 8, 9),
+        ("replace", 15, 19, 9, 22),
     ]
 
 
@@ -362,7 +285,7 @@ def test_no_assembly_generated(db: EntityDb, lines_db: LinesDb, report):
 
     diffreport = compare_functions(db, lines_db, code, recm, report)
 
-    assert diffreport.ratio == 1.0
+    assert diffreport.match_ratio == 1.0
 
 
 def test_displacement_without_match(
@@ -373,19 +296,14 @@ def test_displacement_without_match(
 
     diffreport = compare_functions(db, lines_db, orig, recm, report)
 
-    assert diffreport.ratio < 1.0
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
 
-    assert diffreport.udiff == [
-        (
-            "@@ -0x200,1 +0x400,1 @@",
-            [
-                {
-                    "orig": [("0x200", "mov dword ptr [eax*4 + 0xc815a8], edi")],
-                    "recomp": [("0x400", "mov dword ptr [eax*4 + 0xd015a8], edi")],
-                }
-            ],
-        )
-    ]
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+
+    assert codes == [("replace", 0, 1, 0, 1)]
+    assert orig_inst == [("0x200", "mov dword ptr [eax*4 + 0xc815a8], edi")]
+    assert recomp_inst == [("0x400", "mov dword ptr [eax*4 + 0xd015a8], edi")]
 
 
 def test_displacement_with_match(
@@ -402,7 +320,7 @@ def test_displacement_with_match(
 
     diffreport = compare_functions(db, lines_db, orig, recm, report)
 
-    assert diffreport.ratio == 1.0
+    assert diffreport.match_ratio == 1.0
 
 
 def test_matching_jump_table(
@@ -416,7 +334,7 @@ def test_matching_jump_table(
     # is_relocated_addr = None
     diffreport = compare_functions(db, lines_db, orig, recm, report, is_relocated_addr)
 
-    assert diffreport.ratio == 1.0
+    assert diffreport.match_ratio == 1.0
     assert diffreport.is_effective_match is False
 
 
@@ -439,24 +357,31 @@ def test_jump_table_wrong_order(
     is_relocated_addr = Mock(return_value=True)
     diffreport = compare_functions(db, lines_db, orig, recm, report, is_relocated_addr)
 
-    assert diffreport.ratio < 1.0
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
     assert diffreport.is_effective_match is False
 
-    assert diffreport.udiff == [
-        (
-            "@@ -,4 +,4 @@",
-            [
-                {
-                    "both": [
-                        ("0x200", "jmp dword ptr [eax*4 + <OFFSET1>]", "0x400"),
-                        ("", "Jump table:", ""),
-                    ],
-                },
-                {"orig": [], "recomp": [("0x407", "start + 0x243")]},
-                {"both": [("0x207", "start + 0x233", "0x40b")]},
-                {"orig": [("0x20b", "start + 0x243")], "recomp": []},
-            ],
-        )
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+
+    assert codes == [
+        ("equal", 0, 2, 0, 2),
+        ("insert", 2, 2, 2, 3),
+        ("equal", 2, 3, 3, 4),
+        ("delete", 3, 4, 4, 4),
+    ]
+
+    assert orig_inst == [
+        ("0x200", "jmp dword ptr [eax*4 + <OFFSET1>]"),
+        ("", "Jump table:"),
+        ("0x207", "start + 0x233"),
+        ("0x20b", "start + 0x243"),
+    ]
+
+    assert recomp_inst == [
+        ("0x400", "jmp dword ptr [eax*4 + <OFFSET1>]"),
+        ("", "Jump table:"),
+        ("0x407", "start + 0x243"),
+        ("0x40b", "start + 0x233"),
     ]
 
 
@@ -489,29 +414,49 @@ def test_data_table_wrong_order(
     is_relocated_addr = Mock(return_value=True)
     diffreport = compare_functions(db, lines_db, orig, recm, report, is_relocated_addr)
 
-    assert diffreport.ratio < 1.0
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
     assert diffreport.is_effective_match is False
 
-    assert diffreport.udiff == [
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+
+    assert codes == [
+        ("equal", 0, 6, 0, 6),
+        ("insert", 6, 6, 6, 8),
+        ("equal", 6, 7, 8, 9),
+        ("delete", 7, 9, 9, 9),
+        ("equal", 9, 11, 9, 11),
+    ]
+
+    assert orig_inst == [
+        ("0x200", "mov al, byte ptr [ecx + <OFFSET1>]"),
+        ("0x206", "jmp dword ptr [eax*4 + <OFFSET2>]"),
+        ("", "Jump table:"),
+        ("0x20d", "start + 0x33"),
+        ("0x211", "start + 0x43"),
+        ("", "Data table:"),
+        ("0x215", "0x5"),
+        ("0x216", "0x2"),
+        ("0x217", "0x3"),
         (
-            "@@ -,11 +,11 @@",
-            [
-                {
-                    "both": [
-                        ("0x200", "mov al, byte ptr [ecx + <OFFSET1>]", "0x400"),
-                        ("0x206", "jmp dword ptr [eax*4 + <OFFSET2>]", "0x406"),
-                        ("", "Jump table:", ""),
-                        ("0x20d", "start + 0x33", "0x40d"),
-                        ("0x211", "start + 0x43", "0x411"),
-                        ("", "Data table:", ""),
-                    ]
-                },
-                {"orig": [], "recomp": [("0x415", "0x3"), ("0x416", "0x2")]},
-                {"both": [("0x215", "0x5", "0x417")]},
-                {"orig": [("0x216", "0x2"), ("0x217", "0x3")], "recomp": []},
-                {"both": [("0x218", "0x0", "0x418"), ("0x219", "0x3", "0x419")]},
-            ],
-        )
+            "0x218",
+            "0x0",
+        ),
+        ("0x219", "0x3"),
+    ]
+
+    assert recomp_inst == [
+        ("0x400", "mov al, byte ptr [ecx + <OFFSET1>]"),
+        ("0x406", "jmp dword ptr [eax*4 + <OFFSET2>]"),
+        ("", "Jump table:"),
+        ("0x40d", "start + 0x33"),
+        ("0x411", "start + 0x43"),
+        ("", "Data table:"),
+        ("0x415", "0x3"),
+        ("0x416", "0x2"),
+        ("0x417", "0x5"),
+        ("0x418", "0x0"),
+        ("0x419", "0x3"),
     ]
 
 
@@ -524,21 +469,13 @@ def test_source_reference_without_line_annotation(
 
     diffreport = compare_functions(db, lines_db, orig, recm, report)
 
-    assert diffreport.ratio < 1.0
+    assert diffreport.match_ratio < 1.0
+    assert diffreport.diff is not None
 
-    assert diffreport.udiff == [
-        (
-            "@@ -0x200,1 +0x400,1 @@",
-            [
-                {
-                    "orig": [("0x200", "mov dword ptr [eax*4 + 0xc815a8], edi")],
-                    "recomp": [
-                        (
-                            "0x400",
-                            "mov dword ptr [eax*4 + 0xd015a8], edi \t(test.cpp:42)",
-                        )
-                    ],
-                }
-            ],
-        )
+    (codes, orig_inst, recomp_inst) = diffreport.diff
+
+    assert codes == [("replace", 0, 1, 0, 1)]
+    assert orig_inst == [("0x200", "mov dword ptr [eax*4 + 0xc815a8], edi")]
+    assert recomp_inst == [
+        ("0x400", "mov dword ptr [eax*4 + 0xd015a8], edi \t(test.cpp:42)")
     ]


### PR DESCRIPTION
Refactors the function comparator for better separation of concerns. `compare_function` now returns only the `FunctionCompareResult` tuple with the `SequenceMatcher` opcodes and other information. The `core.py` module creates the `DiffReport` object that is used for JSON/HTML/terminal output.

We now return the complete set of asm and opcodes for all functions, even if the match is 100%. At some point we will want the number of context lines to be user-configurable. We might also want the option to show the asm we generate for 100% matched functions. For now, the output is the same, but the call to restrict the diff to 10 lines of context (or none at all, for perfect matches) happens in `core.py`.

This also moves the `DiffOpcode` type and our copy of `get_grouped_opcodes` to its own `difflib` module to prevent circular imports.

Since `compare_function` no longer generates unified diff output, the unit tests in `test_function_comparator` have less intricate data.