### PR TITLE
Add Local Function Support

### DIFF
--- a/reccmp/isledecomp/cvdump/analysis.py
+++ b/reccmp/isledecomp/cvdump/analysis.py
@@ -149,6 +149,8 @@ class CvdumpAnalysis:
                 node_dict[key] = CvdumpNode(*key)
 
             if sym.type in ("S_GPROC32", "S_LPROC32"):
+                if sym.type == "S_LPROC32" and node_dict[key].symbol_entry is not None:
+                    continue
                 node_dict[key].friendly_name = sym.name
                 node_dict[key].confirmed_size = sym.size
                 node_dict[key].node_type = EntityType.FUNCTION

--- a/reccmp/isledecomp/cvdump/analysis.py
+++ b/reccmp/isledecomp/cvdump/analysis.py
@@ -148,7 +148,7 @@ class CvdumpAnalysis:
             if key not in node_dict:
                 node_dict[key] = CvdumpNode(*key)
 
-            if sym.type == "S_GPROC32":
+            if sym.type in ("S_GPROC32", "S_LPROC32"):
                 node_dict[key].friendly_name = sym.name
                 node_dict[key].confirmed_size = sym.size
                 node_dict[key].node_type = EntityType.FUNCTION


### PR DESCRIPTION
I was getting help with a problem in Matrix, and we came up with this solution. This code change allows reccmp to look for object-local functions (i.e. functions with internal linkage) as well as global functions when attempting to match. This allows it to properly match non-inlined static functions.

This is important because MSVC can choose to use non-standard calling conventions with object-local functions, since it knows all the calls to the function will be compiled at the same time. This seems to have been a particularly common optimization that MSVC did back before x64 support was added, since most of the x86 calling conventions (including the default `__cdecl`) pushes arguments to the stack, which can be slower than passing them via registers. This optimization can also use registers **not** used by the `__fastcall` calling convention, such as EDI and ESI. This means that getting 100% decompilation results requires the function to be declared `static`. (While this can sometimes result in the function being inlined as well, it can also be controlled by using `__declspec(noinline)` or the compile option `/Ob1`.)

Non-inlined static functions do show up in the .pdb file, but instead of using `S_GPROC32`, it uses `S_LPROC32` to indicate that it's a local function. Currently, reccmp only checks for `S_GPROC32` functions, which causes it to miss functions with internal linkage, preventing it from being found for matching with a `// FUNCTION:` annotation. This PR simply adds `S_LPROC32` as a symbol type to check for. This allows reccmp to successfully compare the results for functions with internal linkage.