### PR TITLE
Tests for reccmp report output and unified diff

### DIFF
--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -413,8 +413,9 @@ def test_compare_vtable_diff():
     assert udiff is not None
     assert len(udiff) == 1
 
-    assert udiff[0][0] == "@@ -vtable0x00,32 +vtable0x00,32 @@"
-    assert udiff[0][1][0].keys() == {"orig", "recomp"}
-    assert udiff[0][1][1].keys() == {"both"}
-    assert len(udiff[0][1][1]["both"]) > 10
-    assert udiff[0][1][2].keys() == {"orig", "recomp"}
+    [diff_hunk, diff_groups] = udiff[0]
+    assert diff_hunk == "@@ -vtable0x00,32 +vtable0x00,32 @@"
+    assert diff_groups[0].keys() == {"orig", "recomp"}
+    assert diff_groups[1].keys() == {"both"}
+    assert len(diff_groups[1]["both"]) > 10
+    assert diff_groups[2].keys() == {"orig", "recomp"}


### PR DESCRIPTION
You could call these our first end-to-end tests. We have been storing unified diff output (format: #98) directly in the output JSON and HTML files. #307 makes some changes internally so that the unified diff is produced in the report module instead of directly in the `Compare` core.

This is here as its own PR to demonstrate that #307 does not make any changes to the final output. I only had to make very minor changes to this test to get it working with the new report code.

I avoided comparing the huge unified diff blocks directly, but there is certainly room for more direct comparison if needed.