### PR TITLE
LinesDb: Process local and foreign paths in any order

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -290,7 +290,7 @@ class Compare:
 
     def _load_markers(self, report: ReccmpReportProtocol = reccmp_report_nop):
         codefiles = [Path(p) for p in walk_source_dir(self.code_dir)]
-        self._lines_db.add_files(codefiles)
+        self._lines_db.add_local_paths(codefiles)
         codebase = DecompCodebase(codefiles, self.target_id)
 
         # If the address of any annotation would cause an exception,

--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -81,8 +81,7 @@ class Compare:
         # Controls whether we dump the asm output to a file
         self._debug: bool = False
 
-        code_files = [Path(p) for p in walk_source_dir(self.code_dir)]
-        self._lines_db = LinesDb(code_files)
+        self._lines_db = LinesDb()
         self._db = EntityDb()
 
         # For now, just redirect match alerts to the logger.
@@ -290,15 +289,13 @@ class Compare:
             batch.match(self.orig_bin.entry, self.recomp_bin.entry)
 
     def _load_markers(self, report: ReccmpReportProtocol = reccmp_report_nop):
-        codefiles = list(walk_source_dir(self.code_dir))
+        codefiles = [Path(p) for p in walk_source_dir(self.code_dir)]
+        self._lines_db.add_files(codefiles)
         codebase = DecompCodebase(codefiles, self.target_id)
-
-        def orig_bin_checker(addr: int) -> bool:
-            return self.orig_bin.is_valid_vaddr(addr)
 
         # If the address of any annotation would cause an exception,
         # remove it and report an error.
-        bad_annotations = codebase.prune_invalid_addrs(orig_bin_checker)
+        bad_annotations = codebase.prune_invalid_addrs(self.orig_bin.is_valid_vaddr)
 
         for sym in bad_annotations:
             report(

--- a/reccmp/isledecomp/compare/lines.py
+++ b/reccmp/isledecomp/compare/lines.py
@@ -37,13 +37,11 @@ class LinesDb:
             self._filenames.setdefault(path.name.lower(), []).append(path)
 
         # Save any failed matches to be processed when we get a new local path.
-        retry = []
-
-        for foreign_path, lines in self._line_queue:
-            if not self._match_foreign_path_to_local(foreign_path, lines):
-                retry.append((foreign_path, lines))
-
-        self._line_queue = retry
+        self._line_queue = [
+            (foreign_path, lines)
+            for foreign_path, lines in self._line_queue
+            if not self._match_foreign_path_to_local(foreign_path, lines)
+        ]
 
     def add_line(self, foreign_path: PureWindowsPath, line_no: int, addr: int):
         """Connect the foreign path to a line number and address pair."""

--- a/reccmp/isledecomp/compare/lines.py
+++ b/reccmp/isledecomp/compare/lines.py
@@ -12,15 +12,15 @@ logger = logging.getLogger(__name__)
 
 
 class LinesDb:
-    # pylint: disable=too-many-instance-attributes
     def __init__(self) -> None:
-        self._new_data = False
         self._path_resolver = cache(convert_foreign_path)
 
-        self._path_queue: list[Path | PurePath] = []
+        # List of foreign paths and associated (line_no, address) pairs that cannot be
+        # matched with the current set of local file paths.
         self._line_queue: list[tuple[PureWindowsPath, list[tuple[int, int]]]] = []
 
-        # Set up memoized map of filenames to their paths
+        # Map of local filenames to their paths. This is used to reduce the list of
+        # possible local paths that can be matched to a foreign path.
         self._filenames: dict[str, list[PurePath]] = {}
 
         # Local filename to list of (line_no, address) pairs
@@ -32,59 +32,57 @@ class LinesDb:
         # Addresses for the first line for a function
         self._function_starts: set[int] = set()
 
-    def add_files(self, paths: Iterable[Path] | Iterable[PurePath]):
-        self._new_data = True
-        self._path_queue.extend(paths)
+    def add_local_paths(self, paths: Iterable[Path] | Iterable[PurePath]):
+        for path in paths:
+            self._filenames.setdefault(path.name.lower(), []).append(path)
+
+        # Save any failed matches to be processed when we get a new local path.
+        retry = []
+
+        for foreign_path, lines in self._line_queue:
+            if not self._match_foreign_path_to_local(foreign_path, lines):
+                retry.append((foreign_path, lines))
+
+        self._line_queue = retry
 
     def add_line(self, foreign_path: PureWindowsPath, line_no: int, addr: int):
-        """Connect the remote path to a line number and address pair."""
+        """Connect the foreign path to a line number and address pair."""
         return self.add_lines(foreign_path, ((line_no, addr),))
 
     def add_lines(
-        self, foreign_path: PureWindowsPath, lines: Iterable[tuple[int, int]]
+        self, foreign_path: PureWindowsPath, lines_iter: Iterable[tuple[int, int]]
     ):
         """
-        Connect the remote path to a line number and address pair.
+        Connect the foreign path to a line number and address pair.
         """
-        self._new_data = True
-        self._line_queue.append((foreign_path, list(lines)))
+        lines = list(lines_iter)
+        if not self._match_foreign_path_to_local(foreign_path, lines):
+            self._line_queue.append((foreign_path, lines))
 
     def mark_function_starts(self, addrs: Iterable[int]):
-        self._function_starts = self._function_starts.union(set(addrs))
+        self._function_starts.update(addrs)
 
-    def _process(self):
-        """Defer processing until we need results. This allows us to call add_files()
-        and add_line() or add_lines() in any order up to the point where we search."""
-        for path in self._path_queue:
-            self._filenames.setdefault(path.name.lower(), []).append(path)
+    def _match_foreign_path_to_local(
+        self, foreign_path: PureWindowsPath, lines: Iterable[tuple[int, int]]
+    ) -> bool:
+        """Match the foreign path and its (line_no, address) pairs to a local path.
+        If we can match it, set the internal data structures and return True."""
+        filename = foreign_path.name.lower()
 
-        # Don't remove from lines queue if we can't find a match.
-        retry_lines = []
+        candidates = self._filenames.get(filename)
+        if candidates is None:
+            return False
 
-        for foreign_path, lines in self._line_queue:
-            filename = foreign_path.name.lower()
+        # Must convert to tuple (hashable type) so we can use functools.cache
+        sourcepath = self._path_resolver(foreign_path, tuple(candidates))
+        if sourcepath is None:
+            return False
 
-            candidates = self._filenames.get(filename)
-            if candidates is None:
-                retry_lines.append((foreign_path, lines))
-                continue
+        self._path_to_lines_and_addresses.setdefault(sourcepath, []).extend(list(lines))
+        for line_number, address in lines:
+            self._address_to_path_and_line[address] = (sourcepath, line_number)
 
-            # Must convert to tuple (hashable type) so we can use functools.cache
-            sourcepath = self._path_resolver(foreign_path, tuple(candidates))
-            if sourcepath is None:
-                retry_lines.append((foreign_path, lines))
-                continue
-
-            self._path_to_lines_and_addresses.setdefault(sourcepath, []).extend(
-                list(lines)
-            )
-            for line_number, address in lines:
-                self._address_to_path_and_line[address] = (sourcepath, line_number)
-
-        self._path_queue.clear()
-        self._line_queue.clear()
-        self._line_queue.extend(retry_lines)
-        self._new_data = False
+        return True
 
     def search_line(
         self,
@@ -93,9 +91,6 @@ class LinesDb:
         line_end: int | None = None,
         start_only: bool = False,
     ) -> Iterator[int]:
-        if self._new_data:
-            self._process()
-
         # If there is no end line, search for a single line only
         if line_end is None:
             line_end = line_start
@@ -145,7 +140,4 @@ class LinesDb:
         return None
 
     def find_line_of_recomp_address(self, address: int) -> tuple[PurePath, int] | None:
-        if self._new_data:
-            self._process()
-
         return self._address_to_path_and_line.get(address, None)

--- a/reccmp/isledecomp/parser/codebase.py
+++ b/reccmp/isledecomp/parser/codebase.py
@@ -1,5 +1,6 @@
 """For aggregating decomp markers read from an entire directory and for a single module."""
 
+from pathlib import Path
 from typing import Callable, Iterable, Iterator
 from .parser import DecompParser
 from .node import (
@@ -13,13 +14,13 @@ from .node import (
 
 
 class DecompCodebase:
-    def __init__(self, filenames: Iterable[str], module: str) -> None:
+    def __init__(self, paths: Iterable[Path], module: str) -> None:
         self._symbols: list[ParserSymbol] = []
 
         parser = DecompParser()
-        for filename in filenames:
-            parser.reset_and_set_filename(filename)
-            with open(filename, "r", encoding="utf-8") as f:
+        for path in paths:
+            parser.reset_and_set_filename(str(path))
+            with open(path, "r", encoding="utf-8") as f:
                 parser.read(f.read())
 
             self._symbols += parser.iter_symbols(module)

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -25,7 +25,7 @@ def fixture_db() -> EntityDb:
 @pytest.fixture(name="lines_db")
 def fixture_lines_db() -> LinesDb:
     db = LinesDb()
-    db.add_files([MOCK_PATH])
+    db.add_local_paths([MOCK_PATH])
     return db
 
 

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -24,7 +24,9 @@ def fixture_db() -> EntityDb:
 
 @pytest.fixture(name="lines_db")
 def fixture_lines_db() -> LinesDb:
-    return LinesDb([MOCK_PATH])
+    db = LinesDb()
+    db.add_files([MOCK_PATH])
+    return db
 
 
 @pytest.fixture(name="report")

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -25,7 +25,8 @@ def test_lines(local_path: PureWindowsPath | PurePosixPath):
     """Basic demonstration of behavior with a simple file path."""
     # Start by adding the local code files for our project.
     # These are the candidates for matching Windows paths from the PDB.
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
 
     # No results: we haven't added any addresses yet.
     assert lines.find_function(local_path, 1, 10) is None
@@ -56,10 +57,34 @@ def test_lines(local_path: PureWindowsPath | PurePosixPath):
 
 
 @pytest.mark.parametrize("local_path", LOCAL_PATHS)
+def test_lines_add_local_files_after(local_path: PureWindowsPath | PurePosixPath):
+    """Does it still work if we add the local paths after the foreign paths?"""
+    lines = LinesDb()
+
+    # No results: we haven't added any addresses yet.
+    assert lines.find_function(local_path, 1, 10) is None
+
+    # Attach line 2 of the file to this virtual address.
+    # The add_line function expects a Windows-like path from the PDB.
+    # All other functions use the local path.
+    lines.add_line(PDB_PATH, 2, 0x1234)
+
+    # Should return nothing: we have not marked this addr as the start of a function
+    assert lines.find_function(local_path, 2) is None
+    lines.mark_function_starts((0x1234,))
+
+    # Add source dirs here, after the call to add_line
+    lines.add_files([local_path])
+
+    # Now we get the function
+    assert lines.find_function(local_path, 2) == 0x1234
+
+
+@pytest.mark.parametrize("local_path", LOCAL_PATHS)
 def test_no_files_of_interest(local_path: PureWindowsPath | PurePosixPath):
     """Same as above test, but with no files declared up front.
     Calls to add_line do not alter the db."""
-    lines = LinesDb([])
+    lines = LinesDb()
     lines.add_line(PDB_PATH, 2, 0x1234)
     lines.mark_function_starts((0x1234,))
     # The address is ignored because "test.cpp" is not part of the decomp code base.
@@ -73,7 +98,8 @@ def test_multiple_match(local_path: PureWindowsPath | PurePosixPath):
     If we find more than one address, the file does not match our data source (PDB or MAP).
     """
 
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
     lines.add_line(PDB_PATH, 2, 0x1234)
     lines.add_line(PDB_PATH, 3, 0x1235)
     lines.mark_function_starts((0x1234, 0x1235))
@@ -92,7 +118,8 @@ def test_lines_duplicate_reference(local_path: PureWindowsPath | PurePosixPath):
     In MSVC versions as early as MSVC 7.00, the same function can be referenced on multiple lines.
     This should not cause an error to be raised.
     """
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
     lines.add_line(PDB_PATH, 2, 0x1234)
     lines.add_line(PDB_PATH, 4, 0x1234)
     lines.mark_function_starts((0x1234,))
@@ -106,7 +133,8 @@ def test_db_hash_windows():
     Windows paths are not case-sensitive."""
 
     local_path = PureWindowsPath("code\\test.cpp")
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
 
     pdb_path = PureWindowsPath("code\\test.cpp")
     lines.add_line(pdb_path, 2, 0x1234)
@@ -125,7 +153,8 @@ def test_db_hash_posix():
     and when it can be expected to match."""
 
     local_path = PurePosixPath("code/test.cpp")
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
 
     pdb_path = PureWindowsPath("code\\test.cpp")
     lines.add_line(pdb_path, 2, 0x1234)
@@ -143,7 +172,8 @@ def test_db_search_line(local_path: PureWindowsPath | PurePosixPath):
     """search_line() will return any line in the given range
     unless you restrict to function starts only."""
 
-    lines = LinesDb([local_path])
+    lines = LinesDb()
+    lines.add_files([local_path])
 
     # We haven't added any addresses yet.
     assert [*lines.search_line(local_path, 1, 10)] == []

--- a/tests/test_lines.py
+++ b/tests/test_lines.py
@@ -26,7 +26,7 @@ def test_lines(local_path: PureWindowsPath | PurePosixPath):
     # Start by adding the local code files for our project.
     # These are the candidates for matching Windows paths from the PDB.
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
 
     # No results: we haven't added any addresses yet.
     assert lines.find_function(local_path, 1, 10) is None
@@ -74,7 +74,7 @@ def test_lines_add_local_files_after(local_path: PureWindowsPath | PurePosixPath
     lines.mark_function_starts((0x1234,))
 
     # Add source dirs here, after the call to add_line
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
 
     # Now we get the function
     assert lines.find_function(local_path, 2) == 0x1234
@@ -99,7 +99,7 @@ def test_multiple_match(local_path: PureWindowsPath | PurePosixPath):
     """
 
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
     lines.add_line(PDB_PATH, 2, 0x1234)
     lines.add_line(PDB_PATH, 3, 0x1235)
     lines.mark_function_starts((0x1234, 0x1235))
@@ -119,7 +119,7 @@ def test_lines_duplicate_reference(local_path: PureWindowsPath | PurePosixPath):
     This should not cause an error to be raised.
     """
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
     lines.add_line(PDB_PATH, 2, 0x1234)
     lines.add_line(PDB_PATH, 4, 0x1234)
     lines.mark_function_starts((0x1234,))
@@ -134,7 +134,7 @@ def test_db_hash_windows():
 
     local_path = PureWindowsPath("code\\test.cpp")
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
 
     pdb_path = PureWindowsPath("code\\test.cpp")
     lines.add_line(pdb_path, 2, 0x1234)
@@ -154,7 +154,7 @@ def test_db_hash_posix():
 
     local_path = PurePosixPath("code/test.cpp")
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
 
     pdb_path = PureWindowsPath("code\\test.cpp")
     lines.add_line(pdb_path, 2, 0x1234)
@@ -173,7 +173,7 @@ def test_db_search_line(local_path: PureWindowsPath | PurePosixPath):
     unless you restrict to function starts only."""
 
     lines = LinesDb()
-    lines.add_files([local_path])
+    lines.add_local_paths([local_path])
 
     # We haven't added any addresses yet.
     assert [*lines.search_line(local_path, 1, 10)] == []


### PR DESCRIPTION
Part of #220. The lines database reads two types of data:
- Local paths: the list of code files that contain annotations, local to the file system where you run reccmp
- Foreign paths: as read from the PDB, so this is always a Windows path even if you are using Wine. For each path, read the non-unique[^1] mapping of line numbers to addresses

The problem is that we expect this specific order of operations:
1. Set up the list of local paths first. This happens in the `Compare` constructor when we pass the list of file paths into the `LinesDb` constructor.
2. For each foreign path, send in the list of line-number-to-address tuples.
3. When reading code annotations, search the lines database for the recomp address to match the orig address.

We would like to make it possible to reverse steps 1 and 2. We now read the list of files at the point where we establish `DecompCodebase`.

This simplifies the `LinesDb` constructor and creates a new `add_files()` method to set up the local paths. My solution to the problem of calling the methods out of order is to save up the two types of data in a queue, then process everything when we need to search.

I restricted the types of `LinesDb` to work with `Path` or `PurePath` only instead of allowing `str` and converting it.

I removed `orig_bin_checker` because we can just pass in the `is_valid_addr` function directly.

No new diffs in `LEGO1` or `BETA10`.

[^1]: Non-unique because the same line number can appear multiple times and point to different addresses. For example: templates, and the start and end of a loop.