### PR TITLE
Print diff for effective matches in verbose mode

### DIFF
--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -92,9 +92,12 @@ def print_match_verbose(
         if match.ratio == 1.0:
             print(f"{addrs}: {match.name} 100% match.\n\n{ok_text}\n\n")
         else:
+            print_combined_diff(match.udiff, is_plain, show_both_addrs)
+
             print(
-                f"{addrs}: {match.name} Effective 100% match. (Differs in register allocation only)\n\n{ok_text} (still differs in register allocation)\n\n"
+                f"\n{addrs}: {match.name} 100% effective match (differs, but only in ways that don't affect behavior).\n\n{ok_text}\n\n"
             )
+
     else:
         print_combined_diff(match.udiff, is_plain, show_both_addrs)
 


### PR DESCRIPTION
For effective matches, there are some cases where the match is a false positive. For now, we will print the diff for effective matches so the user can at least confirm the match. Next, we will allow the effective matching algorithms to be enabled/disabled for safety.

```
---
+++
@@ -0x405940,20 +0x46be1f,20 @@
0x405940 : mov eax, dword ptr [gProgram_state+13664 (OFFSET)]   (opponent.c:2431)
...
0x405961 : call BrMemFree (FUNCTION)
0x405966 : add esp, 4
         : +mov dword ptr [gBit_per_node (DATA)], 0     (opponent.c:2436)
0x405969 : mov dword ptr [gProgram_state+7412 (OFFSET)], 0      (opponent.c:2437)
0x405973 : mov dword ptr [gProgram_state+7416 (OFFSET)], 0      (opponent.c:2438)
0x40597d : mov dword ptr [gProgram_state+13660 (OFFSET)], 0     (opponent.c:2439)
0x405987 : mov dword ptr [gProgram_state+13664 (OFFSET)], 0     (opponent.c:2440)
0x405991 : -mov dword ptr [gBit_per_node (DATA)], 0
0x40599b : pop edi      (opponent.c:2441)
0x40599c : pop esi
0x40599d : pop ebx
0x40599e : leave
0x40599f : ret


0x405912: DisposeOpponentPaths 100% effective match (differs, but only in ways that don't affect behavior).

✨ OK! ✨
```