### PR TITLE
Use `TypedDict` for cvdump types parser

### DIFF
--- a/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
+++ b/reccmp/ghidra_scripts/lego_util/pdb_extraction.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 import re
-from typing import Any
 import logging
 
 from reccmp.isledecomp.formats.exceptions import InvalidVirtualAddressError
 from reccmp.isledecomp.cvdump.symbols import SymbolsEntry
 from reccmp.isledecomp.compare import Compare
 from reccmp.isledecomp.compare.db import ReccmpMatch
+from reccmp.isledecomp.cvdump.types import CvdumpParsedType
 
 logger = logging.getLogger(__file__)
 
@@ -65,7 +65,7 @@ class PdbFunctionExtractor:
         "STD Near": "__stdcall",
     }
 
-    def _get_cvdump_type(self, type_name: str | None) -> dict[str, Any] | None:
+    def _get_cvdump_type(self, type_name: str | None) -> CvdumpParsedType | None:
         return (
             None
             if type_name is None
@@ -120,9 +120,7 @@ class PdbFunctionExtractor:
                 )
 
         call_type = self._call_type_map[function_type["call_type"]]
-
-        # parse as hex number, default to 0
-        this_adjust = int(function_type.get("this_adjust", "0"), 16)
+        this_adjust = function_type.get("this_adjust", 0)
 
         return FunctionSignature(
             original_function_symbol=fn,

--- a/reccmp/ghidra_scripts/lego_util/type_importer.py
+++ b/reccmp/ghidra_scripts/lego_util/type_importer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Iterator, NamedTuple, TypeVar
+from typing import Callable, Iterator, NamedTuple, TypeVar
 
 # Disable spurious warnings in vscode / pylance
 # pyright: reportMissingModuleSource=false
@@ -225,9 +225,8 @@ class PdbTypeImporter:
         for existing_variant in result.getNames():
             result.remove(existing_variant)
 
-        variants: list[dict[str, Any]] = field_list["variants"]
-        for variant in variants:
-            result.add(variant["name"], variant["value"])
+        for variant in field_list.get("variants", []):
+            result.add(variant.name, variant.value)
 
         return result
 

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -703,9 +703,9 @@ class CvdumpTypesParser:
         return {
             "type": leaf_type,
             "return_type": match.group("return_type"),
-            "call_type": match.group("call_type"),
             "class_type": match.group("class_type"),
             "this_type": match.group("this_type"),
+            "call_type": match.group("call_type"),
             "func_attr": match.group("func_attr"),
             "num_params": int(match.group("num_params")),
             "arg_list_type": match.group("arg_list_type"),

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -334,7 +334,7 @@ class CvdumpTypesParser:
         members: list[FieldListItem] = []
 
         if "super" in field_obj:
-            for super_id, _ in field_obj["super"].items():
+            for super_id in field_obj["super"].keys():
                 # May need to resolve forward ref.
                 superclass = self.get(super_id)
                 if superclass.members is not None:
@@ -506,38 +506,40 @@ class CvdumpTypesParser:
                 continue
 
             try:
-                if leaf_type == "LF_MODIFIER":
-                    self.keys[leaf_id] = self.read_modifier(leaf, leaf_type)
+                match leaf_type:
+                    case "LF_MODIFIER":
+                        self.keys[leaf_id] = self.read_modifier(leaf, leaf_type)
 
-                elif leaf_type == "LF_ARRAY":
-                    self.keys[leaf_id] = self.read_array(leaf, leaf_type)
+                    case "LF_ARRAY":
+                        self.keys[leaf_id] = self.read_array(leaf, leaf_type)
 
-                elif leaf_type == "LF_FIELDLIST":
-                    self.keys[leaf_id] = self.read_fieldlist(leaf, leaf_type)
+                    case "LF_FIELDLIST":
+                        self.keys[leaf_id] = self.read_fieldlist(leaf, leaf_type)
 
-                elif leaf_type == "LF_ARGLIST":
-                    self.keys[leaf_id] = self.read_arglist(leaf, leaf_type)
+                    case "LF_ARGLIST":
+                        self.keys[leaf_id] = self.read_arglist(leaf, leaf_type)
 
-                elif leaf_type == "LF_MFUNCTION":
-                    self.keys[leaf_id] = self.read_mfunction(leaf, leaf_type)
+                    case "LF_MFUNCTION":
+                        self.keys[leaf_id] = self.read_mfunction(leaf, leaf_type)
 
-                elif leaf_type == "LF_PROCEDURE":
-                    self.keys[leaf_id] = self.read_procedure(leaf, leaf_type)
+                    case "LF_PROCEDURE":
+                        self.keys[leaf_id] = self.read_procedure(leaf, leaf_type)
 
-                elif leaf_type in ["LF_CLASS", "LF_STRUCTURE"]:
-                    self.keys[leaf_id] = self.read_class_or_struct(leaf, leaf_type)
+                    case "LF_CLASS" | "LF_STRUCTURE":
+                        self.keys[leaf_id] = self.read_class_or_struct(leaf, leaf_type)
 
-                elif leaf_type == "LF_POINTER":
-                    self.keys[leaf_id] = self.read_pointer(leaf, leaf_type)
+                    case "LF_POINTER":
+                        self.keys[leaf_id] = self.read_pointer(leaf, leaf_type)
 
-                elif leaf_type == "LF_ENUM":
-                    self.keys[leaf_id] = self.read_enum(leaf, leaf_type)
+                    case "LF_ENUM":
+                        self.keys[leaf_id] = self.read_enum(leaf, leaf_type)
 
-                elif leaf_type == "LF_UNION":
-                    self.keys[leaf_id] = self.read_union(leaf, leaf_type)
-                else:
-                    # Check for exhaustiveness
-                    logger.error("Unhandled data in mode: %s", leaf_type)
+                    case "LF_UNION":
+                        self.keys[leaf_id] = self.read_union(leaf, leaf_type)
+
+                    case _:
+                        # Check for exhaustiveness
+                        logger.error("Unhandled data in mode: %s", leaf_type)
 
             except AssertionError:
                 logger.error("Failed to parse PDB types leaf:\n%s", leaf)

--- a/reccmp/isledecomp/cvdump/types.py
+++ b/reccmp/isledecomp/cvdump/types.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 import re
 import logging
-from typing import Any, NamedTuple
+from typing import NamedTuple
+from typing_extensions import NotRequired, TypedDict
 
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,65 @@ def join_member_names(parent: str, child: str | None) -> str:
     return f"{parent}.{child}"
 
 
+CvdumpTypeKey = str
+
+
+class LfEnumAttrs(TypedDict):
+    field_list_type: NotRequired[CvdumpTypeKey]
+    is_forward_ref: NotRequired[bool]
+    is_nested: NotRequired[bool]
+    name: NotRequired[str]
+    num_members: NotRequired[int]
+    udt: NotRequired[CvdumpTypeKey]
+    underlying_type: NotRequired[CvdumpTypeKey]
+
+
+class CvdumpParsedType(TypedDict):
+    type: str  # leaf type
+
+    # Used by many leaf types
+    name: NotRequired[str]
+    size: NotRequired[int]
+    is_forward_ref: NotRequired[bool]
+    field_list_type: NotRequired[CvdumpTypeKey]
+    udt: NotRequired[CvdumpTypeKey]
+
+    # LF_ARRAY
+    array_type: NotRequired[CvdumpTypeKey]
+
+    # LF_ENUM
+    is_nested: NotRequired[bool]
+    num_members: NotRequired[int]
+    underlying_type: NotRequired[CvdumpTypeKey]
+
+    # LF_MODIFIER
+    modifies: NotRequired[CvdumpTypeKey]
+
+    # LF_FIELDLIST
+    super: NotRequired[dict[CvdumpTypeKey, int]]
+    vbase: NotRequired[VirtualBasePointer]
+    members: NotRequired[list[FieldListItem]]
+    variants: NotRequired[list[dict[str, int | str]]]
+
+    # LF_ARGLIST
+    argcount: NotRequired[int]
+    args: NotRequired[list[CvdumpTypeKey]]
+
+    # LF_POINTER
+    element_type: NotRequired[CvdumpTypeKey]
+    containing_class: NotRequired[str]
+
+    # LF_PROCEDURE / LF_MFUNCTION
+    return_type: NotRequired[CvdumpTypeKey]
+    call_type: NotRequired[str]
+    class_type: NotRequired[CvdumpTypeKey]
+    this_type: NotRequired[CvdumpTypeKey]
+    func_attr: NotRequired[str]
+    num_params: NotRequired[int]
+    arg_list_type: NotRequired[CvdumpTypeKey]
+    this_adjust: NotRequired[int]
+
+
 class CvdumpTypesParser:
     """Parser for cvdump output, TYPES section.
     Tricky enough that it demands its own parser."""
@@ -223,11 +283,10 @@ class CvdumpTypesParser:
         )
     )
 
-    LF_ENUM_ATTRIBUTES = [
-        re.compile(r"^\s*# members = (?P<num_members>\d+)$"),
-        # the enum name can have both commas and whitespace, so '.+' is okay
-        re.compile(r"^\s*enum name = (?P<name>.+)$"),
-    ]
+    LF_ENUM_MEMBER_RE = re.compile(r"^\s*# members = (?P<num_members>\d+)$")
+    # the enum name can have both commas and whitespace, so '.+' is okay
+    LF_ENUM_NAME_RE = re.compile(r"^\s*enum name = (?P<name>.+)$")
+
     LF_ENUM_TYPES = re.compile(
         r"^\s*type = (?P<underlying_type>\S+) field list type (?P<field_type>0x\w{4})$"
     )
@@ -251,10 +310,9 @@ class CvdumpTypesParser:
     }
 
     def __init__(self) -> None:
-        self.mode: str | None = None
-        self.keys: dict[str, dict[str, Any]] = {}
+        self.keys: dict[str, CvdumpParsedType] = {}
 
-    def _get_field_list(self, type_obj: dict[str, Any]) -> list[FieldListItem]:
+    def _get_field_list(self, type_obj: CvdumpParsedType) -> list[FieldListItem]:
         """Return the field list for the given LF_CLASS/LF_STRUCTURE reference"""
 
         if type_obj.get("type") == "LF_FIELDLIST":
@@ -265,26 +323,19 @@ class CvdumpTypesParser:
 
         members: list[FieldListItem] = []
 
-        super_ids = field_obj.get("super", [])
-        for super_id in super_ids:
-            # May need to resolve forward ref.
-            superclass = self.get(super_id)
-            if superclass.members is not None:
-                members += superclass.members
+        if "super" in field_obj:
+            for super_id, _ in field_obj["super"].items():
+                # May need to resolve forward ref.
+                superclass = self.get(super_id)
+                if superclass.members is not None:
+                    members += superclass.members
 
         raw_members = field_obj.get("members", [])
-        members += [
-            FieldListItem(
-                offset=m["offset"],
-                type=m["type"],
-                name=m["name"],
-            )
-            for m in raw_members
-        ]
+        members += raw_members
 
         return sorted(members, key=lambda m: m.offset)
 
-    def _mock_array_members(self, type_obj: dict[str, Any]) -> list[FieldListItem]:
+    def _mock_array_members(self, type_obj: CvdumpParsedType) -> list[FieldListItem]:
         """LF_ARRAY elements provide the element type and the total size.
         We want the list of "members" as if this was a struct."""
 
@@ -442,84 +493,79 @@ class CvdumpTypesParser:
 
             (leaf_id, leaf_type) = match.groups()
             if leaf_type not in self.MODES_OF_INTEREST:
-                self.mode = None
                 continue
 
-            # Add the leaf to our dictionary and add details specific to the leaf type.
-            self.mode = leaf_type
-            self.keys[leaf_id] = {"type": leaf_type}
-
-            this_key = self.keys[leaf_id]
-
             try:
-                if self.mode == "LF_MODIFIER":
-                    this_key.update(self.read_modifier(leaf))
+                if leaf_type == "LF_MODIFIER":
+                    self.keys[leaf_id] = self.read_modifier(leaf, leaf_type)
 
-                elif self.mode == "LF_ARRAY":
-                    this_key.update(self.read_array(leaf))
+                elif leaf_type == "LF_ARRAY":
+                    self.keys[leaf_id] = self.read_array(leaf, leaf_type)
 
-                elif self.mode == "LF_FIELDLIST":
-                    this_key.update(self.read_fieldlist(leaf))
+                elif leaf_type == "LF_FIELDLIST":
+                    self.keys[leaf_id] = self.read_fieldlist(leaf, leaf_type)
 
-                elif self.mode == "LF_ARGLIST":
-                    this_key.update(self.read_arglist(leaf))
+                elif leaf_type == "LF_ARGLIST":
+                    self.keys[leaf_id] = self.read_arglist(leaf, leaf_type)
 
-                elif self.mode == "LF_MFUNCTION":
-                    this_key.update(self.read_mfunction(leaf))
+                elif leaf_type == "LF_MFUNCTION":
+                    self.keys[leaf_id] = self.read_mfunction(leaf, leaf_type)
 
-                elif self.mode == "LF_PROCEDURE":
-                    this_key.update(self.read_procedure(leaf))
+                elif leaf_type == "LF_PROCEDURE":
+                    self.keys[leaf_id] = self.read_procedure(leaf, leaf_type)
 
-                elif self.mode in ["LF_CLASS", "LF_STRUCTURE"]:
-                    this_key.update(self.read_class_or_struct(leaf))
+                elif leaf_type in ["LF_CLASS", "LF_STRUCTURE"]:
+                    self.keys[leaf_id] = self.read_class_or_struct(leaf, leaf_type)
 
-                elif self.mode == "LF_POINTER":
-                    this_key.update(self.read_pointer(leaf))
+                elif leaf_type == "LF_POINTER":
+                    self.keys[leaf_id] = self.read_pointer(leaf, leaf_type)
 
-                elif self.mode == "LF_ENUM":
-                    this_key.update(self.read_enum(leaf))
+                elif leaf_type == "LF_ENUM":
+                    self.keys[leaf_id] = self.read_enum(leaf, leaf_type)
 
-                elif self.mode == "LF_UNION":
-                    this_key.update(self.read_union(leaf))
+                elif leaf_type == "LF_UNION":
+                    self.keys[leaf_id] = self.read_union(leaf, leaf_type)
                 else:
                     # Check for exhaustiveness
-                    logger.error("Unhandled data in mode: %s", self.mode)
+                    logger.error("Unhandled data in mode: %s", leaf_type)
 
             except AssertionError:
                 logger.error("Failed to parse PDB types leaf:\n%s", leaf)
 
-    def read_modifier(self, leaf: str) -> dict[str, Any]:
+    def read_modifier(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.MODIFIES_RE.search(leaf)
         assert match is not None
 
         # For convenience, because this is essentially the same thing
         # as an LF_CLASS forward ref.
         return {
+            "type": leaf_type,
             "is_forward_ref": True,
             "modifies": normalize_type_id(match.group("type")),
         }
 
-    def read_array(self, leaf: str) -> dict[str, Any]:
+    def read_array(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_ARRAY_RE.search(leaf)
         assert match is not None
 
         return {
+            "type": leaf_type,
             "array_type": normalize_type_id(match.group("type")),
             "size": int(match.group("length")),
         }
 
-    def read_fieldlist(self, leaf: str) -> dict[str, Any]:
-        obj: dict[str, Any] = {}
-        members = []
+    def read_fieldlist(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
+        obj: CvdumpParsedType = {"type": leaf_type}
+        members: list[FieldListItem] = []
 
         # If this class has a vtable, create a mock member at offset 0
         if self.VTABLE_RE.search(leaf) is not None:
             # For our purposes, any pointer type will do
-            members.append({"offset": 0, "type": "T_32PVOID", "name": "vftable"})
+            members.append(FieldListItem(offset=0, type="T_32PVOID", name="vftable"))
 
         # Superclass is set here in the fieldlist rather than in LF_CLASS
         for match in self.SUPERCLASS_RE.finditer(leaf):
-            superclass_list: dict[str, int] = obj.setdefault("super", {})
+            superclass_list: dict[CvdumpTypeKey, int] = obj.setdefault("super", {})
             superclass_list[normalize_type_id(match.group("type"))] = int(
                 match.group("offset")
             )
@@ -565,11 +611,11 @@ class CvdumpTypesParser:
             virtual_base_pointer.bases.sort(key=lambda x: x.index)
 
         members += [
-            {
-                "offset": int(offset),
-                "type": normalize_type_id(type_),
-                "name": name,
-            }
+            FieldListItem(
+                offset=int(offset),
+                type=normalize_type_id(type_),
+                name=name,
+            )
             for (_, type_, offset, name) in self.LIST_RE.findall(leaf)
         ]
 
@@ -585,8 +631,8 @@ class CvdumpTypesParser:
 
         return obj
 
-    def read_class_or_struct(self, leaf: str) -> dict[str, Any]:
-        obj: dict[str, Any] = {}
+    def read_class_or_struct(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
+        obj: CvdumpParsedType = {"type": leaf_type}
         # Match the reference to the associated LF_FIELDLIST
         match = self.CLASS_FIELD_RE.search(leaf)
         assert match is not None
@@ -612,7 +658,7 @@ class CvdumpTypesParser:
 
         return obj
 
-    def read_arglist(self, leaf: str) -> dict[str, Any]:
+    def read_arglist(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_ARGLIST_ARGCOUNT.match(leaf)
         assert match is not None
         argcount = int(match.group("argcount"))
@@ -620,14 +666,14 @@ class CvdumpTypesParser:
         arglist = [arg_type for (_, arg_type) in self.LF_ARGLIST_ENTRY.findall(leaf)]
         assert len(arglist) == argcount
 
-        obj: dict[str, Any] = {"argcount": argcount}
+        obj: CvdumpParsedType = {"type": leaf_type, "argcount": argcount}
         # Set the arglist only when argcount > 0
         if arglist:
             obj["args"] = arglist
 
         return obj
 
-    def read_pointer(self, leaf: str) -> dict[str, Any]:
+    def read_pointer(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_POINTER_RE.search(leaf)
         assert match is not None
 
@@ -645,23 +691,41 @@ class CvdumpTypesParser:
         )
 
         return {
+            "type": leaf_type,
             "element_type": match.group("element_type"),
             # `containing_class` is set to `None` if not present
             "containing_class": match.group("containing_class"),
         }
 
-    def read_mfunction(self, leaf: str) -> dict[str, Any]:
+    def read_mfunction(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_MFUNCTION_RE.search(leaf)
         assert match is not None
-        return match.groupdict()
+        return {
+            "type": leaf_type,
+            "return_type": match.group("return_type"),
+            "call_type": match.group("call_type"),
+            "class_type": match.group("class_type"),
+            "this_type": match.group("this_type"),
+            "func_attr": match.group("func_attr"),
+            "num_params": int(match.group("num_params")),
+            "arg_list_type": match.group("arg_list_type"),
+            "this_adjust": int(match.group("this_adjust"), 16),
+        }
 
-    def read_procedure(self, leaf: str) -> dict[str, Any]:
+    def read_procedure(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_PROCEDURE_RE.search(leaf)
         assert match is not None
-        return match.groupdict()
+        return {
+            "type": leaf_type,
+            "return_type": match.group("return_type"),
+            "call_type": match.group("call_type"),
+            "func_attr": match.group("func_attr"),
+            "num_params": int(match.group("num_params")),
+            "arg_list_type": match.group("arg_list_type"),
+        }
 
-    def read_enum(self, leaf: str) -> dict[str, Any]:
-        obj: dict[str, Any] = {}
+    def read_enum(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
+        obj: CvdumpParsedType = {"type": leaf_type}
 
         # TODO: still parsing each line for now
         for line in leaf.splitlines()[1:]:
@@ -680,10 +744,12 @@ class CvdumpTypesParser:
         return obj
 
     # pylint: disable=too-many-return-statements
-    def parse_enum_attribute(self, attribute: str) -> dict[str, Any]:
-        for attribute_regex in self.LF_ENUM_ATTRIBUTES:
-            if (match := attribute_regex.match(attribute)) is not None:
-                return match.groupdict()
+    def parse_enum_attribute(self, attribute: str) -> LfEnumAttrs:
+        if (match := self.LF_ENUM_MEMBER_RE.match(attribute)) is not None:
+            return {"num_members": int(match.group("num_members"))}
+
+        if (match := self.LF_ENUM_NAME_RE.match(attribute)) is not None:
+            return {"name": match.group("name")}
 
         if attribute == "NESTED":
             return {"is_nested": True}
@@ -697,18 +763,19 @@ class CvdumpTypesParser:
             assert match is not None
             return {"udt": normalize_type_id(match.group("udt"))}
         if (match := self.LF_ENUM_TYPES.match(attribute)) is not None:
-            result = match.groupdict()
-            result["underlying_type"] = normalize_type_id(result["underlying_type"])
-            return result
+            return {
+                "underlying_type": normalize_type_id(match.group("underlying_type")),
+                "field_list_type": match.group("field_type"),
+            }
 
         logger.error("Unknown attribute in enum: %s", attribute)
         return {}
 
-    def read_union(self, leaf: str) -> dict[str, Any]:
+    def read_union(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.LF_UNION_LINE.search(leaf)
         assert match is not None
 
-        obj: dict[str, Any] = {"name": match.group("name")}
+        obj: CvdumpParsedType = {"type": leaf_type, "name": match.group("name")}
 
         if match.group("field_type") == "0x0000":
             obj["is_forward_ref"] = True

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -6,6 +6,7 @@ from reccmp.isledecomp.cvdump.types import (
     CvdumpTypesParser,
     CvdumpKeyError,
     CvdumpIntegrityError,
+    EnumItem,
     FieldListItem,
     VirtualBaseClass,
     VirtualBasePointer,
@@ -681,9 +682,9 @@ def test_fieldlist_enumerate(parser: CvdumpTypesParser):
     assert fieldlist_enum == {
         "type": "LF_FIELDLIST",
         "variants": [
-            {"name": "c_read", "value": 1},
-            {"name": "c_write", "value": 2},
-            {"name": "c_text", "value": 4},
+            EnumItem(name="c_read", value=1),
+            EnumItem(name="c_write", value=2),
+            EnumItem(name="c_text", value=4),
         ],
     }
 
@@ -923,3 +924,17 @@ def test_enum_with_whitespace_and_comma(
         "type": "LF_ENUM",
         "underlying_type": "T_INT4",
     }
+
+
+def test_this_adjust_hex(empty_parser: CvdumpTypesParser):
+    """The 'this adjust' attribute is a hex number.
+    Make sure we parse it correctly."""
+    empty_parser.read_all(
+        """\
+0x657a : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+    Return type = T_VOID(0003), Class type = 0x15ED, This type = 0x15EE, 
+    Call type = ThisCall, Func attr = none
+    Parms = 3, Arg list type = 0x6579, This adjust = 24"""
+    )
+
+    assert empty_parser.keys["0x657a"]["this_adjust"] == 0x24

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -638,7 +638,7 @@ def test_procedure(parser: CvdumpTypesParser):
         "return_type": "T_LONG(0012)",
         "call_type": "C Near",
         "func_attr": "none",
-        "num_params": "3",
+        "num_params": 3,
         "arg_list_type": "0x1018",
     }
 
@@ -652,9 +652,9 @@ def test_mfunction(parser: CvdumpTypesParser):
         "this_type": "0x101B",
         "call_type": "ThisCall",
         "func_attr": "none",
-        "num_params": "2",
+        "num_params": 2,
         "arg_list_type": "0x101d",
-        "this_adjust": "0",
+        "this_adjust": 0,
     }
 
 
@@ -855,9 +855,9 @@ def test_enum_with_local_flag(empty_parser: CvdumpTypesParser):
     empty_parser.read_all(MSVC700_ENUM_WITH_LOCAL_FLAG)
 
     assert empty_parser.keys["0x26ba"] == {
-        "field_type": "0x26b9",
+        "field_list_type": "0x26b9",
         "name": "SomeEnumType::SomeEnumInternalName::__l2::__unnamed",
-        "num_members": "3",
+        "num_members": 3,
         "type": "LF_ENUM",
         "underlying_type": "T_INT4",
     }
@@ -916,10 +916,10 @@ def test_enum_with_whitespace_and_comma(
     empty_parser.read_all(ENUM_WITH_WHITESPACE_AND_COMMA)
 
     assert empty_parser.keys["0x4dc2"] == {
-        "field_type": "0x2588",
+        "field_list_type": "0x2588",
         "is_nested": True,
         "name": "CPool<CTask,signed char [128]>::__unnamed",
-        "num_members": "1",
+        "num_members": 1,
         "type": "LF_ENUM",
         "underlying_type": "T_INT4",
     }


### PR DESCRIPTION
The `keys` dict in the cvdump types parser stores all the information about the type leaves we parse. The conglomeration of attributes is now listed under `CvdumpParsedType` as a `TypedDict`. On top of adding type-checking, I made these changes to the existing format:

- Leaves that reference an `LF_FIELDLIST` use the key `"field_list_type"`, except `LF_ENUM` which used `"field_type"`. Now they all use `"field_list_type"`.
- `LF_MEMBER` values now use the namedtuple `FieldListItem` instead of a `dict`. We were already using this type to create the `TypeInfo` object, so we just set it up earlier.
- Similarly, `LF_ENUMERATE` values under an `LF_FIELDLIST` now use `EnumItem` instead of a `dict`.
- Numeric fields such as `"this_adjust"` and `"num_params"` are now converted to `int` instead of being left as `str` when read off the regex match groups. `"this_adjust"` is a hex value (although this may not be obvious at first glance) and there is a new test to make sure we use the correct value.

I also changed the Ghidra scripts to make use of the new types. The `LF_MEMBER` dict had used the `"type"` key to refer to both the cvdump hex key _and_ the Ghidra `DataType` struct interchangeably. There is a new namedtuple `GhidraFieldListItem` to make the conversion more clear.

The last thing was to add the mock type `CvdumpTypeKey` to mark where we expect this instead of just a string. For now it simply resolves to `str`.