### PR TITLE
HTML table refactor

### DIFF
--- a/reccmp/assets/template.html
+++ b/reccmp/assets/template.html
@@ -39,31 +39,38 @@
         font-family: monospace;
       }
 
-      func-row:hover {
+      tr[data-address]:hover {
         background: #404040 !important;
       }
 
-      func-row:nth-child(odd of :not([hidden])), #listing > thead th {
+      tr[data-address]:nth-child(odd of :not([hidden])), #listing > thead th {
         background: #282828;
       }
 
-      func-row:nth-child(even of :not([hidden])) {
+      tr[data-address]:nth-child(even of :not([hidden])) {
         background: #383838;
       }
 
       table#listing {
         border: 1px #f0f0f0 solid;
+        table-layout: fixed;
       }
 
       #listing > thead th {
         padding: 0.5em;
         user-select: none;
-        width: 10%;
         text-align: left;
       }
 
-      #listing:not([show-recomp]) > thead th[data-col="recomp"] {
-        display: none;
+      #listing > thead th[data-col="address"],
+      #listing > thead th[data-col="recomp"] {
+        /* enough for "0x" and 8 digit address */
+        width: 10ch;
+      }
+
+      #listing > thead th[data-col="diffs"],
+      #listing > thead th[data-col="matching"] {
+        width: 8ch;
       }
 
       #listing > thead th > div {
@@ -81,11 +88,9 @@
       }
 
       #listing > thead th:last-child > div {
+        /* Draw the sort triangle to the left of the last column. */
+        flex-direction: row-reverse;
         justify-content: right;
-      }
-
-      #listing > thead th[data-col="name"] {
-        width: 60%;
       }
 
       .diffneg {
@@ -179,6 +184,82 @@
         font-size: 1.2em;
         margin-bottom: 0;
       }
+
+      tr[data-diff]:not([hidden]) {
+        contain: paint;
+      }
+
+      tr[data-diff] > td {
+        border: 1px #f0f0f0 solid;
+        border-bottom: 0px none;
+        display: table-cell;
+        padding: 0.5em;
+        word-break: break-all !important;
+      }
+
+      tr[data-diff] > td > div.no-diff {
+        font-style: italic;
+        text-align: center;
+      }
+
+      tr[data-address] > td[data-col="name"]:hover {
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-style: dotted;
+      }
+
+      tr[data-address] > td:not(data-col="name"]) {
+        white-space: nowrap;
+      }
+
+      tr[data-address] > td {
+        border-top: 1px #f0f0f0 solid;
+        display: table-cell;
+        padding: 0.5em;
+        vertical-align: top;
+        white-space: nowrap;
+      }
+
+      tr[data-address] > td[data-col="name"] {
+        white-space: wrap;
+        word-break: break-all !important;
+      }
+
+      tr[data-address] > td:last-child {
+        text-align: right;
+      }
+
+      can-copy {
+        position: relative;
+        cursor: pointer;
+      }
+      can-copy::after {
+        background-color: #fff;
+        color: #222;
+        display: none;
+        font-size: 12px;
+        padding: 1px 2px;
+        width: fit-content;
+        border-radius: 1px;
+        text-align: center;
+        bottom: 120%;
+        left: 0;
+        box-shadow: 0 4px 14px 0 rgba(0,0,0,.2), 0 0 0 1px rgba(0,0,0,.05);
+        position: absolute;
+        white-space: nowrap;
+        transition: .1s;
+        content: 'Copy to clipboard';
+      }
+      can-copy:hover {
+        text-decoration: underline;
+        text-decoration-style: dotted;
+      }
+      can-copy:hover::after {
+        display: block;
+      }
+      can-copy[copied]:hover::after {
+        content: 'Copied!';
+      }
     </style>
     <script>
       var report = {{{report}}};
@@ -224,145 +305,7 @@
         </div>
       </listing-options>
       <listing-table>
-        <table id="listing">
-          <thead>
-            <tr>
-              <th data-col="address">
-                <div>
-                  <span>Address</span>
-                  <sort-indicator/>
-                </div>
-              </th>
-              <th data-col="recomp">
-                <div>
-                  <span>Recomp</span>
-                  <sort-indicator/>
-                </div>
-              </th>
-              <th data-col="name">
-                <div>
-                  <span>Name</span>
-                  <sort-indicator/>
-                </div>
-              </th>
-              <th data-col="diffs" data-no-sort></th>
-              <th data-col="matching">
-                <div>
-                  <sort-indicator></sort-indicator>
-                  <span>Matching</span>
-                </div>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-        </table>
       </listing-table>
     </div>
-    <template id="funcrow-template">
-      <style>
-        :host(:not([hidden])) {
-          display: table-row;
-        }
-
-        :host(:not([show-recomp])) > div[data-col="recomp"] {
-          display: none;
-        }
-
-        div[data-col="name"]:hover {
-          cursor: pointer;
-        }
-
-        div[data-col="name"]:hover > ::slotted(*) {
-          text-decoration: underline;
-          text-decoration-style: dotted;
-        }
-
-        ::slotted(*:not([slot="name"])) {
-          white-space: nowrap;
-        }
-
-        :host > div {
-          border-top: 1px #f0f0f0 solid;
-          display: table-cell;
-          padding: 0.5em;
-          word-break: break-all !important;
-        }
-
-        :host > div:last-child {
-          text-align: right;
-        }
-      </style>
-      <div data-col="address"><can-copy><slot name="address"></slot></can-copy></div>
-      <div data-col="recomp"><can-copy><slot name="recomp"></slot></can-copy></div>
-      <div data-col="name"><slot name="name"></slot></div>
-      <div data-col="diffs"><slot name="diffs"></slot></div>
-      <div data-col="matching"><slot name="matching"></slot></div>
-    </template>
-    <template id="diffrow-template">
-      <style>
-        :host(:not([hidden])) {
-          display: table-row;
-          contain: paint;
-        }
-
-        td.singleCell {
-          border: 1px #f0f0f0 solid;
-          border-bottom: 0px none;
-          display: table-cell;
-          padding: 0.5em;
-          word-break: break-all !important;
-        }
-      </style>
-      <td class="singleCell" colspan="5">
-        <slot></slot>
-      </td>
-    </template>
-    <template id="nodiff-template">
-      <style>
-        ::slotted(*) {
-          font-style: italic;
-          text-align: center;
-        }
-      </style>
-      <slot></slot>
-    </template>
-    <template id="can-copy-template">
-      <style>
-        :host {
-          position: relative;
-        }
-        ::slotted(*) {
-          cursor: pointer;
-        }
-        slot::after {
-          background-color: #fff;
-          color: #222;
-          display: none;
-          font-size: 12px;
-          padding: 1px 2px;
-          width: fit-content;
-          border-radius: 1px;
-          text-align: center;
-          bottom: 120%;
-          box-shadow: 0 4px 14px 0 rgba(0,0,0,.2), 0 0 0 1px rgba(0,0,0,.05);
-          position: absolute;
-          white-space: nowrap;
-          transition: .1s;
-          content: 'Copy to clipboard';
-        }
-        ::slotted(*:hover) {
-          text-decoration: underline;
-          text-decoration-style: dotted;
-        }
-        slot:hover::after {
-          display: block;
-        }
-        :host([copied]) > slot:hover::after {
-          content: 'Copied!';
-        }
-      </style>
-      <slot></slot>
-    </template>
   </body>
 </html>

--- a/webui/e2e/columnHeader.spec.js
+++ b/webui/e2e/columnHeader.spec.js
@@ -11,7 +11,7 @@ test.describe('Column headers', () => {
     const addressHeader = page.locator('thead').getByText(/Address/);
 
     // TODO: improve locator
-    const topRow = page.locator('func-row').nth(0);
+    const topRow = page.locator('tr[data-address]').nth(0);
 
     // First address in test data
     await expect(topRow).toContainText('0x401000');
@@ -31,7 +31,7 @@ test.describe('Column headers', () => {
     // TODO: improve locators
     const addressHeader = page.locator('thead').getByText(/Address/);
     const nameHeader = page.locator('thead').getByText(/Name/);
-    const topRow = page.locator('func-row').nth(0);
+    const topRow = page.locator('tr[data-address]').nth(0);
 
     // Should be sorted by orig address to start.
     await expect(topRow).toContainText('0x401000');
@@ -50,7 +50,7 @@ test.describe('Column headers', () => {
 
     // Now sorting by name in reverse alphabetical order.
     // Inverted sort on address retained for the new column.
-    await expect(topRow).toContainText('_wctomb');
+    await expect(topRow).toContainText('list<ROI *,allocator<ROI *> >::_Buynode');
   });
 
   test('Update sort indicator', async ({ page }) => {

--- a/webui/e2e/diffRows.spec.js
+++ b/webui/e2e/diffRows.spec.js
@@ -7,62 +7,62 @@ test.beforeEach(async ({ page }) => {
 test.describe('Diff rows', () => {
   test('Should add/remove element', async ({ page }) => {
     // Name text to click that toggles the diff row.
-    const nameLink = page.locator('func-row').getByText('IsleApp::IsleApp');
+    const nameLink = page.locator('tr[data-address]').getByText('IsleApp::IsleApp');
 
     // There are none to start
-    await expect(page.locator('diff-row')).toHaveCount(0);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(0);
 
     // Create diff-row element
     await nameLink.click();
-    await expect(page.locator('diff-row')).toHaveCount(1);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(1);
 
     // Remove diff-row element
     await nameLink.click();
-    await expect(page.locator('diff-row')).toHaveCount(0);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(0);
   });
 
   test('"No diff" message', async ({ page }) => {
     // Get the first row with 100% score (and not an effective match)
-    const matchRow = page.locator('func-row', { hasText: '100.00%', exact: true }).nth(0);
+    const matchRow = page.locator('tr[data-address]', { hasText: '100.00%', exact: true }).nth(0);
     // TODO: This highlights a potential design flaw: there is no obvious indication that
     // clicking the name (and only the name) of the row will expand the diff display.
-    const link = matchRow.locator('div[data-col="name"]');
+    const link = matchRow.locator('td[data-col="name"]');
 
     // Make sure there are no diff rows (so our next locator can cast a wide net)
-    await expect(page.locator('diff-row')).toHaveCount(0);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(0);
 
     // Expand the diff
     await link.click();
 
     // Should now see the "no diff" message
-    await expect(page.locator('diff-row').getByText('no diff')).toBeAttached();
+    await expect(page.locator('tr[data-diff]').getByText('no diff')).toBeAttached();
 
     // Close the diff row
     await link.click();
 
     // The message should be gone
-    await expect(page.locator('diff-row').getByText('no diff')).not.toBeAttached();
+    await expect(page.locator('tr[data-diff]').getByText('no diff')).not.toBeAttached();
   });
 
   test('"Stub" message', async ({ page }) => {
     // Get the first stub
-    const stubRow = page.locator('func-row', { hasText: 'stub', exact: true }).nth(0);
-    const link = stubRow.locator('div[data-col="name"]');
+    const stubRow = page.locator('tr[data-address]', { hasText: 'stub', exact: true }).nth(0);
+    const link = stubRow.locator('td[data-col="name"]');
 
     // Make sure there are no diff rows (so our next locator can look for any diff-row element)
-    await expect(page.locator('diff-row')).toHaveCount(0);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(0);
 
     // Expand the diff
     await link.click();
 
     // Should now see the "no diff" message
-    await expect(page.locator('diff-row').getByText('no diff')).toBeAttached();
+    await expect(page.locator('tr[data-diff]').getByText('no diff')).toBeAttached();
 
     // Close the diff row
     await link.click();
 
     // The message should be gone
-    await expect(page.locator('diff-row').getByText('no diff')).not.toBeAttached();
+    await expect(page.locator('tr[data-diff]').getByText('no diff')).not.toBeAttached();
   });
 
   test('Diff display', async ({ page }) => {
@@ -71,23 +71,21 @@ test.describe('Diff rows', () => {
     await page.getByRole('checkbox', { name: /Hide stubs/ }).click();
 
     // Make sure there are no diff rows (so our next locator can look for any diff-row element)
-    await expect(page.locator('diff-row')).toHaveCount(0);
+    await expect(page.locator('tr[data-diff]')).toHaveCount(0);
 
     // Expand diff row
-    const topRow = page.locator('func-row').nth(0);
-    await topRow.locator('div[data-col="name"]').click();
+    const topRow = page.locator('tr[data-address]').nth(0);
+    await topRow.locator('td[data-col="name"]').click();
 
     // Searching for unified diff display elements.
-    await expect(page.locator('diff-row')).toContainText('---');
-    await expect(page.locator('diff-row')).toContainText('+++');
+    await expect(page.locator('tr[data-diff]')).toContainText('---');
+    await expect(page.locator('tr[data-diff]')).toContainText('+++');
   });
 
   test('Should stay open after entity filtering', async ({ page }) => {
-    const nameLink = page.locator('func-row').getByText('IsleApp::IsleApp');
+    const nameLink = page.locator('tr[data-address]').getByText('IsleApp::IsleApp');
     const searchbox = page.getByRole('searchbox');
-
-    // TODO: Not sure of a better way to identify this element in the current design
-    const diffRow = page.locator('diff-row[data-address="0x401000"]');
+    const diffRow = page.locator('tr[data-diff]');
 
     // Diff row should appear when we toggle this entity.
     await nameLink.click();

--- a/webui/e2e/entityTable.spec.js
+++ b/webui/e2e/entityTable.spec.js
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('');
+});
+
+test('Entity names with HTML-escaped characters', async ({ page }) => {
+  // Rows in the table with characters that should be escaped for XML/HTML should appear correctly.
+  // For example: <, >, and &.
+  // These test cases should be on the first page and visible right away.
+  await expect(page.locator('tr[data-address]').getByText('Vector2::MulImpl(float const &)')).toBeAttached();
+  await expect(page.locator('tr[data-address]').getByText('list<ROI *,allocator<ROI *> >::_Buynode')).toBeAttached();
+  await expect(page.locator('tr[data-address]').getByText("MxParam::`scalar deleting destructor'")).toBeAttached();
+});

--- a/webui/e2e/searchBar.spec.js
+++ b/webui/e2e/searchBar.spec.js
@@ -11,8 +11,8 @@ test.describe('Search bar', () => {
 
     // Locators for rows matching and not matching our intended query.
     // TODO: use better locator for table rows/cells
-    const notMatchRows = page.locator('func-row').filter({ hasNotText: query });
-    const matchRows = page.locator('func-row').filter({ hasText: query });
+    const notMatchRows = page.locator('tr[data-address]').filter({ hasNotText: query });
+    const matchRows = page.locator('tr[data-address]').filter({ hasText: query });
 
     // Should have a variety of rows to start.
     await expect(notMatchRows).not.toHaveCount(0);
@@ -37,7 +37,7 @@ test.describe('Search bar', () => {
     const searchbox = page.getByRole('searchbox');
 
     // TODO: use better locator for table rows/cells
-    const rows = page.locator('func-row');
+    const rows = page.locator('tr[data-address]');
 
     // Make sure we have rows displayed.
     await expect(rows).not.toHaveCount(0);
@@ -54,7 +54,7 @@ test.describe('Search bar', () => {
     const radio = page.getByRole('radio', { name: 'Asm output' });
 
     // TODO: use better locator for table rows/cells
-    const rows = page.locator('func-row');
+    const rows = page.locator('tr[data-address]');
 
     // Make sure we have some rows
     await expect(rows).not.toHaveCount(0);

--- a/webui/e2e/tableOption.spec.js
+++ b/webui/e2e/tableOption.spec.js
@@ -56,7 +56,7 @@ test.describe('Table display options', () => {
     const recompHeader = page.getByRole('rowgroup').getByText(/Recomp/);
 
     // First row should display the original address, but not the recomp address.
-    const topRow = page.locator('func-row').nth(0);
+    const topRow = page.locator('tr[data-address]').nth(0);
     await expect(topRow.getByText('0x401000')).toBeVisible();
     await expect(topRow.getByText('0x501000')).not.toBeVisible();
 

--- a/webui/testdata.json
+++ b/webui/testdata.json
@@ -22,6 +22,20 @@
       "stub": true
     },
     {
+      "address": "0x401270",
+      "diff": [],
+      "matching": 1.0,
+      "name": "Vector2::MulImpl(float const &)",
+      "recomp": "0x501270"
+    },
+    {
+      "address": "0x401280",
+      "diff": [],
+      "matching": 1.0,
+      "name": "list<ROI *,allocator<ROI *> >::_Buynode",
+      "recomp": "0x501280"
+    },
+    {
       "address": "0x4013b0",
       "diff": [],
       "matching": 1.0,


### PR DESCRIPTION
This makes the following changes:

- The table of entities (internal name: `listing-table`) is now completely controlled by the javascript component code. It had used the `<thead>` element in `template.html` as a sort of hybrid, but now all the internal HTML is set in code.
  - ~Doing it this way means we need to escape the entity name field: template functions will contain angle brackets that disrupt the HTML. There is a new test (and new dummy data) to check for this.~
- Removed the `func-row` and `diff-row` components. They were wrappers for the table rows. This was technically not valid HTML because only `<tr>` elements should be children of `<table>` or `<tbody>`.
   - As a result of this, the query selectors used in the playwright tests now look for rows with the `data-address` or `data-diff` attributes. This still isn't perfect (they would prefer you use `getByRole('row')`) but it's a little better.
- The "show recomp column" option now rewrites the HTML instead of using CSS classes to hide the column in place. The `colspan` used in the diff display rows is now accurate to the number of columns that are there. The upshot here is that the playwright tests succeed even if you remove the `<style>` section completely.

- Custom components no longer use shadow DOM or `<template>` / `<slot>` elements. There wasn't a pressing reason to use them except for maybe the clipboard component. The old design was just hacked together.
- Removed the `no-diff` component. It's just a `<div>` with text.

We end up with less code and redraw performance that should be the same or better. (I'll verify this again before merging just for style points.)

My end goal with this is to give users/teams the option to customize the HTML output. We provide a series of custom components to display the data from the reccmp report and you position them on the page however you like, using whatever CSS style you want.