### PR TITLE
Ignore `S_FRAMEPROC` leaf from cvdump

### DIFF
--- a/reccmp/isledecomp/cvdump/symbols.py
+++ b/reccmp/isledecomp/cvdump/symbols.py
@@ -111,6 +111,7 @@ class CvdumpSymbolsParser:
         "S_LABEL32",
         "S_REGREL32",  # TODO: Seen as early as MSVC 7.00; might be relevant to Ghidra and/or stackcmp
         "S_UDT",
+        "S_FRAMEPROC",
     ]
 
     """Parser for cvdump output, SYMBOLS section."""


### PR DESCRIPTION
The `FRAMEPROCSYM` struct [here](https://github.com/microsoft/microsoft-pdb/blob/805655a28bd8198004be2ac27e6e0290121a5e89/include/cvinfo.h#L4069) shows the potential data we could mine from this. I'm not sure how much would be useful unless you have the pdb from the _original_ binary.