### PR TITLE
Move `match_entry` to its original spot

### DIFF
--- a/reccmp/isledecomp/compare/core.py
+++ b/reccmp/isledecomp/compare/core.py
@@ -98,11 +98,11 @@ class Compare:
         )
 
     def run(self):
-        self._match_entry(self._db, self.orig_bin, self.recomp_bin)
-
         self._load_cvdump_types(self.cvdump_analysis, self.types)
         self._load_cvdump(self.cvdump_analysis, self._db, self.recomp_bin)
         self._load_cvdump_lines(self.cvdump_analysis, self._lines_db, self.recomp_bin)
+
+        self._match_entry(self._db, self.orig_bin, self.recomp_bin)
 
         self._load_markers(
             self.code_dir,


### PR DESCRIPTION
Fixes #233. The requirement to run these functions in a particular order is a problem, but not one to be solved here.

I don't usually test on the EXE targets (`ISLE` and `CONFIG`) so that's how this got missed. No errors on `ISLE`, `LEGO1`, `BETA10`, or `CONFIG`.