### PR TITLE
Tests for `load_cvdump` function

### DIFF
--- a/tests/test_compare_ingest_cvdump.py
+++ b/tests/test_compare_ingest_cvdump.py
@@ -1,0 +1,442 @@
+from textwrap import dedent
+from reccmp.isledecomp.formats import PEImage
+from reccmp.isledecomp.cvdump import CvdumpAnalysis, CvdumpParser
+from reccmp.isledecomp.compare.db import EntityDb
+from reccmp.isledecomp.compare.ingest import load_cvdump
+from reccmp.isledecomp.types import EntityType
+
+
+# These functions use our sample PE image to "cheat" and not have to mock as much.
+# This sets up the imagebase and valid section boundaries for calculation inside load_cvdump.
+# The seg:offsets and addresses in the tests match where strings and other items can be found.
+# Strictly speaking this *should* be a fully mocked sample image, but this isn't
+# easy with the current API. TODO: #190
+#
+# The addresses are calculated using this:
+#
+#     name │    start │   v.size │ raw size
+# ─────────┼──────────┼──────────┼─────────
+#    .text │ 10001000 │    d2a66 │    d2c00
+#   .rdata │ 100d4000 │    1b5b6 │    1b600
+#    .data │ 100f0000 │    1a734 │    12c00
+#   .idata │ 1010b000 │     1006 │     1200
+#    .rsrc │ 1010d000 │     21d8 │     2200
+#   .reloc │ 10110000 │    10c58 │    10e00
+
+
+def test_symbol_overwrite(binfile: PEImage):
+    """Library functions may have multiple linker names for the same address.
+    New entries for the same address will overwrite the previous one."""
+
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        dedent(
+            """\
+            S_PUB32: [0001:0008B410], Flags: 00000000, __strlwr
+            S_PUB32: [0001:0008B410], Flags: 00000000, _strlwr
+            """
+        ),
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x1008C410)
+    assert entity is not None
+    assert entity.get("symbol") == "_strlwr"
+
+
+def test_string_without_section_contrib(binfile: PEImage):
+    """Can create the string entity even if we don't have the exact length
+    from the entry in SECTION CONTRIBUTIONS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:0000757C], Flags: 00000000, ??_C@_08LIDF@December?$AA@",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100DB57C)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert entity.get("symbol") == "??_C@_08LIDF@December?$AA@"
+
+    # Name set during string decode
+    assert entity.get("name") == '"December"'
+
+    # Size includes null-terminator.
+    assert entity.get("size") == 9
+
+
+def test_string_with_section_contrib(binfile: PEImage):
+    """Can create the string entity using the length found in SECTION CONTRIBUTIONS.
+    TODO: It would be better to showcase a string that contains nulls and thus cannot
+    be read correctly using Image.read_string()."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:0000757C], Flags: 00000000, ??_C@_08LIDF@December?$AA@",
+    )
+    parser.read_section(
+        "SECTION CONTRIBUTIONS",
+        "  0032  0002:0000757C  00000009  40303040",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100DB57C)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert entity.get("symbol") == "??_C@_08LIDF@December?$AA@"
+
+    # Name set during string decode
+    assert entity.get("name") == '"December"'
+
+    # Size includes null-terminator
+    assert entity.get("size") == 9
+
+
+def test_utf16_without_section_contrib(binfile: PEImage):
+    """Can create the widechar entity even if we don't have the exact length
+    from the entry in SECTION CONTRIBUTIONS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:00006AA0], Flags: 00000000, ??_C@_1O@POHA@?$AA?$CI?$AAn?$AAu?$AAl?$AAl?$AA?$CJ?$AA?$AA?$AA?$AA?$AA?$AH?$AA?$AA?$AA?$AA?$AA?$AA?$AA?$9A?$AE?$;I@",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100DAAA0)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert (
+        entity.get("symbol")
+        == "??_C@_1O@POHA@?$AA?$CI?$AAn?$AAu?$AAl?$AAl?$AA?$CJ?$AA?$AA?$AA?$AA?$AA?$AH?$AA?$AA?$AA?$AA?$AA?$AA?$AA?$9A?$AE?$;I@"
+    )
+
+    # Name set during string decode
+    assert entity.get("name") == 'L"(null)"'
+
+    # Size includes two-byte null-terminator
+    assert entity.get("size") == 14
+
+
+def test_utf16_with_section_contrib(binfile: PEImage):
+    """Can create the widechar entity using the length found in SECTION CONTRIBUTIONS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:00006AA0], Flags: 00000000, ??_C@_1O@POHA@?$AA?$CI?$AAn?$AAu?$AAl?$AAl?$AA?$CJ?$AA?$AA?$AA?$AA?$AA?$AH?$AA?$AA?$AA?$AA?$AA?$AA?$AA?$9A?$AE?$;I@",
+    )
+    parser.read_section(
+        "SECTION CONTRIBUTIONS",
+        "  00FA  0002:00006AA0  0000000E  40303040",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100DAAA0)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert (
+        entity.get("symbol")
+        == "??_C@_1O@POHA@?$AA?$CI?$AAn?$AAu?$AAl?$AAl?$AA?$CJ?$AA?$AA?$AA?$AA?$AA?$AH?$AA?$AA?$AA?$AA?$AA?$AA?$AA?$9A?$AE?$;I@"
+    )
+
+    # Name set during string decode
+    assert entity.get("name") == 'L"(null)"'
+
+    # Size includes two-byte null-terminator
+    assert entity.get("size") == 14
+
+
+def test_vtable(binfile: PEImage):
+    """Should create vtable entity from linker name."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:00000018], Flags: 00000000, ??_7Score@@6B@",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100D4018)
+    assert entity is not None
+    assert entity.get("type") == EntityType.VTABLE
+    assert entity.get("name") == "Score::`vftable'"
+    assert entity.get("symbol") == "??_7Score@@6B@"
+
+
+def test_vtable_with_vbclass(binfile: PEImage):
+    """Should create vtable entity with virtual base class (multiple inheritance)."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:00002860], Flags: 00000000, ??_7BumpBouy@@6BOgelAnimActor@@@",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100D6860)
+    assert entity is not None
+    assert entity.get("type") == EntityType.VTABLE
+    assert entity.get("name") == "BumpBouy::`vftable'{for `OgelAnimActor'}"
+    assert entity.get("symbol") == "??_7BumpBouy@@6BOgelAnimActor@@@"
+
+
+def test_vbtable(binfile: PEImage):
+    """Should create vbtable entity from linker name."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0002:00002788], Flags: 00000000, ??_8BumpBouy@@7B@",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100D6788)
+    assert entity is not None
+    assert entity.get("type") == EntityType.DATA
+    assert entity.get("name") == "BumpBouy::`vbtable'"
+    assert entity.get("symbol") == "??_8BumpBouy@@7B@"
+    # TODO: Is this just a number? We could assume the size based on nothing else.
+
+
+def test_gdata32(binfile: PEImage):
+    """Should create an entity from only an S_GDATA32 node in GLOBALS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "GLOBALS",
+        "S_GDATA32: [0002:000054F8], Type:             0x5BB7, g_pizzaHitSounds",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100D94F8)
+    assert entity is not None
+    assert entity.get("type") == EntityType.DATA
+    assert entity.get("name") == "g_pizzaHitSounds"
+
+
+def test_ldata32(binfile: PEImage):
+    """Should create an entity from only an S_LDATA32 node in GLOBALS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "GLOBALS",
+        "S_LDATA32: [0002:00000000], Type:             0x5D8C, Pi",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x100D4000)
+    assert entity is not None
+    assert entity.get("type") == EntityType.DATA
+    assert entity.get("name") == "Pi"
+
+
+def test_variable_size_scalar_type(binfile: PEImage):
+    """Should correctly set the size for a variable with scalar type.
+    We don't currently need to preload the type database with any MSVC-specific data in order to do this. TODO: #106
+    """
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "GLOBALS",
+        "S_GDATA32: [0003:00012B24], Type:      T_UINT4(0075), g_nextInterruptWavIndex",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x10102B24)
+    assert entity is not None
+    assert entity.get("size") == 4
+    assert entity.get("name") == "g_nextInterruptWavIndex"
+
+
+def test_variable_size_without_type_info(binfile: PEImage):
+    """The variable is: char g_hdPath[1024].
+    We cannot properly set the size without having information about its type."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "GLOBALS",
+        "S_GDATA32: [0003:000115B8], Type:             0x1424, g_hdPath",
+    )
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x101015B8)
+    assert entity is not None
+    assert entity.get("name") == "g_hdPath"
+
+    # Asserting it this way because the current behavior is to estimate the entity size
+    # using the distance between the address and the end of the section.
+    assert entity.get("size") != 1024
+
+
+def test_variable_size_with_type_info(binfile: PEImage):
+    """Should cross-reference the type information to set the entity size correctly."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "GLOBALS",
+        "S_GDATA32: [0003:000115B8], Type:             0x1424, g_hdPath",
+    )
+    parser.read_section(
+        "TYPES",
+        dedent(
+            """\
+            0x1424 : Length = 14, Leaf = 0x1503 LF_ARRAY
+                Element type = T_RCHAR(0070)
+                Index type = T_SHORT(0011)
+                length = 1024
+                Name = 
+        """
+        ),
+    )
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x101015B8)
+    assert entity is not None
+    assert entity.get("size") == 1024
+
+
+def test_gproc32(binfile: PEImage):
+    """Should create a function entity from only an S_GPROC32 block in SYMBOLS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "SYMBOLS",
+        dedent(
+            """\
+        (00038C) S_GPROC32: [0001:00037220], Cb: 0000008B, Type:             0x2068, Pizza::Start
+                 Parent: 00000000, End: 000003E8, Next: 00000000
+                 Debug start: 00000001, Debug end: 00000087
+
+        (0003C0)  S_REGISTER: esi, Type:             0x2055, this
+        (0003D0)  S_BPREL32: [00000004], Type:             0x1134, p_objectId
+
+        (0003E8) S_END
+        """
+        ),
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x10038220)
+    assert entity is not None
+    assert entity.get("type") == EntityType.FUNCTION
+    assert entity.get("size") == 0x8B
+    assert entity.get("name") == "Pizza::Start"
+
+
+def test_lproc32(binfile: PEImage):
+    """Should create a function entity from only an S_LPROC32 block in SYMBOLS."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "SYMBOLS",
+        dedent(
+            """\
+        (0000A8) S_LPROC32: [0001:00091350], Cb: 00000005, Type:             0x164F, $E28
+                 Parent: 00000000, End: 000000D4, Next: 00000000
+                 Debug start: 00000000, Debug end: 00000005
+        """
+        ),
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    # This is one of the ___xc_a functions.
+    entity = db.get_by_recomp(0x10092350)
+    assert entity is not None
+    assert entity.get("type") == EntityType.FUNCTION
+    assert entity.get("size") == 5
+    assert entity.get("name") == "$E28"
+
+
+def test_invalid_seg_ofs(binfile: PEImage):
+    """Should skip entities that are outside the sections defined in the image headers."""
+    db = EntityDb()
+    parser = CvdumpParser()
+    parser.read_section(
+        "PUBLICS",
+        "S_PUB32: [0008:00000000], Flags: 00000000, __except_list",
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+
+    # Make sure we read it
+    assert cvdump_analysis.nodes
+
+    # No exception raised
+    load_cvdump(cvdump_analysis, db, binfile)
+
+
+def test_gproc_with_static_var(binfile: PEImage):
+    """Should create entities for static variables using S_LDATA32 embedded in S_GPROC32."""
+
+    db = EntityDb()
+    parser = CvdumpParser()
+
+    # This is a real function and static variable, but the cvdump output is made up.
+    # MSVC 4.20 doesn't indicate static variables like this.
+    parser.read_section(
+        "SYMBOLS",
+        dedent(
+            """\
+        (000780) S_GPROC32: [0001:0009CA20], Cb: 00000051, Type:             0x234C, EnableResizing
+                 Parent: 00000000, End: 000007EC, Next: 00000000
+                 Debug start: 00000007, Debug end: 0000004E
+
+        (0007B8)  S_BPREL32: [00000004], Type:    T_32PVOID(0403), p_hwnd
+        (0007CC)  S_LDATA32: [0003:00019594], Type:       T_UINT4(0075), g_dwStyle
+
+        (0007EC) S_END
+        """
+        ),
+    )
+
+    cvdump_analysis = CvdumpAnalysis(parser)
+    load_cvdump(cvdump_analysis, db, binfile)
+
+    entity = db.get_by_recomp(0x10109594)
+    assert entity is not None
+    assert entity.get("type") == EntityType.DATA
+    assert entity.get("name") == "g_dwStyle"
+
+    # We can get the size from just the scalar type for now.
+    # We may need to preload the types db with MSVC-specific data later. TODO: #106
+    assert entity.get("size") == 4
+
+    # TODO: #102. The parent function's address should be set instead.
+    symbol = entity.get("symbol")
+    assert symbol is not None
+    assert "g_dwStyle" in symbol
+    assert "EnableResizing" in symbol


### PR DESCRIPTION
There isn't a clear separation between `CvdumpAnalysis` and `load_cvdump`. This tests both to establish a baseline for how things work now.

Some things we could change (that aren't marked with `TODO`):
- Move string (and float) reads outside of `load_cvdump` and into their own function.
- `CvdumpAnalysis` makes assumptions about the entity based solely on the linker name. This could be broken out into its own function to run on both orig and recomp entities.
- I don't think estimating the size of an entity based on the distance to the next one is very useful. This is something we could calculate when needed.

As documented, I used `LEGO1.DLL` as a dependency so we don't have to mock `PEImage`. When it is possible to conveniently mock it, we should. (We are doing this in `test_function_comparator.py`, but it's in a wrapper function that I don't think would work here.)