### PR TITLE
Save more data for `LF_POINTER` and `LF_MODIFIER`

### DIFF
--- a/reccmp/cvdump/types.py
+++ b/reccmp/cvdump/types.py
@@ -195,6 +195,7 @@ class CvdumpParsedType(TypedDict):
 
     # LF_MODIFIER
     modifies: NotRequired[CvdumpTypeKey]
+    modification: NotRequired[str]
 
     # LF_FIELDLIST
     super: NotRequired[dict[CvdumpTypeKey, int]]
@@ -209,6 +210,7 @@ class CvdumpParsedType(TypedDict):
     # LF_POINTER
     element_type: NotRequired[CvdumpTypeKey]
     containing_class: NotRequired[CvdumpTypeKey]
+    pointer_type: NotRequired[str]
 
     # LF_PROCEDURE / LF_MFUNCTION
     return_type: NotRequired[CvdumpTypeKey]
@@ -265,7 +267,9 @@ class CvdumpTypesParser:
     )
 
     # LF_MODIFIER, type being modified
-    MODIFIES_RE = re.compile(r"\s+modifies type (?P<type>[^\n,]*)")
+    MODIFIES_RE = re.compile(
+        r"\n\s+(?P<modification>.+?), modifies type (?P<type>[^\n,]*)"
+    )
 
     # LF_ARGLIST number of entries
     LF_ARGLIST_ARGCOUNT = re.compile(r".*argument count = (?P<argcount>\d+)")
@@ -554,6 +558,7 @@ class CvdumpTypesParser:
             "type": leaf_type,
             "is_forward_ref": True,
             "modifies": normalize_type_id(match.group("type")),
+            "modification": match.group("modification"),
         }
 
     def read_array(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
@@ -705,6 +710,7 @@ class CvdumpTypesParser:
         return {
             "type": leaf_type,
             "element_type": match.group("element_type"),
+            "pointer_type": match.group("type"),
             # `containing_class` is set to `None` if not present
             "containing_class": match.group("containing_class"),
         }


### PR DESCRIPTION
This saves the attributes for `LF_POINTER` and `LF_MODIFIER` that describe how the value is being modified. (e.g. is it a const pointer, a reference, volatile, etc). We need this information to create a string representation of a particular type. The end goal is to do this for the return type and parameter list for functions.

These values are not used in the `TypeInfo` object returned when you call `types.get()`, so it should not affect anything with `datacmp` or other processing.

`LF_MODIFIER` appears to have only these values: [const, volatile, and unaligned](https://github.com/microsoft/microsoft-pdb/blob/805655a28bd8198004be2ac27e6e0290121a5e89/include/cvinfo.h#L1090).