### PR TITLE
Fix `IndexError` raised for single operand `IMUL` instruction

### DIFF
--- a/reccmp/compare/asm/fixes.py
+++ b/reccmp/compare/asm/fixes.py
@@ -155,7 +155,11 @@ def patch_mov_commutative(orig: list[str], recomp: list[str]) -> set[int]:
     orig_ops = _split_operands(orig[inst_index])
     recomp_ops = _split_operands(recomp[inst_index])
 
-    if len(orig_mov_ops) < 2 or len(recomp_mov_ops) < 2:
+    # We expect these instructions to all have two operands.
+    if any(
+        len(operands) != 2
+        for operands in (orig_mov_ops, recomp_mov_ops, orig_ops, recomp_ops)
+    ):
         return set()
 
     # MOV destination must be the same register in both versions.

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -256,6 +256,26 @@ def test_fix_mov_imul_swap_valid():
     assert is_effective is True
 
 
+def test_fix_mov_imul_single_operand_imul():
+    """Should not crash with IndexError if single operand IMUL is used.
+    The desination is presumed to be EAX/AX/AL, so this example could be considered a match.
+    """
+
+    orig_asm = [
+        "mov ax, word ptr [ebp - 0x4]",
+        "imul word ptr [ebp - 0x8]",
+    ]
+    recomp_asm = [
+        "mov ax, word ptr [ebp - 0x8]",
+        "imul word ptr [ebp - 0x4]",
+    ]
+
+    diff = difflib.SequenceMatcher(None, orig_asm, recomp_asm)
+    is_effective = find_effective_match(diff.get_opcodes(), orig_asm, recomp_asm)
+
+    assert is_effective is False
+
+
 def test_fix_mov_add_swap_valid():
 
     orig_asm = [


### PR DESCRIPTION
A group of instructions like this breaks the recent `mov/imul` swap correction in #314:
```asm
mov ax, word ptr [bp + 0x38]
imul word ptr [bp + 0x3a]
```
This fix aborts the attempted fix if we get a single-operand `imul`.