### PR TITLE
Adds handling of compiler entropy for mov-cmp-jmp and tests

### DIFF
--- a/reccmp/isledecomp/compare/asm/fixes.py
+++ b/reccmp/isledecomp/compare/asm/fixes.py
@@ -43,24 +43,7 @@ def is_operand_swap(a: str, b: str) -> bool:
     return a.partition(", ")[0] != b.partition(", ")[0] and sorted(a) == sorted(b)
 
 
-def can_cmp_swap(orig: list[str], recomp: list[str]) -> bool:
-    # Make sure we have 1 cmp and 1 jmp for both
-    if len(orig) != 2 or len(recomp) != 2:
-        return False
-
-    if not orig[0].startswith("cmp") or not recomp[0].startswith("cmp"):
-        return False
-
-    if not orig[1].startswith("j") or not recomp[1].startswith("j"):
-        return False
-
-    # Checking two things:
-    # Are the cmp operands flipped?
-    # Is the jump instruction compatible with a flip?
-    return is_operand_swap(orig[0], recomp[0]) and jump_swap_ok(orig[1], recomp[1])
-
-
-def patch_jump(a: str, b: str) -> str:
+def get_patched_jump(a: str, b: str) -> str:
     """For jump instructions a, b, return `(mnemonic_a) (operand_b)`.
     The reason to do it this way (instead of just returning `a`) is that
     the jump instructions might use different displacement offsets
@@ -72,20 +55,93 @@ def patch_jump(a: str, b: str) -> str:
     return mnemonic_a + " " + operand_b
 
 
+def patch_mov_cmp_jmp(orig: list[str], recomp: list[str]) -> list[int]:
+    """Can we resolve the diffs between orig and recomp by patching
+    swapped cmp instructions?
+    For example:
+        mov eax, dword ptr [ebp - 0x4]  mov eax, dword ptr [ebp - 0x8]
+        cmp dword ptr [ebp - 0x8]       cmp dword ptr [ebp - 0x4]
+        ja .label                       jb .label
+    """
+
+    # find the first "cmp" instruction
+    cmp_index = next((i for i, s in enumerate(orig) if s.startswith("cmp")), -1)
+
+    # return if not found, or only found on first or last line
+    if cmp_index in (-1, 0, len(orig) - 1):
+        return []
+
+    if not orig[cmp_index - 1].startswith("mov") or not recomp[
+        cmp_index - 1
+    ].startswith("mov"):
+        return []
+
+    if not recomp[cmp_index].startswith("cmp"):
+        return []
+
+    # if the last lines are not a compatible jump difference
+    if not jump_swap_ok(orig[cmp_index + 1], recomp[cmp_index + 1]):
+        return []
+
+    # Checking if the combination of mov + cmp include the same set of characters
+    # - that is, the set of operands are the same although switched in order
+    if sorted(orig[cmp_index - 1] + orig[cmp_index]) == sorted(
+        recomp[cmp_index - 1] + recomp[cmp_index]
+    ):
+        # We only register the fix if the jmp actually matches
+        if orig[cmp_index + 1] == get_patched_jump(
+            orig[cmp_index + 1], recomp[cmp_index + 1]
+        ):
+            return [0, 1, 2]
+    return []
+
+
+def patch_cmp_jmp(orig: list[str], recomp: list[str]) -> bool:
+    """Can we resolve the diffs between orig and recomp by patching
+    swapped cmp instructions?
+    For example:
+        cmp eax, ebx                    cmp ebx, eax
+        je .label                       je .label
+
+        cmp eax, ebx                    cmp ebx, eax
+        ja .label                       jb .label
+    """
+
+    # find the first "cmp" instruction
+    cmp_index = next((i for i, s in enumerate(orig) if s.startswith("cmp")), -1)
+    # return if not found, or only found on the last line
+    if cmp_index in (-1, len(orig) - 1):
+        return []
+
+    # return if the recmp doesn't also have "cmp" in the same line
+    if not recomp[cmp_index].startswith("cmp"):
+        return []
+
+    # next line expected to be type of jmp
+    if not jump_swap_ok(orig[cmp_index + 1], recomp[cmp_index + 1]):
+        return []
+
+    # Checking two things:
+    # Are the cmp operands flipped?
+    # Is the jump instruction compatible with a flip?
+    if is_operand_swap(orig[cmp_index], recomp[cmp_index]):
+        if orig[cmp_index + 1] == get_patched_jump(
+            orig[cmp_index + 1], recomp[cmp_index + 1]
+        ):
+            return [cmp_index, cmp_index + 1]
+    return []
+
+
 def patch_cmp_swaps(
     codes: Sequence[DiffOpcode], orig_asm: list[str], recomp_asm: list[str]
 ) -> set[int]:
     """Can we resolve the diffs between orig and recomp by patching
     swapped cmp instructions?
-    For example:
-        cmp eax, ebx            cmp ebx, eax
-        je .label               je .label
-
-        cmp eax, ebx            cmp ebx, eax
-        ja .label               jb .label
     """
 
     fixed_lines = set()
+
+    patch_fns = [patch_cmp_jmp, patch_mov_cmp_jmp]
 
     for code, i1, i2, j1, j2 in codes:
         # To save us the trouble of finding "compatible" cmp instructions
@@ -95,15 +151,12 @@ def patch_cmp_swaps(
 
         # If the ranges in orig and recomp are not equal, use the shorter one
         for i, j in zip(range(i1, i2), range(j1, j2)):
-            if can_cmp_swap(orig_asm[i : i + 2], recomp_asm[j : j + 2]):
-                # Patch cmp
-                fixed_lines.add(j)
-
-                # Patch the jump if necessary
-                patched = patch_jump(orig_asm[i + 1], recomp_asm[j + 1])
-                # We only register a fix if it actually matches
-                if orig_asm[i + 1] == patched:
-                    fixed_lines.add(j + 1)
+            for fn in patch_fns:
+                this_patch_lines = fn(orig_asm[i : i + 3], recomp_asm[j : j + 3])
+                # if we have fixed lines by this patcher, add them to the combined `fixed_lines`
+                if len(this_patch_lines) > 0:
+                    fixed_lines.update([j + x for x in this_patch_lines])
+                    break
 
     return fixed_lines
 

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,84 @@
+import difflib
+from reccmp.isledecomp.compare.asm.fixes import assert_fixup, find_effective_match
+
+
+def test_fix_cmp_jmp():
+    orig_asm = ["mov eax, 1",
+                "mov ebx, 2",
+                "cmp eax, ebx",
+                "jg 0x1"
+    ]
+    recomp_asm = [
+                "mov eax, 1",
+                "mov ebx, 2",
+                "cmp ebx, eax",
+                "jl 0x1"
+    ]
+
+    diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+    assert diff.ratio != 1.0
+
+    is_effective = find_effective_match(
+        diff.get_opcodes(), orig_asm, recomp_asm
+    )
+
+    assert is_effective == True
+
+def test_fix_mov_cmp_jmp_mem_with_different_operands():
+    """This should not be fixed up, since the operands are different"""
+    orig_asm = [
+                "mov eax, dword ptr [ebp-4]",
+                "cmp dword ptr [global_var_1 (DATA)], eax",
+                "jne 0x1"
+    ]
+    recomp_asm = [
+                "mov eax, dword ptr [global_var_2 (DATA)]",
+                "cmp dword ptr [ebp-4], eax",
+                "jne 0x1"
+    ]
+
+    diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+    is_effective = find_effective_match(
+        diff.get_opcodes(), orig_asm, recomp_asm
+    )
+    assert is_effective == False
+
+def test_fix_mov_cmp_jmp_mem_with_non_matching_jmp():
+
+    orig_asm = [
+                "mov eax, dword ptr [ebp-4]",
+                "cmp dword ptr [gCurrent_key (DATA)], eax",
+                "jl 0x1"
+    ]
+    recomp_asm = [
+                "mov eax, [gCurrent_key (DATA)]",
+                "cmp dword ptr [ebp-4], eax",
+                "jl 0x1"
+    ]
+
+    diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+    is_effective = find_effective_match(
+        diff.get_opcodes(), orig_asm, recomp_asm
+    )
+
+    assert is_effective == False
+
+def test_fix_mov_cmp_jmp_mem_valid():
+
+    orig_asm = [
+                "mov eax, dword ptr [ebp-4]",
+                "cmp dword ptr [gCurrent_key (DATA)], eax",
+                "jne 0x1"
+    ]
+    recomp_asm = [
+                "mov eax, dword ptr [gCurrent_key (DATA)]",
+                "cmp dword ptr [ebp-4], eax",
+                "jne 0x1"
+    ]
+
+    diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+    is_effective = find_effective_match(
+        diff.get_opcodes(), orig_asm, recomp_asm
+    )
+
+    assert is_effective == True


### PR DESCRIPTION
In addition to handling 
```
- cmp eax, ebx,
- jg 0x1
+ cmp ebx, eax
+ jl 0x1
```,

we now handle
```
- mov eax, dword ptr [ebp-4],
- cmp dword ptr [gCurrent_key (DATA)], eax,
- jg 0x1
+ mov eax, dword ptr [gCurrent_key (DATA)],
+ cmp dword ptr [ebp-4], eax,
+ jl 0x1
```

And added tests for both cases