### PR TITLE
Migrate off `db.get_by_x`, `batch.set_x` functions in tests

### DIFF
--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -59,7 +59,7 @@ def test_create_analysis_strings(db: EntityDb):
 
     create_analysis_strings(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") == EntityType.STRING
     assert e.get("size") == 6
@@ -76,7 +76,7 @@ def test_create_analysis_strings_do_not_replace(db: EntityDb):
 
     create_analysis_strings(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") != EntityType.STRING
 
@@ -90,7 +90,7 @@ def test_create_analysis_strings_not_relocated(db: EntityDb):
 
     create_analysis_strings(db, ImageId.ORIG, binfile)
 
-    assert db.get_by_orig(100) is None
+    assert db.get(ImageId.ORIG, 100) is None
 
 
 def test_create_analysis_strings_not_latin1(db: EntityDb):
@@ -102,7 +102,7 @@ def test_create_analysis_strings_not_latin1(db: EntityDb):
 
     create_analysis_strings(db, ImageId.ORIG, binfile)
 
-    assert db.get_by_orig(100) is None
+    assert db.get(ImageId.ORIG, 100) is None
 
 
 def test_create_thunks(db: EntityDb):
@@ -112,7 +112,7 @@ def test_create_thunks(db: EntityDb):
 
     create_thunks(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") == EntityType.THUNK
     assert e.get("size") == 5
@@ -128,7 +128,7 @@ def test_create_thunks_do_not_replace(db: EntityDb):
 
     create_thunks(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") == EntityType.FUNCTION
     assert e.get("size") != 5
@@ -144,7 +144,7 @@ def test_create_analysis_floats(db: EntityDb):
     ):
         create_analysis_floats(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") == EntityType.FLOAT
     assert e.get("size") == 4
@@ -164,7 +164,7 @@ def test_create_analysis_floats_do_not_replace(db: EntityDb):
     ):
         create_analysis_floats(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("type") != EntityType.FLOAT
 
@@ -174,7 +174,7 @@ def test_create_analysis_vtordisps(db: EntityDb, binfile: PEImage):
     create_analysis_vtordisps(db, ImageId.ORIG, binfile)
 
     # Using the first vtordisp as an example
-    e = db.get_by_orig(0x1000FB50)
+    e = db.get(ImageId.ORIG, 0x1000FB50)
     assert e is not None
     assert e.get("type") == EntityType.VTORDISP
     assert e.get("size") == 8
@@ -182,7 +182,7 @@ def test_create_analysis_vtordisps(db: EntityDb, binfile: PEImage):
     assert get_ref_displacement(db, ImageId.ORIG, 0x1000FB50) == (-4, 0)
 
     # Should also set up the function entity (if it does not already exist)
-    e = db.get_by_orig(0x1000FB60)
+    e = db.get(ImageId.ORIG, 0x1000FB60)
     assert e is not None
     assert e.get("type") == EntityType.FUNCTION
 
@@ -191,14 +191,14 @@ def test_create_analysis_vtordisps_no_overwrite(db: EntityDb, binfile: PEImage):
     """Should not overwrite an entity on the referenced function if it exists."""
     with db.batch() as batch:
         # Using addrs from above example.
-        batch.set_orig(0x1000FB60, type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 0x1000FB60, type=EntityType.STRING)
 
     create_analysis_vtordisps(db, ImageId.ORIG, binfile)
 
     # For now: Don't overwrite the entity type of the referenced function.
     # This is probably fine to do in the long run, but we want to protect against
     # changes to how regular thunks are identified if/when they get their own type.
-    e = db.get_by_orig(0x1000FB60)
+    e = db.get(ImageId.ORIG, 0x1000FB60)
     assert e is not None
     assert e.get("type") != EntityType.FUNCTION
 
@@ -214,7 +214,7 @@ def test_complete_partial_strings(db: EntityDb):
     complete_partial_strings(db, ImageId.ORIG, binfile)
 
     # Entity size set according to string length plus null-terminator.
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("size") == 6
     assert e.name == '"Hello"'
@@ -233,7 +233,7 @@ def test_complete_partial_strings_with_nulls(db: EntityDb):
 
     complete_partial_strings(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == '"\\x00test"'
 
@@ -249,7 +249,7 @@ def test_complete_partial_strings_widechar(db: EntityDb):
     complete_partial_strings(db, ImageId.ORIG, binfile)
 
     # Entity size set according to string length plus null-terminator.
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("size") == 12
     assert e.name == 'L"Hello"'
@@ -278,7 +278,7 @@ def test_complete_partial_strings_exceptions(db: EntityDb, ex_type: Exception):
     complete_partial_strings(db, ImageId.ORIG, binfile)
 
     # Should not modify the entity.
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name is None
 
@@ -300,7 +300,7 @@ def test_complete_partial_strings_unicode_exception(db: EntityDb):
     complete_partial_strings(db, ImageId.ORIG, binfile)
 
     # Should not modify the entity.
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name is None
 
@@ -315,7 +315,7 @@ def test_create_imports(db: EntityDb):
 
     create_imports(db, ImageId.ORIG, binfile)
 
-    e = db.get_by_orig(0x1000)
+    e = db.get(ImageId.ORIG, 0x1000)
     assert e is not None
     assert e.get("type") == EntityType.IMPORT
     name = e.get("name")
@@ -323,7 +323,7 @@ def test_create_imports(db: EntityDb):
     assert "Hello" in name
 
     # Create mock name using the ordinal number.
-    e = db.get_by_orig(0x2000)
+    e = db.get(ImageId.ORIG, 0x2000)
     assert e is not None
     assert e.get("type") == EntityType.IMPORT
     name = e.get("name")

--- a/tests/test_compare_analyze_partial_floats.py
+++ b/tests/test_compare_analyze_partial_floats.py
@@ -87,7 +87,7 @@ def test_complete_partial_floats_matched(
 ):
     """Will update matched entities by reading from whichever binary is provided."""
     with db.batch() as batch:
-        batch.set_recomp(0x100D5748, type=EntityType.FLOAT, size=8)
+        batch.set(ImageId.RECOMP, 0x100D5748, type=EntityType.FLOAT, size=8)
         batch.match(0x100D5748, 0x100D5748)
 
     # Parametrized so we will use both address spaces as the key.

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -23,7 +23,7 @@ def test_ignore_recomp_collision(db):
 def test_dynamic_metadata(db):
     """Using the API we have now"""
     db.set_recomp_symbol(1234, hello="abcdef", option=True)
-    obj = db.get_by_recomp(1234)
+    obj = db.get(ImageId.RECOMP, 1234)
     assert obj.get("hello") == "abcdef"
 
     # Should preserve boolean type
@@ -36,8 +36,8 @@ def test_db_count(db):
     assert db.count() == 0
 
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(100)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 100)
 
     assert db.count() == 2
 
@@ -53,10 +53,10 @@ def test_db_all_order(db):
     2. Unmatched entities with only a recomp_addr. Order by recomp_addr, ascending."""
     with db.batch() as batch:
         for addr in (600, 500, 300, 200):
-            batch.set_recomp(addr)
+            batch.set(ImageId.RECOMP, addr)
 
         for addr in (400, 300, 200, 100):
-            batch.set_orig(addr)
+            batch.set(ImageId.ORIG, addr)
 
         batch.match(200, 200)
         batch.match(300, 300)
@@ -79,30 +79,30 @@ def test_get_by_exact(db):
     """
 
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(100)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 100)
 
     # If there is an exact addr match, return the entity.
-    assert db.get_by_orig(100) is not None
-    assert db.get_by_orig(100, exact=True) is not None
-    assert db.get_by_orig(100, exact=False) is not None
-    assert db.get_by_recomp(100) is not None
-    assert db.get_by_recomp(100, exact=True) is not None
-    assert db.get_by_recomp(100, exact=False) is not None
+    assert db.get(ImageId.ORIG, 100) is not None
+    assert db.get(ImageId.ORIG, 100, exact=True) is not None
+    assert db.get(ImageId.ORIG, 100, exact=False) is not None
+    assert db.get(ImageId.RECOMP, 100) is not None
+    assert db.get(ImageId.RECOMP, 100, exact=True) is not None
+    assert db.get(ImageId.RECOMP, 100, exact=False) is not None
 
     # If there is no exact match, return None.
-    assert db.get_by_orig(200) is None
-    assert db.get_by_orig(200, exact=True) is None
-    assert db.get_by_recomp(200) is None
-    assert db.get_by_recomp(200, exact=True) is None
+    assert db.get(ImageId.ORIG, 200) is None
+    assert db.get(ImageId.ORIG, 200, exact=True) is None
+    assert db.get(ImageId.RECOMP, 200) is None
+    assert db.get(ImageId.RECOMP, 200, exact=True) is None
 
     # Return the preceding entity if exact=False.
-    assert db.get_by_orig(200, exact=False) is not None
-    assert db.get_by_recomp(200, exact=False) is not None
+    assert db.get(ImageId.ORIG, 200, exact=False) is not None
+    assert db.get(ImageId.RECOMP, 200, exact=False) is not None
 
     # Should only return the preceding entity if one exists.
-    assert db.get_by_orig(50, exact=False) is None
-    assert db.get_by_recomp(50, exact=False) is None
+    assert db.get(ImageId.ORIG, 50, exact=False) is None
+    assert db.get(ImageId.RECOMP, 50, exact=False) is None
 
 
 def test_get_by_exact_keyword(db: EntityDb):
@@ -111,24 +111,24 @@ def test_get_by_exact_keyword(db: EntityDb):
     # Should fail if called without the 'exact' keyword.
     # Disable mypy checking for these calls because we've intentionally created a typing error.
     with pytest.raises(TypeError):
-        db.get_by_orig(100, False)  # type: ignore
+        db.get(ImageId.ORIG, 100, False)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_orig(100, True)  # type: ignore
+        db.get(ImageId.ORIG, 100, True)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_recomp(100, True)  # type: ignore
+        db.get(ImageId.RECOMP, 100, True)  # type: ignore
 
     with pytest.raises(TypeError):
-        db.get_by_recomp(100, False)  # type: ignore
+        db.get(ImageId.RECOMP, 100, False)  # type: ignore
 
     # Succeeds with 'exact' keyword or if it the parameter is omitted.
-    db.get_by_orig(100)
-    db.get_by_orig(100, exact=False)
-    db.get_by_orig(100, exact=True)
-    db.get_by_recomp(100)
-    db.get_by_recomp(100, exact=False)
-    db.get_by_recomp(100, exact=True)
+    db.get(ImageId.ORIG, 100)
+    db.get(ImageId.ORIG, 100, exact=False)
+    db.get(ImageId.ORIG, 100, exact=True)
+    db.get(ImageId.RECOMP, 100)
+    db.get(ImageId.RECOMP, 100, exact=False)
+    db.get(ImageId.RECOMP, 100, exact=True)
 
 
 #### Testing new batch API ####
@@ -137,11 +137,11 @@ def test_get_by_exact_keyword(db: EntityDb):
 def test_batch(db):
     """Demonstrate batch with context manager"""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello")
-        batch.set_recomp(200, name="Test")
+        batch.set(ImageId.ORIG, 100, name="Hello")
+        batch.set(ImageId.RECOMP, 200, name="Test")
 
-    assert db.get_by_orig(100).name == "Hello"
-    assert db.get_by_recomp(200).name == "Test"
+    assert db.get(ImageId.ORIG, 100).name == "Hello"
+    assert db.get(ImageId.RECOMP, 200).name == "Test"
 
 
 def test_batch_upsert(db):
@@ -150,29 +150,29 @@ def test_batch_upsert(db):
     db.set_recomp_symbol(200, name="Test")
 
     with db.batch() as batch:
-        batch.set_orig(100, name="abc")
-        batch.set_recomp(200, name="xyz")
+        batch.set(ImageId.ORIG, 100, name="abc")
+        batch.set(ImageId.RECOMP, 200, name="xyz")
 
-    assert db.get_by_orig(100).name == "abc"
-    assert db.get_by_recomp(200).name == "xyz"
+    assert db.get(ImageId.ORIG, 100).name == "abc"
+    assert db.get(ImageId.RECOMP, 200).name == "xyz"
 
 
 def test_batch_match_attach(db):
     """Match example with new orig addr.
     There is no existing entity with the orig addr being matched."""
     with db.batch() as batch:
-        batch.set_recomp(200, name="Hello")
+        batch.set(ImageId.RECOMP, 200, name="Hello")
         batch.match(100, 200)
 
     # Confirm match
-    assert db.get_by_orig(100).name == "Hello"
+    assert db.get(ImageId.ORIG, 100).name == "Hello"
 
 
 def test_batch_match_combine(db):
     """Match example with existing orig addr."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test")
-        batch.set_recomp(200, name="Hello")
+        batch.set(ImageId.ORIG, 100, name="Test")
+        batch.set(ImageId.RECOMP, 200, name="Hello")
 
     # Two entities
     assert len([*db.get_all()]) == 2
@@ -185,8 +185,8 @@ def test_batch_match_combine(db):
     assert len([*db.get_all()]) == 1
 
     # Confirm match. Both entities have the "name" attribute. Should use recomp value.
-    assert db.get_by_orig(100).recomp_addr == 200
-    assert db.get_by_orig(100).name == "Hello"
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).name == "Hello"
 
 
 def test_batch_match_combine_except_null(db):
@@ -194,21 +194,21 @@ def test_batch_match_combine_except_null(db):
     The exception is when the recomp entity has a NULL. We should use the orig attribute in this case.
     """
     with db.batch() as batch:
-        batch.set_orig(100, name="Test", test=123)
-        batch.set_recomp(200, name="Hello", test=None)
+        batch.set(ImageId.ORIG, 100, name="Test", test=123)
+        batch.set(ImageId.RECOMP, 200, name="Hello", test=None)
         batch.match(100, 200)
 
-    assert db.get_by_recomp(200).get("test") == 123
+    assert db.get(ImageId.RECOMP, 200).get("test") == 123
 
 
 def test_batch_match_combine_replace_null(db):
     """Confirm that we will replace a NULL on the orig side with a recomp value."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test", test=None)
-        batch.set_recomp(200, name="Hello", test=123)
+        batch.set(ImageId.ORIG, 100, name="Test", test=None)
+        batch.set(ImageId.RECOMP, 200, name="Hello", test=123)
         batch.match(100, 200)
 
-    assert db.get_by_recomp(200).get("test") == 123
+    assert db.get(ImageId.RECOMP, 200).get("test") == 123
 
 
 @pytest.mark.xfail(reason="Known limitation.")
@@ -217,14 +217,14 @@ def test_batch_match_create(db):
     with db.batch() as batch:
         batch.match(100, 200)
 
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
 
 
 def test_batch_commit_twice(db):
     """Calling commit() clears the pending updates.
     Calling commit() again without adding new changes will not alter the database."""
     batch = db.batch()
-    batch.set_orig(100, name="Test")
+    batch.set(ImageId.ORIG, 100, name="Test")
 
     with patch("reccmp.compare.db.EntityDb.bulk_orig_insert") as mock:
         batch.commit()
@@ -241,18 +241,18 @@ def test_batch_cannot_alter_matched(db):
 
     # Set up the match
     with db.batch() as batch:
-        batch.set_recomp(200, name="Test")
+        batch.set(ImageId.RECOMP, 200, name="Test")
         batch.match(100, 200)
 
     # Confirm it is there
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
 
     # Try to change recomp=200 to match orig=101
     with db.batch() as batch:
         batch.match(101, 200)
 
     # Should not change it
-    assert db.get_by_recomp(200).orig_addr == 100
+    assert db.get(ImageId.RECOMP, 200).orig_addr == 100
 
 
 def test_batch_match_repeat_orig_addr(db):
@@ -260,55 +260,55 @@ def test_batch_match_repeat_orig_addr(db):
     As such, each orig and recomp address should appear only once. If either address is repeated
     and would collide with a previous staged match, ignore the new one."""
     with db.batch() as batch:
-        batch.set_recomp(200, name="Hello")
-        batch.set_recomp(201, name="Test")
+        batch.set(ImageId.RECOMP, 200, name="Hello")
+        batch.set(ImageId.RECOMP, 201, name="Test")
         batch.match(100, 200)
         batch.match(100, 201)
 
-    assert db.get_by_orig(100).recomp_addr == 200
-    assert db.get_by_recomp(201).orig_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
+    assert db.get(ImageId.RECOMP, 201).orig_addr is None
 
 
 def test_batch_match_repeat_recomp_addr(db):
     """Same as the previous test, except that we are repeating the recomp addr instead of orig."""
     with db.batch() as batch:
-        batch.set_recomp(200, name="Hello")
-        batch.set_recomp(201, name="Test")
+        batch.set(ImageId.RECOMP, 200, name="Hello")
+        batch.set(ImageId.RECOMP, 201, name="Test")
         batch.match(100, 200)
         batch.match(101, 200)
 
-    assert db.get_by_recomp(200).orig_addr == 100
-    assert db.get_by_orig(101) is None
+    assert db.get(ImageId.RECOMP, 200).orig_addr == 100
+    assert db.get(ImageId.ORIG, 101) is None
 
 
 def test_batch_exception_uncaught(db):
     """When using batch context manager, an uncaught exception should clear the staged changes."""
     try:
         with db.batch() as batch:
-            batch.set_orig(100, name="Test")
-            batch.set_recomp(200, test=123)
+            batch.set(ImageId.ORIG, 100, name="Test")
+            batch.set(ImageId.RECOMP, 200, test=123)
             batch.match(100, 200)
             _ = 1 / 0
     except ZeroDivisionError:
         pass
 
-    assert db.get_by_orig(100) is None
-    assert db.get_by_orig(200) is None
+    assert db.get(ImageId.ORIG, 100) is None
+    assert db.get(ImageId.ORIG, 200) is None
 
 
 def test_batch_exception_caught(db):
     """If the exception is caught, allow the batch to go through."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test")
-        batch.set_recomp(200, test=123)
+        batch.set(ImageId.ORIG, 100, name="Test")
+        batch.set(ImageId.RECOMP, 200, test=123)
         batch.match(100, 200)
         try:
             _ = 1 / 0
         except ZeroDivisionError:
             pass
 
-    assert db.get_by_orig(100) is not None
-    assert db.get_by_recomp(200) is not None
+    assert db.get(ImageId.ORIG, 100) is not None
+    assert db.get(ImageId.RECOMP, 200) is not None
 
 
 def test_batch_sqlite_exception(db):
@@ -316,8 +316,8 @@ def test_batch_sqlite_exception(db):
 
     # Not using batch context for clarity
     batch = db.batch()
-    batch.set_orig(100, name="Test")
-    batch.set_recomp(200, test=123)
+    batch.set(ImageId.ORIG, 100, name="Test")
+    batch.set(ImageId.RECOMP, 200, test=123)
 
     # Insert bad data that will cause a binding error
     batch.match(100, ("bogus",))
@@ -326,8 +326,8 @@ def test_batch_sqlite_exception(db):
         batch.commit()
 
     # Should rollback everything
-    assert db.get_by_orig(100) is None
-    assert db.get_by_recomp(200) is None
+    assert db.get(ImageId.ORIG, 100) is None
+    assert db.get(ImageId.RECOMP, 200) is None
 
 
 def test_generic_used_function(db: EntityDb):
@@ -336,13 +336,13 @@ def test_generic_used_function(db: EntityDb):
     assert db.used(ImageId.RECOMP, 100) is False
 
     with db.batch() as batch:
-        batch.set_orig(100, name="Test")
+        batch.set(ImageId.ORIG, 100, name="Test")
 
     assert db.used(ImageId.ORIG, 100) is True
     assert db.used(ImageId.RECOMP, 100) is False
 
     with db.batch() as batch:
-        batch.set_recomp(100, name="Test")
+        batch.set(ImageId.RECOMP, 100, name="Test")
 
     assert db.used(ImageId.ORIG, 100) is True
     assert db.used(ImageId.RECOMP, 100) is True
@@ -359,14 +359,14 @@ def test_generic_set_function(db: EntityDb):
     with db.batch() as batch:
         batch.set(ImageId.ORIG, 100, name="Test")
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "Test"
 
     with db.batch() as batch:
         batch.set(ImageId.RECOMP, 100, name="Test")
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "Test"
 
@@ -379,12 +379,12 @@ def test_generic_set_invalid_id(db: EntityDb):
 
 
 def test_generic_get_function(db: EntityDb):
-    """used() has a parameter to select which address space to check."""
+    """get() has a parameter to select which address space to check."""
     assert db.get(ImageId.ORIG, 100) is None
     assert db.get(ImageId.ORIG, 110, exact=False) is None
 
     with db.batch() as batch:
-        batch.set_orig(100, name="Test")
+        batch.set(ImageId.ORIG, 100, name="Test")
 
     e = db.get(ImageId.ORIG, 100)
     assert e is not None
@@ -395,7 +395,7 @@ def test_generic_get_function(db: EntityDb):
     assert db.get(ImageId.RECOMP, 110, exact=False) is None
 
     with db.batch() as batch:
-        batch.set_recomp(100, name="Test")
+        batch.set(ImageId.RECOMP, 100, name="Test")
 
     e = db.get(ImageId.RECOMP, 100)
     assert e is not None
@@ -413,8 +413,8 @@ def test_get_next_orig_addr(db: EntityDb):
     """Should return the address of the entity from
     the orig address space after the given address."""
     with db.batch() as batch:
-        batch.set_orig(100, type=EntityType.FUNCTION)
-        batch.set_orig(200, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION)
 
     # The value does not need to contain an entity itself
     assert db.get_next_orig_addr(0) == 100
@@ -429,8 +429,8 @@ def test_get_next_orig_addr(db: EntityDb):
 def test_get_next_orig_addr_any_type(db: EntityDb):
     """Demonstrate that the function works with all entity types (not just functions)."""
     with db.batch() as batch:
-        batch.set_orig(100, type=EntityType.STRING)
-        batch.set_orig(200, type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 100, type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 200, type=EntityType.DATA)
 
     assert db.get_next_orig_addr(0) == 100
     assert db.get_next_orig_addr(100) == 200
@@ -440,9 +440,9 @@ def test_get_next_orig_addr_any_type(db: EntityDb):
 def test_get_next_orig_addr_no_type(db: EntityDb):
     """Skip entities without a type."""
     with db.batch() as batch:
-        batch.set_orig(100, type=EntityType.FUNCTION)
-        batch.set_orig(150)
-        batch.set_orig(200, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 150)
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION)
 
     assert db.get_next_orig_addr(100) == 200
     assert db.get_next_orig_addr(150) == 200
@@ -453,10 +453,10 @@ def test_get_next_orig_addr_function_passenger_type(db: EntityDb):
     These entities appear inside of other entities (i.e. functions)
     If we did not skip them, our estimate on function size will be too small."""
     with db.batch() as batch:
-        batch.set_orig(100, type=EntityType.FUNCTION)
-        batch.set_orig(150, type=EntityType.LINE)
-        batch.set_orig(160, type=EntityType.LABEL)
-        batch.set_orig(200, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 150, type=EntityType.LINE)
+        batch.set(ImageId.ORIG, 160, type=EntityType.LABEL)
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION)
 
     assert db.get_next_orig_addr(100) == 200
     assert db.get_next_orig_addr(150) == 200

--- a/tests/test_compare_db_queries.py
+++ b/tests/test_compare_db_queries.py
@@ -21,9 +21,9 @@ def test_overloaded_functions_all_unique(db: EntityDb):
     assert len(list(get_overloaded_functions(db))) == 0
 
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
-        batch.set_orig(200, name="Test", type=EntityType.FUNCTION)
-        batch.set_recomp(300, name="xyz", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, name="Test", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 300, name="xyz", type=EntityType.FUNCTION)
 
     # All entities are functions, but their names are unique.
     assert len(list(get_overloaded_functions(db))) == 0
@@ -31,21 +31,21 @@ def test_overloaded_functions_all_unique(db: EntityDb):
 
 def test_overloaded_functions_ignore_non_functions(db: EntityDb):
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello")
-        batch.set_orig(200, name="Hello")
-        batch.set_recomp(300, name="Hello")
+        batch.set(ImageId.ORIG, 100, name="Hello")
+        batch.set(ImageId.ORIG, 200, name="Hello")
+        batch.set(ImageId.RECOMP, 300, name="Hello")
 
     # Name reused, but no entities are functions.
     assert len(list(get_overloaded_functions(db))) == 0
 
     with db.batch() as batch:
-        batch.set_orig(400, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 400, name="Hello", type=EntityType.FUNCTION)
 
     # The name is not shared with *other* functions
     assert len(list(get_overloaded_functions(db))) == 0
 
     with db.batch() as batch:
-        batch.set_recomp(400, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 400, name="Hello", type=EntityType.FUNCTION)
 
     # Now we have two entities that are functions and have the same name.
     # Don't count the other entities that are *not* functions.
@@ -55,9 +55,9 @@ def test_overloaded_functions_ignore_non_functions(db: EntityDb):
 def test_overloaded_functions(db: EntityDb):
     with db.batch() as batch:
         # Inserted in reverse order to test numbering
-        batch.set_recomp(300, name="Hello", type=EntityType.FUNCTION)
-        batch.set_recomp(200, name="Hello", type=EntityType.FUNCTION)
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 300, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 200, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION)
         batch.match(200, 200)
 
     # Should have three entities, one matched, all functions and all with the name "Hello".
@@ -71,18 +71,18 @@ def test_overloaded_functions_ignore_thunks(db: EntityDb):
     """When deciding which functions have duplicate names, exclude thunk entities."""
     with db.batch() as batch:
         # Unique among non-ref functions
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
-        batch.set_orig(200, name="Hello", type=EntityType.THUNK)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, name="Hello", type=EntityType.THUNK)
         batch.set_ref(ImageId.ORIG, 200, ref=1000)
         # Non-unique but both are refs
-        batch.set_orig(300, name="Test", type=EntityType.THUNK)
-        batch.set_orig(400, name="Test", type=EntityType.THUNK)
+        batch.set(ImageId.ORIG, 300, name="Test", type=EntityType.THUNK)
+        batch.set(ImageId.ORIG, 400, name="Test", type=EntityType.THUNK)
         batch.set_ref(ImageId.ORIG, 300, ref=1000)
         batch.set_ref(ImageId.ORIG, 400, ref=1000)
         # Non-unique but should ignore the ref function
-        batch.set_orig(500, name="Hey", type=EntityType.FUNCTION)
-        batch.set_orig(600, name="Hey", type=EntityType.FUNCTION)
-        batch.set_orig(700, name="Hey", type=EntityType.THUNK)
+        batch.set(ImageId.ORIG, 500, name="Hey", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 600, name="Hey", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 700, name="Hey", type=EntityType.THUNK)
         batch.set_ref(ImageId.ORIG, 700, ref=1000)
 
     # Should only include the duplicate names where both are not ref entities.
@@ -96,8 +96,8 @@ def test_get_referencing_entity_matches(db: EntityDb):
 
     # Set up matched parent entity.
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(100)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 100)
         batch.match(100, 100)
 
     # There are no referencing entities.
@@ -105,8 +105,8 @@ def test_get_referencing_entity_matches(db: EntityDb):
 
     # Set up child entities with reference link.
     with db.batch() as batch:
-        batch.set_orig(200)
-        batch.set_recomp(300)
+        batch.set(ImageId.ORIG, 200)
+        batch.set(ImageId.RECOMP, 300)
 
         batch.set_ref(ImageId.ORIG, 200, ref=100)
         batch.set_ref(ImageId.RECOMP, 300, ref=100)
@@ -127,12 +127,12 @@ def test_get_referencing_entity_matches_check_entity_type(db: EntityDb):
     """Possible future behavior of the query: require types of child entities
     to match along with checking reference and displacement values."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(100)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 100)
         batch.match(100, 100)
 
-        batch.set_orig(200, type=EntityType.THUNK)
-        batch.set_recomp(300, type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, type=EntityType.THUNK)
+        batch.set(ImageId.RECOMP, 300, type=EntityType.FUNCTION)
 
         batch.set_ref(ImageId.ORIG, 200, ref=100)
         batch.set_ref(ImageId.RECOMP, 300, ref=100)

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -3,7 +3,7 @@
 from pathlib import PurePath, PureWindowsPath
 from textwrap import dedent
 import pytest
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 from reccmp.formats import PEImage, TextFile
 from reccmp.compare.ingest import load_markers
 from reccmp.compare.db import EntityDb
@@ -34,7 +34,7 @@ def test_load_code_invalid_addr(db: EntityDb, lines_db: LinesDb, binfile: PEImag
     load_markers(files, lines_db, binfile, "TEST", db)
 
     # No exception raised
-    assert db.get_by_orig(0x11001000) is None
+    assert db.get(ImageId.ORIG, 0x11001000) is None
 
 
 def test_load_code_duplicate_addr(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
@@ -60,7 +60,7 @@ def test_load_code_duplicate_addr(db: EntityDb, lines_db: LinesDb, binfile: PEIm
     load_markers(files, lines_db, binfile, "TEST", db)
 
     # Should use the name from the first file (alphabetical, by path)
-    entity = db.get_by_orig(0x1001DDE0)
+    entity = db.get(ImageId.ORIG, 0x1001DDE0)
     assert entity is not None
     assert entity.get("name") == "_Lockit::~_Lockit"
 
@@ -79,7 +79,7 @@ def test_load_code_cpp_symbol_function(
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10086240)
+    entity = db.get(ImageId.ORIG, 0x10086240)
     assert entity is not None
     assert entity.get("symbol") == "??2@YAPAXI@Z"
     assert entity.get("name") is None
@@ -99,7 +99,7 @@ def test_load_code_cpp_symbol_global(db: EntityDb, lines_db: LinesDb, binfile: P
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100FD624)
+    entity = db.get(ImageId.ORIG, 0x100FD624)
     assert entity is not None
     assert entity.get("symbol") == "?__pInconsistency@@3P6AXXZA"
     assert entity.get("name") is None
@@ -119,7 +119,7 @@ def test_load_code_c_symbol_implicit(db: EntityDb, lines_db: LinesDb, binfile: P
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x1008C410)
+    entity = db.get(ImageId.ORIG, 0x1008C410)
     assert entity is not None
     assert entity.get("symbol") is None
     assert entity.get("name") == "_strlwr"
@@ -138,7 +138,7 @@ def test_load_code_c_symbol_explicit(db: EntityDb, lines_db: LinesDb, binfile: P
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x1008C410)
+    entity = db.get(ImageId.ORIG, 0x1008C410)
     assert entity is not None
     assert entity.get("symbol") == "_strlwr"
     assert entity.get("name") is None
@@ -175,7 +175,7 @@ def test_load_code_function_nameref_variants(
     # We don't need to protect against None by using: entity.get("stub", False)
 
     # FUNCTION
-    entity = db.get_by_orig(0x1001DDE0)
+    entity = db.get(ImageId.ORIG, 0x1001DDE0)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("library") is False
@@ -183,7 +183,7 @@ def test_load_code_function_nameref_variants(
     assert entity.get("name") == "_Lockit::~_Lockit"
 
     # TEMPLATE
-    entity = db.get_by_orig(0x1001C050)
+    entity = db.get(ImageId.ORIG, 0x1001C050)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("library") is False
@@ -191,7 +191,7 @@ def test_load_code_function_nameref_variants(
     assert entity.get("name") == "Vector<unsigned char *>::~Vector<unsigned char *>"
 
     # LIBRARY
-    entity = db.get_by_orig(0x1008B400)
+    entity = db.get(ImageId.ORIG, 0x1008B400)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("library") is True
@@ -199,7 +199,7 @@ def test_load_code_function_nameref_variants(
     assert entity.get("name") == "_atol"
 
     # STUB
-    entity = db.get_by_orig(0x1008B4B0)
+    entity = db.get(ImageId.ORIG, 0x1008B4B0)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("library") is False
@@ -207,7 +207,7 @@ def test_load_code_function_nameref_variants(
     assert entity.get("name") == "_atoi"
 
     # SYNTHETIC
-    entity = db.get_by_orig(0x100380E0)
+    entity = db.get(ImageId.ORIG, 0x100380E0)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("library") is False
@@ -230,7 +230,7 @@ def test_load_code_lineref(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10038220)
+    entity = db.get(ImageId.ORIG, 0x10038220)
     assert entity is not None
 
     # Nothing in the lines database. No match.
@@ -258,10 +258,10 @@ def test_load_code_match_line(db: EntityDb, lines_db: LinesDb, binfile: PEImage)
 
     # TODO: For a successful match, the recomp entity must already exist.
     with db.batch() as batch:
-        batch.set_recomp(0x1234)
+        batch.set(ImageId.RECOMP, 0x1234)
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10038220)
+    entity = db.get(ImageId.ORIG, 0x10038220)
     assert entity is not None
     assert entity.recomp_addr == 0x1234
 
@@ -290,10 +290,10 @@ def test_load_code_no_match_line(db: EntityDb, lines_db: LinesDb, binfile: PEIma
 
     # TODO: For a successful match, the recomp entity must already exist.
     with db.batch() as batch:
-        batch.set_recomp(0x1234)
+        batch.set(ImageId.RECOMP, 0x1234)
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10038220)
+    entity = db.get(ImageId.ORIG, 0x10038220)
     assert entity is not None
     assert entity.recomp_addr is None
     assert entity.get("type") == EntityType.FUNCTION
@@ -312,7 +312,7 @@ def test_load_code_string(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100F038C)
+    entity = db.get(ImageId.ORIG, 0x100F038C)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.get("size") == 6
@@ -332,7 +332,7 @@ def test_load_code_string_no_match(db: EntityDb, lines_db: LinesDb, binfile: PEI
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100F038C)
+    entity = db.get(ImageId.ORIG, 0x100F038C)
     assert entity is None
 
 
@@ -349,7 +349,7 @@ def test_load_code_widechar(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100DAAA0)
+    entity = db.get(ImageId.ORIG, 0x100DAAA0)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.get("size") == 14
@@ -370,7 +370,7 @@ def test_load_code_string_with_nulls(db: EntityDb, lines_db: LinesDb, binfile: P
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100DAAA0)
+    entity = db.get(ImageId.ORIG, 0x100DAAA0)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.get("size") == 12
@@ -391,7 +391,7 @@ def test_load_code_widechar_invalid(db: EntityDb, lines_db: LinesDb, binfile: PE
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100DDA7B)
+    entity = db.get(ImageId.ORIG, 0x100DDA7B)
     assert entity is None
 
 
@@ -408,7 +408,7 @@ def test_load_code_vtable(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100D7380)
+    entity = db.get(ImageId.ORIG, 0x100D7380)
     assert entity is not None
     assert entity.get("type") == EntityType.VTABLE
 
@@ -432,14 +432,14 @@ def test_load_code_vtable_vbase(db: EntityDb, lines_db: LinesDb, binfile: PEImag
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x100D9EC8)
+    entity = db.get(ImageId.ORIG, 0x100D9EC8)
     assert entity is not None
     assert entity.get("type") == EntityType.VTABLE
     assert entity.get("name") == "Pizza"
     assert entity.get("base_class") == "Lunch"
 
     # Should assign the base class even if it is the same as the main class.
-    entity = db.get_by_orig(0x100D7380)
+    entity = db.get(ImageId.ORIG, 0x100D7380)
     assert entity is not None
     assert entity.get("type") == EntityType.VTABLE
     assert entity.get("name") == "Pizza"
@@ -458,7 +458,7 @@ def test_load_code_variable(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10102048)
+    entity = db.get(ImageId.ORIG, 0x10102048)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "g_strACTION"
@@ -481,7 +481,7 @@ def test_load_code_static_variable(db: EntityDb, lines_db: LinesDb, binfile: PEI
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10109594)
+    entity = db.get(ImageId.ORIG, 0x10109594)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "g_dwStyle"
@@ -508,7 +508,7 @@ def test_load_code_static_variable_no_function(
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10109594)
+    entity = db.get(ImageId.ORIG, 0x10109594)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "g_dwStyle"
@@ -530,7 +530,7 @@ def test_load_code_line_marker(db: EntityDb, lines_db: LinesDb, binfile: PEImage
     )
     load_markers(files, lines_db, binfile, "TEST", db)
 
-    entity = db.get_by_orig(0x10001038)
+    entity = db.get(ImageId.ORIG, 0x10001038)
     assert entity is not None
     assert entity.get("type") == EntityType.LINE
     assert entity.get("filename") == "test.cpp"

--- a/tests/test_compare_ingest_csv.py
+++ b/tests/test_compare_ingest_csv.py
@@ -3,7 +3,7 @@ from pathlib import PurePath
 import pytest
 from reccmp.compare.db import EntityDb
 from reccmp.compare.ingest import load_csv, load_data_sources
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 from reccmp.formats import TextFile
 
 
@@ -26,7 +26,7 @@ def test_load_data_sources(db: EntityDb):
 
     load_data_sources(db, ds_files)
 
-    entity = db.get_by_orig(0x1234)
+    entity = db.get(ImageId.ORIG, 0x1234)
     assert entity is not None
     assert entity.get("name") == "hello"
 
@@ -52,11 +52,11 @@ def test_load_data_sources_skip_unknown(db: EntityDb):
 
     load_data_sources(db, ds_files)
 
-    entity = db.get_by_orig(0x1234)
+    entity = db.get(ImageId.ORIG, 0x1234)
     assert entity is not None
     assert entity.get("name") == "hello"
 
-    assert db.get_by_orig(0x5555) is None
+    assert db.get(ImageId.ORIG, 0x5555) is None
 
 
 def test_load_csv(db: EntityDb):
@@ -71,7 +71,7 @@ def test_load_csv(db: EntityDb):
 
     load_csv(db, csv_file)
 
-    entity = db.get_by_orig(0x1234)
+    entity = db.get(ImageId.ORIG, 0x1234)
     assert entity is not None
     assert entity.get("name") == "hello"
 
@@ -101,13 +101,13 @@ def test_load_csv_overwrite(db: EntityDb):
         load_csv(db, csv_file)
 
     # Name overwritten by second file. Type retained from first file.
-    entity = db.get_by_orig(0x1234)
+    entity = db.get(ImageId.ORIG, 0x1234)
     assert entity is not None
     assert entity.get("name") == "test"
     assert entity.get("type") == EntityType.FUNCTION
 
     # Both fields overwritten in the same file.
-    entity = db.get_by_orig(0x5555)
+    entity = db.get(ImageId.ORIG, 0x5555)
     assert entity is not None
     assert entity.get("name") == "jetski"
     assert entity.get("type") == EntityType.DATA
@@ -128,15 +128,15 @@ def test_load_csv_with_errors(db: EntityDb):
 
     load_csv(db, csv_file)
 
-    entity = db.get_by_orig(0x1234)
+    entity = db.get(ImageId.ORIG, 0x1234)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
 
-    entity = db.get_by_orig(0x4321)
+    entity = db.get(ImageId.ORIG, 0x4321)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
 
-    assert db.get_by_orig(0x5555) is None
+    assert db.get(ImageId.ORIG, 0x5555) is None
 
 
 def test_load_csv_with_fatal_error(db: EntityDb):
@@ -152,5 +152,5 @@ def test_load_csv_with_fatal_error(db: EntityDb):
 
     load_csv(db, csv_file)
 
-    assert db.get_by_orig(0x1234) is None
-    assert db.get_by_orig(0x4321) is None
+    assert db.get(ImageId.ORIG, 0x1234) is None
+    assert db.get(ImageId.ORIG, 0x4321) is None

--- a/tests/test_compare_ingest_cvdump.py
+++ b/tests/test_compare_ingest_cvdump.py
@@ -3,7 +3,7 @@ from reccmp.formats import PEImage
 from reccmp.cvdump import CvdumpAnalysis, CvdumpParser
 from reccmp.compare.db import EntityDb
 from reccmp.compare.ingest import load_cvdump
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 
 # These functions use our sample PE image to "cheat" and not have to mock as much.
 # This sets up the imagebase and valid section boundaries for calculation inside load_cvdump.
@@ -41,13 +41,13 @@ def test_size_estimate(binfile: PEImage):
     load_cvdump(cvdump_analysis, db, binfile)
 
     # There are 32 bytes between this and __OP_LOGjmptab
-    entity = db.get_by_recomp(0x1010292A)
+    entity = db.get(ImageId.RECOMP, 0x1010292A)
     assert entity is not None
     assert entity.get("symbol") == "__OP_LOG10jmptab"
     assert entity.get("size") == 0x20
 
     # Calculate the distance to the end of the .data section.
-    entity = db.get_by_recomp(0x1010294A)
+    entity = db.get(ImageId.RECOMP, 0x1010294A)
     assert entity is not None
     assert entity.get("symbol") == "__OP_LOGjmptab"
     assert entity.get("size") == 0x100F0000 + 0x1A734 - 0x1010294A
@@ -71,12 +71,12 @@ def test_size_estimate_different_sections(binfile: PEImage):
     # Calculate the distance to the end of the .rdata section.
     # n.b. The physical size is aligned to the image FileAlignment value
     # so it is used instead of the smaller virtual size.
-    entity = db.get_by_recomp(0x100D4018)
+    entity = db.get(ImageId.RECOMP, 0x100D4018)
     assert entity is not None
     assert entity.get("size") == 0x100D4000 + 0x1B600 - 0x100D4018
 
     # Calculate the distance to the end of the .data section.
-    entity = db.get_by_recomp(0x1010292A)
+    entity = db.get(ImageId.RECOMP, 0x1010292A)
     assert entity is not None
     assert entity.get("size") == 0x100F0000 + 0x1A734 - 0x1010292A
 
@@ -107,19 +107,19 @@ def test_size_estimate_section_contrib(binfile: PEImage):
     load_cvdump(cvdump_analysis, db, binfile)
 
     # Distance to next entity is smaller than section contribution.
-    entity = db.get_by_recomp(0x1010292A)
+    entity = db.get(ImageId.RECOMP, 0x1010292A)
     assert entity is not None
     assert entity.get("symbol") == "__OP_LOG10jmptab"
     assert entity.get("size") == 0x20
 
     # Section contribution size is smaller than distance to next entity.
-    entity = db.get_by_recomp(0x1010294A)
+    entity = db.get(ImageId.RECOMP, 0x1010294A)
     assert entity is not None
     assert entity.get("symbol") == "__OP_LOGjmptab"
     assert entity.get("size") == 0x10
 
     # Prefer section contribution size over distance to end of section.
-    entity = db.get_by_recomp(0x1010296A)
+    entity = db.get(ImageId.RECOMP, 0x1010296A)
     assert entity is not None
     assert entity.get("symbol") == "__OP_EXPjmptab"
     assert entity.get("size") == 0x10
@@ -137,7 +137,7 @@ def test_no_entity_for_section_contributions_only(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    assert db.get_by_recomp(0x1010292A) is None
+    assert db.get(ImageId.RECOMP, 0x1010292A) is None
 
 
 def test_symbol_overwrite(binfile: PEImage):
@@ -157,7 +157,7 @@ def test_symbol_overwrite(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x1008C410)
+    entity = db.get(ImageId.RECOMP, 0x1008C410)
     assert entity is not None
     assert entity.get("symbol") == "_strlwr"
 
@@ -175,7 +175,7 @@ def test_string_without_section_contrib(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100DB57C)
+    entity = db.get(ImageId.RECOMP, 0x100DB57C)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.get("symbol") == "??_C@_08LIDF@December?$AA@"
@@ -205,7 +205,7 @@ def test_string_with_section_contrib(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100DB57C)
+    entity = db.get(ImageId.RECOMP, 0x100DB57C)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.get("symbol") == "??_C@_08LIDF@December?$AA@"
@@ -230,7 +230,7 @@ def test_utf16_without_section_contrib(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100DAAA0)
+    entity = db.get(ImageId.RECOMP, 0x100DAAA0)
     assert entity is not None
     assert entity.get("type") == EntityType.WIDECHAR
     assert (
@@ -261,7 +261,7 @@ def test_utf16_with_section_contrib(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100DAAA0)
+    entity = db.get(ImageId.RECOMP, 0x100DAAA0)
     assert entity is not None
     assert entity.get("type") == EntityType.WIDECHAR
     assert (
@@ -288,7 +288,7 @@ def test_vtable(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100D4018)
+    entity = db.get(ImageId.RECOMP, 0x100D4018)
     assert entity is not None
     assert entity.get("type") == EntityType.VTABLE
     assert entity.get("name") == "Score::`vftable'"
@@ -307,7 +307,7 @@ def test_vtable_with_vbclass(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100D6860)
+    entity = db.get(ImageId.RECOMP, 0x100D6860)
     assert entity is not None
     assert entity.get("type") == EntityType.VTABLE
     assert entity.get("name") == "BumpBouy::`vftable'{for `OgelAnimActor'}"
@@ -326,7 +326,7 @@ def test_vbtable(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100D6788)
+    entity = db.get(ImageId.RECOMP, 0x100D6788)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "BumpBouy::`vbtable'"
@@ -350,7 +350,7 @@ def test_gdata32(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100D94F8)
+    entity = db.get(ImageId.RECOMP, 0x100D94F8)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "g_pizzaHitSounds"
@@ -368,7 +368,7 @@ def test_ldata32(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x100D4000)
+    entity = db.get(ImageId.RECOMP, 0x100D4000)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "Pi"
@@ -392,7 +392,7 @@ def test_variable_size_scalar_type(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x10102B24)
+    entity = db.get(ImageId.RECOMP, 0x10102B24)
     assert entity is not None
     assert entity.get("size") == 4
     assert entity.get("name") == "g_nextInterruptWavIndex"
@@ -413,7 +413,7 @@ def test_variable_size_without_type_info(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x101015B8)
+    entity = db.get(ImageId.RECOMP, 0x101015B8)
     assert entity is not None
     assert entity.get("name") == "g_hdPath"
 
@@ -447,7 +447,7 @@ def test_variable_size_with_type_info(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x101015B8)
+    entity = db.get(ImageId.RECOMP, 0x101015B8)
     assert entity is not None
     assert entity.get("size") == 1024
     assert entity.get("data_type") == 0x1424
@@ -474,7 +474,7 @@ def test_gproc32(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x10038220)
+    entity = db.get(ImageId.RECOMP, 0x10038220)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("size") == 0x8B
@@ -498,7 +498,7 @@ def test_lproc32(binfile: PEImage):
     load_cvdump(cvdump_analysis, db, binfile)
 
     # This is one of the ___xc_a functions.
-    entity = db.get_by_recomp(0x10092350)
+    entity = db.get(ImageId.RECOMP, 0x10092350)
     assert entity is not None
     assert entity.get("type") == EntityType.FUNCTION
     assert entity.get("size") == 5
@@ -548,7 +548,7 @@ def test_gproc_with_static_var(binfile: PEImage):
     cvdump_analysis = CvdumpAnalysis(parser)
     load_cvdump(cvdump_analysis, db, binfile)
 
-    entity = db.get_by_recomp(0x10109594)
+    entity = db.get(ImageId.RECOMP, 0x10109594)
     assert entity is not None
     assert entity.get("type") == EntityType.DATA
     assert entity.get("name") == "g_dwStyle"
@@ -579,7 +579,7 @@ def test_floats(binfile: PEImage):
     load_cvdump(cvdump_analysis, db, binfile)
 
     # Zero in single precision
-    entity = db.get_by_recomp(0x100D5740)
+    entity = db.get(ImageId.RECOMP, 0x100D5740)
     assert entity is not None
     assert entity.get("symbol") == "__real@4@00000000000000000000"
     assert entity.get("type") == EntityType.FLOAT
@@ -589,7 +589,7 @@ def test_floats(binfile: PEImage):
     assert entity.get("name") is None
 
     # Zero in double precision
-    entity = db.get_by_recomp(0x100D5748)
+    entity = db.get(ImageId.RECOMP, 0x100D5748)
     assert entity is not None
     assert entity.get("symbol") == "__real@8@00000000000000000000"
     assert entity.get("type") == EntityType.FLOAT
@@ -618,7 +618,7 @@ def test_skip_global_without_matching_public(binfile: PEImage):
     load_cvdump(cvdump_analysis, db, binfile)
 
     # Should skip the entry at 0004:0000C718
-    assert db.get_by_recomp(0x101DF718) is None
+    assert db.get(ImageId.RECOMP, 0x101DF718) is None
 
     # Should create an entry at 0004:0002F6BC
-    assert db.get_by_recomp(0x1013A6BC) is not None
+    assert db.get(ImageId.RECOMP, 0x1013A6BC) is not None

--- a/tests/test_compare_mutate_match_array.py
+++ b/tests/test_compare_mutate_match_array.py
@@ -6,7 +6,7 @@ import pytest
 from reccmp.compare.mutate import (
     match_array_elements,
 )
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 from reccmp.compare.db import EntityDb
 from reccmp.cvdump.types import CvdumpTypesParser, FieldListItem, CVInfoTypeEnum
 from reccmp.cvdump.cvinfo import CvdumpTypeKey as TK
@@ -38,33 +38,38 @@ def test_match_array(db: EntityDb, types_db: CvdumpTypesParser):
     with db.batch() as batch:
         # NOTE: It does not work if entity size is not set.
         # We should be able to set it because how else would we have the type key?
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=8
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=8,
         )
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test[0]"
     assert e.get("type") == EntityType.DATA
     assert e.get("size") == 8
 
-    e = db.get_by_orig(104)
+    e = db.get(ImageId.ORIG, 104)
     assert e is not None
     assert e.name == "test[1]"
     assert e.get("type") == EntityType.OFFSET
     assert e.get("size") == 4
     assert e.recomp_addr == 104  # Should create new match
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test[0]"
     assert e.get("type") == EntityType.DATA
     assert e.get("size") == 8
 
-    e = db.get_by_recomp(104)
+    e = db.get(ImageId.RECOMP, 104)
     assert e is not None
     assert e.name == "test[1]"
     assert e.get("type") == EntityType.OFFSET
@@ -75,8 +80,13 @@ def test_match_array(db: EntityDb, types_db: CvdumpTypesParser):
 def test_match_array_key_unset(db: EntityDb):
     """Should have no effect if the data_type key is not in the types database."""
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=8
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=8,
         )
         batch.match(100, 100)
 
@@ -84,26 +94,27 @@ def test_match_array_key_unset(db: EntityDb):
     match_array_elements(db, CvdumpTypesParser())
 
     # Does not rename main entity
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
     # Does not create new entity
-    assert db.get_by_orig(104) is None
-    assert db.get_by_recomp(104) is None
+    assert db.get(ImageId.ORIG, 104) is None
+    assert db.get(ImageId.RECOMP, 104) is None
 
 
 def test_match_array_type_is_scalar(db: EntityDb):
     """Should have no effect if the data_type key is a scalar.
     TODO: The expectation will change slightly when the type database does. #211"""
     with db.batch() as batch:
-        batch.set_recomp(
+        batch.set(
+            ImageId.RECOMP,
             100,
             name="test",
             type=EntityType.DATA,
@@ -116,19 +127,19 @@ def test_match_array_type_is_scalar(db: EntityDb):
     match_array_elements(db, CvdumpTypesParser())
 
     # Does not rename main entity
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
     # Does not create new entity
-    assert db.get_by_orig(104) is None
-    assert db.get_by_recomp(104) is None
+    assert db.get(ImageId.ORIG, 104) is None
+    assert db.get(ImageId.RECOMP, 104) is None
 
 
 def test_match_array_type_is_struct(db: EntityDb, types_db: CvdumpTypesParser):
@@ -148,8 +159,13 @@ def test_match_array_type_is_struct(db: EntityDb, types_db: CvdumpTypesParser):
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=8
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=8,
         )
         batch.match(100, 100)
 
@@ -157,19 +173,19 @@ def test_match_array_type_is_struct(db: EntityDb, types_db: CvdumpTypesParser):
     match_array_elements(db, CvdumpTypesParser())
 
     # Does not rename main entity
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test"
     assert e.get("type") == EntityType.DATA
 
     # Does not create new entity
-    assert db.get_by_orig(104) is None
-    assert db.get_by_recomp(104) is None
+    assert db.get(ImageId.ORIG, 104) is None
+    assert db.get(ImageId.RECOMP, 104) is None
 
 
 def test_match_array_type_orig_smaller(db: EntityDb, types_db: CvdumpTypesParser):
@@ -182,32 +198,37 @@ def test_match_array_type_orig_smaller(db: EntityDb, types_db: CvdumpTypesParser
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=8
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=8,
         )
-        batch.set_orig(104, name="blocker", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 104, name="blocker", type=EntityType.DATA)
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
     # Should rename first orig entity
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test[0]"
     assert e.get("type") == EntityType.DATA
 
     # But not the second
-    e = db.get_by_orig(104)
+    e = db.get(ImageId.ORIG, 104)
     assert e is not None
     assert e.name == "blocker"
     assert e.recomp_addr is None  # Should NOT create new match
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test[0]"
     assert e.get("type") == EntityType.DATA
 
-    e = db.get_by_recomp(104)
+    e = db.get(ImageId.RECOMP, 104)
     assert e is not None
     assert e.name == "test[1]"
     assert e.get("type") == EntityType.OFFSET
@@ -235,15 +256,20 @@ def test_match_array_array_of_structs(db: EntityDb, types_db: CvdumpTypesParser)
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=16
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=16,
         )
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
-    orig_entities = [db.get_by_orig(addr) for addr in (100, 104, 108, 112)]
-    recomp_entities = [db.get_by_recomp(addr) for addr in (100, 104, 108, 112)]
+    orig_entities = [db.get(ImageId.ORIG, addr) for addr in (100, 104, 108, 112)]
+    recomp_entities = [db.get(ImageId.RECOMP, addr) for addr in (100, 104, 108, 112)]
 
     assert all(orig_entities)
     assert all(recomp_entities)
@@ -301,15 +327,20 @@ def test_match_array_array_of_arrays(db: EntityDb, types_db: CvdumpTypesParser):
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=16
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=16,
         )
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
-    orig_entities = [db.get_by_orig(addr) for addr in (100, 104, 108, 112)]
-    recomp_entities = [db.get_by_recomp(addr) for addr in (100, 104, 108, 112)]
+    orig_entities = [db.get(ImageId.ORIG, addr) for addr in (100, 104, 108, 112)]
+    recomp_entities = [db.get(ImageId.RECOMP, addr) for addr in (100, 104, 108, 112)]
 
     assert all(orig_entities)
     assert all(recomp_entities)
@@ -385,16 +416,21 @@ def test_match_array_array_of_structs_limit(db: EntityDb, types_db: CvdumpTypesP
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=16
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=16,
         )
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
     # Create first and second level entities. (Same as test_match_array_array_of_structs)
-    orig_entities = [db.get_by_orig(addr) for addr in (100, 104, 108, 112)]
-    recomp_entities = [db.get_by_recomp(addr) for addr in (100, 104, 108, 112)]
+    orig_entities = [db.get(ImageId.ORIG, addr) for addr in (100, 104, 108, 112)]
+    recomp_entities = [db.get(ImageId.RECOMP, addr) for addr in (100, 104, 108, 112)]
 
     assert all(orig_entities)
     assert all(recomp_entities)
@@ -417,8 +453,8 @@ def test_match_array_array_of_structs_limit(db: EntityDb, types_db: CvdumpTypesP
     ]
 
     # Should NOT create the third level entities. (e.g "test[0].hello.y")
-    assert not any(db.get_by_orig(addr) for addr in (102, 106, 110, 114))
-    assert not any(db.get_by_recomp(addr) for addr in (102, 106, 110, 114))
+    assert not any(db.get(ImageId.ORIG, addr) for addr in (102, 106, 110, 114))
+    assert not any(db.get(ImageId.RECOMP, addr) for addr in (102, 106, 110, 114))
 
     # Should create offset entities but not alter the parent variable entity.
     orig_types = [e.get("type") for e in orig_entities if e]
@@ -483,37 +519,46 @@ def test_match_array_array_of_union_structs(db: EntityDb, types_db: CvdumpTypesP
     }
 
     with db.batch() as batch:
-        batch.set_recomp(
-            100, name="test", type=EntityType.DATA, data_type=0x1000, size=8
+        batch.set(
+            ImageId.RECOMP,
+            100,
+            name="test",
+            type=EntityType.DATA,
+            data_type=0x1000,
+            size=8,
         )
         batch.match(100, 100)
 
     match_array_elements(db, types_db)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.name == "test[0].hello"
     assert e.get("type") == EntityType.DATA
     assert e.get("size") == 8
 
-    e = db.get_by_orig(104)
+    e = db.get(ImageId.ORIG, 104)
     assert e is not None
     assert e.name == "test[1].hello"
     assert e.get("type") == EntityType.OFFSET
     assert e.get("size") == 4
 
-    e = db.get_by_recomp(100)
+    e = db.get(ImageId.RECOMP, 100)
     assert e is not None
     assert e.name == "test[0].hello"
     assert e.get("type") == EntityType.DATA
     assert e.get("size") == 8
 
-    e = db.get_by_recomp(104)
+    e = db.get(ImageId.RECOMP, 104)
     assert e is not None
     assert e.name == "test[1].hello"
     assert e.get("type") == EntityType.OFFSET
     assert e.get("size") == 4
 
     # Should NOT create entities for the union offsets
-    assert not any(db.get_by_orig(addr) for addr in (101, 102, 103, 105, 106, 107))
-    assert not any(db.get_by_recomp(addr) for addr in (101, 102, 103, 105, 106, 107))
+    assert not any(
+        db.get(ImageId.ORIG, addr) for addr in (101, 102, 103, 105, 106, 107)
+    )
+    assert not any(
+        db.get(ImageId.RECOMP, addr) for addr in (101, 102, 103, 105, 106, 107)
+    )

--- a/tests/test_match_msvc.py
+++ b/tests/test_match_msvc.py
@@ -33,13 +33,13 @@ def fixture_report_mock() -> ReccmpReportProtocol:
 def test_match_symbols(db):
     """Should combine entities with the same symbol"""
     with db.batch() as batch:
-        batch.set_orig(123, symbol="hello")
-        batch.set_recomp(555, symbol="hello")
+        batch.set(ImageId.ORIG, 123, symbol="hello")
+        batch.set(ImageId.RECOMP, 555, symbol="hello")
 
     match_symbols(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
     # Should combine entities
     assert db.count() == 1
@@ -48,20 +48,20 @@ def test_match_symbols(db):
 def test_match_symbols_no_match(db):
     """Should not affect entities with no symbol or no matching symbol."""
     with db.batch() as batch:
-        batch.set_orig(123)
-        batch.set_recomp(555, symbol="hello")
+        batch.set(ImageId.ORIG, 123)
+        batch.set(ImageId.RECOMP, 555, symbol="hello")
 
     match_symbols(db)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
     assert db.count() == 2
 
 
 def test_match_symbols_no_match_report(db, report):
     """Should report if we cannot match a symbol on the orig side."""
     with db.batch() as batch:
-        batch.set_orig(123, symbol="test")
+        batch.set(ImageId.ORIG, 123, symbol="test")
 
     match_symbols(db, report)
 
@@ -72,28 +72,28 @@ def test_match_symbols_stable_match_order(db):
     """Match in ascending address order on both sides for duplicate symbols."""
     with db.batch() as batch:
         # Descending order
-        batch.set_orig(200, symbol="test")
-        batch.set_orig(100, symbol="test")
-        batch.set_recomp(555, symbol="test")
-        batch.set_recomp(333, symbol="test")
+        batch.set(ImageId.ORIG, 200, symbol="test")
+        batch.set(ImageId.ORIG, 100, symbol="test")
+        batch.set(ImageId.RECOMP, 555, symbol="test")
+        batch.set(ImageId.RECOMP, 333, symbol="test")
 
     match_symbols(db)
 
-    assert db.get_by_orig(100).recomp_addr == 333
-    assert db.get_by_orig(200).recomp_addr == 555
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 333
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 555
 
 
 def test_match_symbols_recomp_not_unique(db, report):
     """Alert when symbol match is non-unique on the recomp side."""
     with db.batch() as batch:
-        batch.set_orig(123, symbol="hello")
-        batch.set_recomp(555, symbol="hello")
-        batch.set_recomp(222, symbol="hello")
+        batch.set(ImageId.ORIG, 123, symbol="hello")
+        batch.set(ImageId.RECOMP, 555, symbol="hello")
+        batch.set(ImageId.RECOMP, 222, symbol="hello")
 
     match_symbols(db, report)
 
     # Should match first occurrence.
-    assert db.get_by_orig(123).recomp_addr == 222
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 222
 
     # Report non-unique match for orig_addr 123
     report.assert_called_with(ReccmpEvent.NON_UNIQUE_SYMBOL, 123, msg=ANY)
@@ -104,26 +104,26 @@ def test_match_symbols_truncate_255(db):
     Match entities where the symbols are equal up to the 255th character."""
     long_name = "x" * 255
     with db.batch() as batch:
-        batch.set_orig(123, symbol=long_name + "y")
-        batch.set_recomp(555, symbol=long_name + "z")
+        batch.set(ImageId.ORIG, 123, symbol=long_name + "y")
+        batch.set(ImageId.RECOMP, 555, symbol=long_name + "z")
 
     match_symbols(db, truncate=True)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
 
 def test_match_symbols_no_truncate(db):
     """Should recognize these as distinct symbols if truncate=False"""
     long_name = "x" * 255
     with db.batch() as batch:
-        batch.set_orig(123, symbol=long_name + "y")
-        batch.set_recomp(555, symbol=long_name + "z")
+        batch.set(ImageId.ORIG, 123, symbol=long_name + "y")
+        batch.set(ImageId.RECOMP, 555, symbol=long_name + "z")
 
     match_symbols(db, truncate=False)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
 
 
 #### match_functions ####
@@ -132,13 +132,13 @@ def test_match_symbols_no_truncate(db):
 def test_match_functions(db):
     """Simple match by name and type"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(555, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 555, name="hello", type=EntityType.FUNCTION)
 
     match_functions(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
     # Should combine entities
     assert db.count() == 1
@@ -147,20 +147,20 @@ def test_match_functions(db):
 def test_match_functions_no_match(db):
     """Skip entities with no match"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(555, name="test", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 555, name="test", type=EntityType.FUNCTION)
 
     match_functions(db)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
     assert db.count() == 2
 
 
 def test_match_functions_no_match_report(db, report):
     """Should report if we cannot match a name on the orig side."""
     with db.batch() as batch:
-        batch.set_orig(123, name="test", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 123, name="test", type=EntityType.FUNCTION)
 
     match_functions(db, report)
 
@@ -172,27 +172,27 @@ def test_match_function_stable_order(db):
     i.e. insertion order does not matter"""
     with db.batch() as batch:
         # Descending order
-        batch.set_orig(101, name="hello", type=EntityType.FUNCTION)
-        batch.set_orig(100, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(501, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(500, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 101, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 501, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 500, name="hello", type=EntityType.FUNCTION)
 
     match_functions(db)
 
-    assert db.get_by_orig(100).recomp_addr == 500
-    assert db.get_by_orig(101).recomp_addr == 501
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 500
+    assert db.get(ImageId.ORIG, 101).recomp_addr == 501
 
 
 def test_match_functions_type_null(db):
     """Will allow a function match if the recomp side has type=null"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(555, name="hello")
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 555, name="hello")
 
     match_functions(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
     assert db.count() == 1
 
 
@@ -201,10 +201,10 @@ def test_match_functions_ambiguous(db, report):
     If there is only one option left, but previous matches were ambiguous, report it anyway.
     """
     with db.batch() as batch:
-        batch.set_orig(100, name="hello", type=EntityType.FUNCTION)
-        batch.set_orig(101, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(500, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(501, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 101, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 500, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 501, name="hello", type=EntityType.FUNCTION)
 
     match_functions(db, report)
 
@@ -221,9 +221,9 @@ def test_match_functions_ignore_already_matched(db, report):
     (i.e. if previous entities were matched by line number)
     do not report an ambiguous match."""
     with db.batch() as batch:
-        batch.set_orig(101, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(500, name="hello", type=EntityType.FUNCTION)
-        batch.set_recomp(501, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 101, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 500, name="hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 501, name="hello", type=EntityType.FUNCTION)
         # Match these addrs before calling match_functions()
         batch.match(100, 500)
 
@@ -236,7 +236,7 @@ def test_match_functions_ignore_already_matched(db, report):
     report.assert_not_called()
 
     # Should combine the two unmatched entities
-    assert db.get_by_recomp(501).orig_addr == 101
+    assert db.get(ImageId.RECOMP, 501).orig_addr == 101
     assert db.count() == 2
 
 
@@ -245,26 +245,26 @@ def test_match_function_names_truncate_255(db):
     Match function entities where the names are are equal up to the 255th character."""
     long_name = "x" * 255
     with db.batch() as batch:
-        batch.set_orig(123, name=long_name + "y", type=EntityType.FUNCTION)
-        batch.set_recomp(555, name=long_name + "z", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 123, name=long_name + "y", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 555, name=long_name + "z", type=EntityType.FUNCTION)
 
     match_functions(db, truncate=True)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
 
 def test_match_function_names_no_truncate(db):
     """Should recognize these as distinct names if truncate=False"""
     long_name = "x" * 255
     with db.batch() as batch:
-        batch.set_orig(123, name=long_name + "y", type=EntityType.FUNCTION)
-        batch.set_recomp(555, name=long_name + "z", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 123, name=long_name + "y", type=EntityType.FUNCTION)
+        batch.set(ImageId.RECOMP, 555, name=long_name + "z", type=EntityType.FUNCTION)
 
     match_functions(db, truncate=False)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
 
 
 #### match_vtables ####
@@ -274,53 +274,53 @@ def test_match_vtables(db):
     """Matching with the specific requirements on attributes for orig and recomp entities"""
     with db.batch() as batch:
         # Orig has class name and type
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
         # Recomp has full vtable name and type
-        batch.set_recomp(200, name="Pizza::`vftable'", type=EntityType.VTABLE)
+        batch.set(ImageId.RECOMP, 200, name="Pizza::`vftable'", type=EntityType.VTABLE)
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
     assert db.count() == 1
 
 
 def test_match_vtables_no_match_recomp_name(db):
     """Recomp entity name must be in a specific format"""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
-        batch.set_recomp(200, name="Pizza", type=EntityType.VTABLE)
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(ImageId.RECOMP, 200, name="Pizza", type=EntityType.VTABLE)
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
 def test_match_vtables_no_match_recomp_type(db):
     """Recomp entity must have type=EntityType.VTABLE"""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
-        batch.set_recomp(200, name="Pizza::`vftable'")
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(ImageId.RECOMP, 200, name="Pizza::`vftable'")
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
 def test_match_vtables_no_match_orig_type(db):
     """Orig entity must have type=EntityType.VTABLE"""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza")
-        batch.set_recomp(200, name="Pizza::`vftable'", type=EntityType.VTABLE)
+        batch.set(ImageId.ORIG, 100, name="Pizza")
+        batch.set(ImageId.RECOMP, 200, name="Pizza::`vftable'", type=EntityType.VTABLE)
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
 def test_match_vtables_no_match_report(db, report):
     """Report a failure to match a vtable from the orig side."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
 
     match_vtables(db, report)
 
@@ -330,66 +330,84 @@ def test_match_vtables_no_match_report(db, report):
 def test_match_vtables_base_class(db):
     """Match a vtable with a base class"""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE, base_class="Lunch")
-        batch.set_recomp(
-            200, name="Pizza::`vftable'{for `Lunch'}", type=EntityType.VTABLE
+        batch.set(
+            ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE, base_class="Lunch"
+        )
+        batch.set(
+            ImageId.RECOMP,
+            200,
+            name="Pizza::`vftable'{for `Lunch'}",
+            type=EntityType.VTABLE,
         )
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
 
 
 def test_match_vtables_base_class_orig_none(db):
     """Do not match a multiple-inheritance vtable if the base class is not specified on the orig entity."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
-        batch.set_recomp(
-            200, name="Pizza::`vftable'{for `Lunch'}", type=EntityType.VTABLE
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(
+            ImageId.RECOMP,
+            200,
+            name="Pizza::`vftable'{for `Lunch'}",
+            type=EntityType.VTABLE,
         )
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
 def test_match_vtables_base_class_same_as_derived(db):
     """Matching a vtable with the same base class and derived class.
     The base_class attribute is set on the orig entity."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE, base_class="Pizza")
-        batch.set_recomp(
-            200, name="Pizza::`vftable'{for `Pizza'}", type=EntityType.VTABLE
+        batch.set(
+            ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE, base_class="Pizza"
+        )
+        batch.set(
+            ImageId.RECOMP,
+            200,
+            name="Pizza::`vftable'{for `Pizza'}",
+            type=EntityType.VTABLE,
         )
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
 
 
 def test_match_vtables_base_class_same_as_derived_orig_none(db):
     """If orig does not have the base_class attribute set, we can still match if
     the recomp vtable has the same base and derived class."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE)
-        batch.set_recomp(
-            200, name="Pizza::`vftable'{for `Pizza'}", type=EntityType.VTABLE
+        batch.set(ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE)
+        batch.set(
+            ImageId.RECOMP,
+            200,
+            name="Pizza::`vftable'{for `Pizza'}",
+            type=EntityType.VTABLE,
         )
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr == 200
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
 
 
 def test_match_vtables_incompatible_base_class(db):
     """If the orig entity has a base_class, do not match with a recomp vtable that does not use multiple-inheritance."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Pizza", type=EntityType.VTABLE, base_class="Lunch")
-        batch.set_recomp(200, name="Pizza::`vftable'", type=EntityType.VTABLE)
+        batch.set(
+            ImageId.ORIG, 100, name="Pizza", type=EntityType.VTABLE, base_class="Lunch"
+        )
+        batch.set(ImageId.RECOMP, 200, name="Pizza::`vftable'", type=EntityType.VTABLE)
 
     match_vtables(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
 #### match_static_variables ####
@@ -399,11 +417,16 @@ def test_match_static_var(db):
     """Match a static variable with all requirements satisfied."""
     with db.batch() as batch:
         # Orig entity function with symbol
-        batch.set_orig(200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION)
+        batch.set(
+            ImageId.ORIG, 200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION
+        )
         # Static variable with symbol
-        batch.set_recomp(500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA")
+        batch.set(
+            ImageId.RECOMP, 500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
+        )
         # Orig entity with variable name and link to orig function addr
-        batch.set_orig(
+        batch.set(
+            ImageId.ORIG,
             600,
             name="g_startupDelay",
             parent_function=200,
@@ -413,16 +436,21 @@ def test_match_static_var(db):
 
     match_static_variables(db)
 
-    assert db.get_by_orig(600).recomp_addr == 500
+    assert db.get(ImageId.ORIG, 600).recomp_addr == 500
 
 
 def test_match_static_var_no_parent_function(db):
     """Cannot match static variable without a reference to its parent function"""
     with db.batch() as batch:
-        batch.set_orig(200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION)
-        batch.set_recomp(500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA")
+        batch.set(
+            ImageId.ORIG, 200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION
+        )
+        batch.set(
+            ImageId.RECOMP, 500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
+        )
         # No parent function
-        batch.set_orig(
+        batch.set(
+            ImageId.ORIG,
             600,
             name="g_startupDelay",
             static_var=True,
@@ -431,16 +459,21 @@ def test_match_static_var_no_parent_function(db):
 
     match_static_variables(db)
 
-    assert db.get_by_orig(600).recomp_addr is None
+    assert db.get(ImageId.ORIG, 600).recomp_addr is None
 
 
 def test_match_static_var_static_false(db):
     """Cannot match static variable unless the static_var attribute is True"""
     with db.batch() as batch:
-        batch.set_orig(200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION)
-        batch.set_recomp(500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA")
+        batch.set(
+            ImageId.ORIG, 200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION
+        )
+        batch.set(
+            ImageId.RECOMP, 500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
+        )
         # static_var is not set
-        batch.set_orig(
+        batch.set(
+            ImageId.ORIG,
             600,
             name="g_startupDelay",
             parent_function=200,
@@ -449,16 +482,19 @@ def test_match_static_var_static_false(db):
 
     match_static_variables(db)
 
-    assert db.get_by_orig(600).recomp_addr is None
+    assert db.get(ImageId.ORIG, 600).recomp_addr is None
 
 
 def test_match_static_var_no_symbol_function(db):
     """Cannot match static variable if the parent function has no symbol"""
     with db.batch() as batch:
         # No symbol on parent function
-        batch.set_orig(200, type=EntityType.FUNCTION)
-        batch.set_recomp(500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA")
-        batch.set_orig(
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION)
+        batch.set(
+            ImageId.RECOMP, 500, symbol="?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
+        )
+        batch.set(
+            ImageId.ORIG,
             600,
             name="g_startupDelay",
             parent_function=200,
@@ -468,16 +504,19 @@ def test_match_static_var_no_symbol_function(db):
 
     match_static_variables(db)
 
-    assert db.get_by_orig(600).recomp_addr is None
+    assert db.get(ImageId.ORIG, 600).recomp_addr is None
 
 
 def test_match_static_var_no_symbol_variable(db):
     """Cannot match static variable without a symbol."""
     with db.batch() as batch:
-        batch.set_orig(200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION)
+        batch.set(
+            ImageId.ORIG, 200, symbol="?Tick@IsleApp@@QAEXH@Z", type=EntityType.FUNCTION
+        )
         # No symbol on variable
-        batch.set_recomp(500, name="g_startupDelay")
-        batch.set_orig(
+        batch.set(ImageId.RECOMP, 500, name="g_startupDelay")
+        batch.set(
+            ImageId.ORIG,
             600,
             name="g_startupDelay",
             parent_function=200,
@@ -487,13 +526,13 @@ def test_match_static_var_no_symbol_variable(db):
 
     match_static_variables(db)
 
-    assert db.get_by_orig(600).recomp_addr is None
+    assert db.get(ImageId.ORIG, 600).recomp_addr is None
 
 
 def test_match_static_var_no_match_report(db, report):
     """Report match failure for any orig entities with static_var=True"""
     with db.batch() as batch:
-        batch.set_orig(600, name="test", static_var=True, type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 600, name="test", static_var=True, type=EntityType.DATA)
 
     match_static_variables(db, report)
 
@@ -506,13 +545,13 @@ def test_match_static_var_no_match_report(db, report):
 def test_match_variables(db):
     """Simple match by name and type"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.DATA)
-        batch.set_recomp(555, name="hello", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.DATA)
+        batch.set(ImageId.RECOMP, 555, name="hello", type=EntityType.DATA)
 
     match_variables(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
     # Should combine entities
     assert db.count() == 1
@@ -521,20 +560,20 @@ def test_match_variables(db):
 def test_match_variables_no_match(db):
     """Skip entities with no match"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.DATA)
-        batch.set_recomp(555, name="test", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.DATA)
+        batch.set(ImageId.RECOMP, 555, name="test", type=EntityType.DATA)
 
     match_variables(db)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
     assert db.count() == 2
 
 
 def test_match_variables_no_match_report(db, report):
     """Should report if we cannot match a name on the orig side."""
     with db.batch() as batch:
-        batch.set_orig(123, name="test", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 123, name="test", type=EntityType.DATA)
 
     match_variables(db, report)
 
@@ -544,13 +583,13 @@ def test_match_variables_no_match_report(db, report):
 def test_match_variables_type_null(db):
     """Will allow a variable match if the recomp side has type=null"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.DATA)
-        batch.set_recomp(555, name="hello")
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.DATA)
+        batch.set(ImageId.RECOMP, 555, name="hello")
 
     match_variables(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
     assert db.count() == 1
 
 
@@ -559,13 +598,13 @@ def test_match_variables_type_null(db):
 
 def test_match_strings(db):
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.STRING)
-        batch.set_recomp(555, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 555, name="hello", type=EntityType.STRING)
 
     match_strings(db)
 
-    assert db.get_by_orig(123).recomp_addr == 555
-    assert db.get_by_recomp(555).orig_addr == 123
+    assert db.get(ImageId.ORIG, 123).recomp_addr == 555
+    assert db.get(ImageId.RECOMP, 555).orig_addr == 123
 
     # Should combine entities
     assert db.count() == 1
@@ -574,13 +613,13 @@ def test_match_strings(db):
 def test_match_strings_no_match(db):
     """Skip strings with no match"""
     with db.batch() as batch:
-        batch.set_orig(123, name="hello", type=EntityType.STRING)
-        batch.set_recomp(555, name="test", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 123, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 555, name="test", type=EntityType.STRING)
 
     match_strings(db)
 
-    assert db.get_by_orig(123).recomp_addr is None
-    assert db.get_by_recomp(555).orig_addr is None
+    assert db.get(ImageId.ORIG, 123).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 555).orig_addr is None
     assert db.count() == 2
 
 
@@ -588,15 +627,15 @@ def test_match_strings_type_required(db):
     """Do not match if one side is missing the type.
     This is a concern because we use the name attribute for the string's text."""
     with db.batch() as batch:
-        batch.set_orig(100, name="hello", type=EntityType.STRING)
-        batch.set_orig(200, name="test")
-        batch.set_recomp(500, name="hello")
-        batch.set_recomp(600, name="test", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 100, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 200, name="test")
+        batch.set(ImageId.RECOMP, 500, name="hello")
+        batch.set(ImageId.RECOMP, 600, name="test", type=EntityType.STRING)
 
     match_strings(db)
 
-    assert db.get_by_orig(100).recomp_addr is None
-    assert db.get_by_orig(200).recomp_addr is None
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
+    assert db.get(ImageId.ORIG, 200).recomp_addr is None
 
 
 def test_match_strings_no_match_report(db, report):
@@ -604,7 +643,7 @@ def test_match_strings_no_match_report(db, report):
     However: only alert if the string is 'verified' by user input,
     a symbol in the PDB, or some (future) heuristic."""
     with db.batch() as batch:
-        batch.set_orig(123, name="test", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 123, name="test", type=EntityType.STRING)
 
     match_strings(db, report)
 
@@ -613,7 +652,7 @@ def test_match_strings_no_match_report(db, report):
 
     # Should alert after we mark the string as verified
     with db.batch() as batch:
-        batch.set_orig(123, verified=True)
+        batch.set(ImageId.ORIG, 123, verified=True)
 
     match_strings(db, report)
     report.assert_called_with(ReccmpEvent.NO_MATCH, 123, msg=ANY)
@@ -622,18 +661,18 @@ def test_match_strings_no_match_report(db, report):
 def test_match_strings_duplicates(db, report):
     """Binaries that do not de-dupe string should match duplicates by address order."""
     with db.batch() as batch:
-        batch.set_orig(100, name="hello", type=EntityType.STRING)
-        batch.set_orig(200, name="hello", type=EntityType.STRING)
-        batch.set_orig(300, name="hello", type=EntityType.STRING)
-        batch.set_recomp(500, name="hello", type=EntityType.STRING)
-        batch.set_recomp(600, name="hello", type=EntityType.STRING)
-        batch.set_recomp(700, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 100, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 200, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 300, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 500, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 600, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 700, name="hello", type=EntityType.STRING)
 
     match_strings(db, report)
 
-    assert db.get_by_orig(100).recomp_addr == 500
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_orig(300).recomp_addr == 700
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 500
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.ORIG, 300).recomp_addr == 700
     assert db.count() == 3
 
     # Do not alert for duplicate string matches.
@@ -644,25 +683,25 @@ def test_match_strings_stable_order(db):
     """Duplicates are matched by address order, not db insertion order."""
     with db.batch() as batch:
         # Descending order
-        batch.set_orig(300, name="hello", type=EntityType.STRING)
-        batch.set_orig(200, name="hello", type=EntityType.STRING)
-        batch.set_orig(100, name="hello", type=EntityType.STRING)
-        batch.set_recomp(700, name="hello", type=EntityType.STRING)
-        batch.set_recomp(600, name="hello", type=EntityType.STRING)
-        batch.set_recomp(500, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 300, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 200, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.ORIG, 100, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 700, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 600, name="hello", type=EntityType.STRING)
+        batch.set(ImageId.RECOMP, 500, name="hello", type=EntityType.STRING)
 
     match_strings(db)
 
-    assert db.get_by_orig(100).recomp_addr == 500
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_orig(300).recomp_addr == 700
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 500
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.ORIG, 300).recomp_addr == 700
 
 
 def test_match_ref(db):
     """Match child entities that refer to the same matched parent entity, regardless of type."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         batch.match(100, 500)
 
         batch.set(ImageId.ORIG, 200)
@@ -673,16 +712,16 @@ def test_match_ref(db):
 
     match_ref(db)
 
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_recomp(600).orig_addr == 200
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.RECOMP, 600).orig_addr == 200
 
 
 def test_match_ref_chained(db):
     """Match any child entities that refer to other child entities,
     provided we have a matched parent at the end of the chain."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         batch.match(100, 500)
 
         # First level
@@ -701,18 +740,18 @@ def test_match_ref_chained(db):
 
     match_ref(db)
 
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_recomp(600).orig_addr == 200
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.RECOMP, 600).orig_addr == 200
 
-    assert db.get_by_orig(300).recomp_addr == 700
-    assert db.get_by_recomp(700).orig_addr == 300
+    assert db.get(ImageId.ORIG, 300).recomp_addr == 700
+    assert db.get(ImageId.RECOMP, 700).orig_addr == 300
 
 
 def test_match_ref_parent_not_matched(db):
     """Don't match child entities if the parent is not matched."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         # Don't match parent entity.
 
         batch.set(ImageId.ORIG, 200)
@@ -724,16 +763,16 @@ def test_match_ref_parent_not_matched(db):
     match_ref(db)
 
     # Child entities unchanged.
-    assert db.get_by_orig(200).recomp_addr is None
-    assert db.get_by_recomp(600).orig_addr is None
+    assert db.get(ImageId.ORIG, 200).recomp_addr is None
+    assert db.get(ImageId.RECOMP, 600).orig_addr is None
 
 
 def test_match_ref_expected_order(db):
     """If there is more than one child entity that points to the same matched parent,
     match according to child address order."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         batch.match(100, 500)
 
         # Orig thunks
@@ -748,17 +787,17 @@ def test_match_ref_expected_order(db):
 
     match_ref(db)
 
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_orig(201).recomp_addr == 601
-    assert db.get_by_orig(202).recomp_addr == 602
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.ORIG, 201).recomp_addr == 601
+    assert db.get(ImageId.ORIG, 202).recomp_addr == 602
 
 
 def test_match_ref_include_vtordisp(db):
     """If a displacement value is specified for the child entity (vtordisp)
     use it when matching the parent."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         batch.match(100, 500)
 
         batch.set(ImageId.ORIG, 200)
@@ -774,8 +813,8 @@ def test_match_ref_include_vtordisp(db):
     match_ref(db)
 
     # Match thunks and vtordisp separately.
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_orig(201).recomp_addr == 601
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.ORIG, 201).recomp_addr == 601
 
 
 def test_match_ref_include_vtordisp_order(db):
@@ -783,8 +822,8 @@ def test_match_ref_include_vtordisp_order(db):
     by child address order.
     NOTE: It may not be possible for MSVC to duplicate vtordisps in this way."""
     with db.batch() as batch:
-        batch.set_orig(100)
-        batch.set_recomp(500)
+        batch.set(ImageId.ORIG, 100)
+        batch.set(ImageId.RECOMP, 500)
         batch.match(100, 500)
 
         # Orig thunks
@@ -799,9 +838,9 @@ def test_match_ref_include_vtordisp_order(db):
 
     match_ref(db)
 
-    assert db.get_by_orig(200).recomp_addr == 600
-    assert db.get_by_orig(201).recomp_addr == 601
-    assert db.get_by_orig(202).recomp_addr == 602
+    assert db.get(ImageId.ORIG, 200).recomp_addr == 600
+    assert db.get(ImageId.ORIG, 201).recomp_addr == 601
+    assert db.get(ImageId.ORIG, 202).recomp_addr == 602
 
 
 def test_match_ref_maximum_depth(db, report):
@@ -843,10 +882,10 @@ def test_match_imports(db: EntityDb):
 
     match_imports(db)
 
-    e = db.get_by_orig(100)
+    e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.recomp_addr == 100
 
-    e = db.get_by_orig(200)
+    e = db.get(ImageId.ORIG, 200)
     assert e is not None
     assert e.recomp_addr == 200

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -1,5 +1,5 @@
 import pytest
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 from reccmp.compare.db import EntityDb
 from reccmp.compare.asm.replacement import (
     create_name_lookup,
@@ -34,9 +34,9 @@ def test_name_replacement(db):
     """Should return a name for an entity that has one.
     Return None if there are no name attributes set or the entity does not exist."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test")
-        batch.set_orig(200, computed_name="Hello")
-        batch.set_orig(300)  # No name
+        batch.set(ImageId.ORIG, 100, name="Test")
+        batch.set(ImageId.ORIG, 200, computed_name="Hello")
+        batch.set(ImageId.ORIG, 300)  # No name
 
     lookup = create_lookup(db)
     entity_100 = lookup(100)
@@ -57,7 +57,7 @@ def test_name_hierarchy(db):
     """Use the "best" entity name. Currently there are only two.
     'computed_name' is preferred over just 'name'."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Test", computed_name="Hello")
+        batch.set(ImageId.ORIG, 100, name="Test", computed_name="Hello")
 
     lookup = create_lookup(db)
     entity = lookup(100)
@@ -75,7 +75,7 @@ def test_offset_name(db: EntityDb, entity_type: EntityType):
     is inside the address range of the entity. This is determined by the size attribute.
     """
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=entity_type, size=10)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=entity_type, size=10)
 
     lookup = create_lookup(db)
 
@@ -89,8 +89,8 @@ def test_offset_name(db: EntityDb, entity_type: EntityType):
 def test_offset_name_non_variables(db):
     """Do not return an offset name for non-variable entities. (e.g. functions)."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION, size=10)
-        batch.set_orig(200, name="Hello", size=10)  # No type
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION, size=10)
+        batch.set(ImageId.ORIG, 200, name="Hello", size=10)  # No type
 
     lookup = create_lookup(db)
 
@@ -105,7 +105,7 @@ def test_offset_name_no_size(db):
     """An enity with no size attribute is considered to have size=0.
     Meaning: match only against the address value."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA)
 
     lookup = create_lookup(db)
 
@@ -117,7 +117,7 @@ def test_exact_restriction(db):
     """If exact=True, return a name only if the entity's address matches the search address.
     Otherwise we might return a name if the entity contains the search address."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.DATA, size=10)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA, size=10)
 
     lookup = create_lookup(db)
 
@@ -132,7 +132,7 @@ def test_indirect_function(db):
     """An instruction like `call dword ptr [0x1234]` means that we call the function
     whose address is at address 0x1234. This is an indirect lookup."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION)
 
     # Mock lookup so we will read 100 from address 200.
     lookup = create_lookup(db, {200: 100})
@@ -150,8 +150,8 @@ def test_indirect_function_variable(db):
     """If the indirect call instruction has the address of a variable in our database,
     prefer the variable name rather than reading the pointer."""
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.FUNCTION)
-        batch.set_orig(200, name="Test", type=EntityType.DATA)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, name="Test", type=EntityType.DATA)
 
     # Mock lookup so we will read 100 from address 200.
     lookup = create_lookup(db, {200: 100})
@@ -168,7 +168,7 @@ def test_indirect_import(db):
     attribute used in the result. This will probably contain the DLL and function name.
     """
     with db.batch() as batch:
-        batch.set_orig(100, name="Hello", type=EntityType.IMPORT)
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.IMPORT)
 
     # No mock needed here because we will not need to read any data.
     lookup = create_lookup(db)
@@ -189,7 +189,7 @@ def test_indirect_import(db):
 def test_import_without_name(db):
     """If the import entity doesn't have a name, the lookup should return None."""
     with db.batch() as batch:
-        batch.set_orig(100, type=EntityType.IMPORT)  # No name
+        batch.set(ImageId.ORIG, 100, type=EntityType.IMPORT)  # No name
 
     lookup = create_lookup(db)
 
@@ -202,7 +202,7 @@ def test_indirect_failed_lookup(db):
     """In the general case (i.e. we do not use the base entity to get the name)
     if there is no entity at the pointer location, return None."""
     with db.batch() as batch:
-        batch.set_orig(200, name="Hello", type=EntityType.FUNCTION)
+        batch.set(ImageId.ORIG, 200, name="Hello", type=EntityType.FUNCTION)
 
     # Mock lookup so we will read 100 from address 200.
     lookup = create_lookup(db, {200: 100})

--- a/tests/test_variable_comparator.py
+++ b/tests/test_variable_comparator.py
@@ -7,7 +7,7 @@ from reccmp.cvdump.types import (
     TypeInfo,
 )
 from reccmp.compare.db import EntityDb, ReccmpMatch
-from reccmp.types import EntityType
+from reccmp.types import EntityType, ImageId
 from .mock_types_db import MockTypesDb
 from .raw_image import RawImage
 
@@ -40,12 +40,12 @@ def create_matched_variable(
     """Helper to create a matched entity for the variable.
     Intended to reduce boilerplate code in the tests."""
     with db.batch() as batch:
-        batch.set_recomp(addr, type=EntityType.DATA, name=f"test_{addr:#04x}")
+        batch.set(ImageId.RECOMP, addr, type=EntityType.DATA, name=f"test_{addr:#04x}")
         if data_type is not None:
-            batch.set_recomp(addr, data_type=data_type)
+            batch.set(ImageId.RECOMP, addr, data_type=data_type)
 
         if size is not None:
-            batch.set_recomp(addr, size=size)
+            batch.set(ImageId.RECOMP, addr, size=size)
 
         batch.match(addr, addr)
 
@@ -83,7 +83,7 @@ def test_compare_pointer_match(db: EntityDb, types: CvdumpTypesParser):
     create_matched_variable(db, 0, data_type=CVInfoTypeEnum.T_32PVOID)
     # Entity at address 0x0004 required to match
     with db.batch() as batch:
-        batch.set_recomp(8, name="Hello")
+        batch.set(ImageId.RECOMP, 8, name="Hello")
         batch.match(4, 8)
 
     orig = RawImage.from_memory(b"\x04\x00\x00\x00")
@@ -101,7 +101,7 @@ def test_compare_pointer_diff(db: EntityDb, types: CvdumpTypesParser):
     create_matched_variable(db, 0, data_type=CVInfoTypeEnum.T_32PVOID)
     # Create the entity only on the recomp side.
     with db.batch() as batch:
-        batch.set_recomp(8, name="Hello")
+        batch.set(ImageId.RECOMP, 8, name="Hello")
 
     orig = RawImage.from_memory(b"\x04\x00\x00\x00")
     recomp = RawImage.from_memory(b"\x08\x00\x00\x00")
@@ -388,7 +388,7 @@ def test_compare_pointer_entity_offset(db: EntityDb, types: CvdumpTypesParser):
     in both binaries, this is a match."""
     create_matched_variable(db, 0, data_type=CVInfoTypeEnum.T_32PVOID)
     with db.batch() as batch:
-        batch.set_recomp(6, size=10, type=EntityType.DATA, name="hello")
+        batch.set(ImageId.RECOMP, 6, size=10, type=EntityType.DATA, name="hello")
         batch.match(4, 6)
 
     # Pointers each point to "hello+4"


### PR DESCRIPTION
Part of #300. These functions are almost exclusively used in tests, so I thought it made sense to start here and see what this change actually looks like.