### PR TITLE
Add --nolib option

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -337,7 +337,10 @@ class Compare:
 
             for fun in codebase.iter_name_functions():
                 batch.set_orig(
-                    fun.offset, type=EntityType.FUNCTION, stub=fun.should_skip()
+                    fun.offset,
+                    type=EntityType.FUNCTION,
+                    stub=fun.should_skip(),
+                    library=fun.is_library(),
                 )
 
                 if fun.name.startswith("?") or fun.name_is_symbol:
@@ -886,6 +889,7 @@ class Compare:
                 udiff=udiff,
                 ratio=diff_result.match_ratio,
                 is_effective_match=diff_result.is_effective_match,
+                is_library=match.get("library", False),
             )
 
         if match.entity_type == EntityType.VTABLE:

--- a/reccmp/isledecomp/compare/diff.py
+++ b/reccmp/isledecomp/compare/diff.py
@@ -124,6 +124,7 @@ class DiffReport:
     ratio: float = 0.0
     is_effective_match: bool = False
     is_stub: bool = False
+    is_library: bool = False
 
     @property
     def effective_ratio(self) -> float:

--- a/reccmp/isledecomp/parser/node.py
+++ b/reccmp/isledecomp/parser/node.py
@@ -21,6 +21,10 @@ class ParserSymbol:
         """The default is to compare any symbols we have"""
         return False
 
+    def is_library(self) -> bool:
+        """The default is to assume that arbitrary symbols are not library functions"""
+        return False
+
     def is_nameref(self) -> bool:
         """All symbols default to name lookup"""
         return True
@@ -41,6 +45,9 @@ class ParserFunction(ParserSymbol):
 
     def should_skip(self) -> bool:
         return self.type == MarkerType.STUB
+
+    def is_library(self) -> bool:
+        return self.type == MarkerType.LIBRARY
 
     def is_nameref(self) -> bool:
         return (

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -185,6 +185,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Don't display text summary of matches",
     )
+    parser.add_argument(
+        "--nolib",
+        action="store_true",
+        help="Exclude LIBRARY annotations from the analysis",
+    )
     argparse_add_logging_args(parser)
 
     args = parser.parse_args()
@@ -242,6 +247,8 @@ def main():
             match.match_type == EntityType.FUNCTION
             and match.name in target.report_config.ignore_functions
         ):
+            continue
+        if args.nolib and match.is_library:
             continue
 
         if not args.silent and args.diff is None:


### PR DESCRIPTION
This adds an option to `reccmp` to exclude functions with the `LIBRARY` annotation. The idea being that excluding library functions, particularly functions from libc, is useful for getting a more accurate accuracy percentage and limits the report to functions that are expected to be reimplemented.