### PR TITLE
Allow function comparator to use 16-bit capstone

### DIFF
--- a/reccmp/isledecomp/compare/functions.py
+++ b/reccmp/isledecomp/compare/functions.py
@@ -88,6 +88,7 @@ class FunctionComparator:
     report: ReccmpReportProtocol
     runid: str = timestamp_string()
     debug: bool = False
+    is_32bit: bool = True
 
     def __post_init__(self):
         self.orig_sanitize = ParseAsm(
@@ -97,6 +98,7 @@ class FunctionComparator:
             name_lookup=create_name_lookup(
                 self.db.get_by_orig, create_bin_lookup(self.orig_bin), "orig_addr"
             ),
+            is_32bit=self.is_32bit,
         )
         self.recomp_sanitize = ParseAsm(
             addr_test=create_valid_addr_lookup(
@@ -107,6 +109,7 @@ class FunctionComparator:
                 create_bin_lookup(self.recomp_bin),
                 "recomp_addr",
             ),
+            is_32bit=self.is_32bit,
         )
 
     def _dump_asm(self, orig_combined, recomp_combined):

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -458,3 +458,21 @@ def test_consistent_numbering():
     assert p.replacements[0x1000] == "<OFFSET1>"
     assert p.replacements[0x1234] == "<OFFSET2>"
     assert p.replacements[0x2000] == "<OFFSET3>"
+
+
+def test_16bit_mode():
+    """Demonstrating the difference in asm output."""
+    code = b"\xe8\xbb\x00\xd1\xe3"
+
+    # Interpreted as CALL to 32-bit pointer
+    p = ParseAsm(is_32bit=True)
+    assert p.parse_asm(code, 0x1000) == [
+        (0x1000, "call <OFFSET1>"),
+    ]
+
+    # Interpreted as CALL to cs:offset
+    p = ParseAsm(is_32bit=False)
+    assert p.parse_asm(code, 0x1000) == [
+        (0x1000, "call <OFFSET1>"),
+        (0x1003, "shl bx, 1"),
+    ]


### PR DESCRIPTION
Part of #257. I have this all working in another branch and this is just one piece.

We may want to create a separate set of classes just for handling 16-bit instructions, but we're not there yet.