### PR TITLE
Alert to unhandled PDB symbol types only once

### DIFF
--- a/reccmp/cvdump/symbols.py
+++ b/reccmp/cvdump/symbols.py
@@ -123,6 +123,7 @@ class CvdumpSymbolsParser:
         # This is so we do not end the proc early by reading an S_END
         # that indicates the end of the block.
         self.block_level: int = 0
+        self.alerted_types: set[str] = set()
 
     def read_line(self, line: str):
         if len(line) == 0:
@@ -214,4 +215,6 @@ class CvdumpSymbolsParser:
         elif symbol_type in self._unhandled_symbols:
             return
         else:
-            logger.error("Unhandled symbol type: %s", line)
+            if symbol_type not in self.alerted_types:
+                self.alerted_types.add(symbol_type)
+                logger.info("Unhandled symbol type: %s", symbol_type)


### PR DESCRIPTION
Part of #263. I downgraded these to `info` from `error` since there is no problem for the user to solve.

We had displayed the entire line with the unhandled symbol type, but this no longer makes sense if we are alerting only once per type. If we need data from users to review the PDB data, #216 may be worth pursuing.

Before:
```
[ERROR] Unhandled symbol type: (000044) S_COMPILE:
[ERROR] Unhandled symbol type: (0000C4)  S_LABEL32: [0001:00000190], $L73798
[ERROR] Unhandled symbol type: (0000D8)  S_LABEL32: [0001:00000186], $L73797
[ERROR] Unhandled symbol type: (0000EC)  S_LABEL32: [0001:0000017E], $L73799
[ERROR] Unhandled symbol type: (000154)  S_LABEL32: [0001:00000249], $L73820
[ERROR] Unhandled symbol type: (000004) S_OBJNAME: Signature: 00000000, WINMM.dll
[ERROR] Unhandled symbol type: (000040) S_OBJNAME: Signature: 00000000, WINMM.dll
[ERROR] Unhandled symbol type: (000004) S_OBJNAME: Signature: 00000000, KERNEL32.dll
[ERROR] Unhandled symbol type: (000044) S_OBJNAME: Signature: 00000000, KERNEL32.dll
```

After:
```
[INFO] Unhandled symbol type: S_OBJNAME
[INFO] Unhandled symbol type: S_COMPILE
[INFO] Unhandled symbol type: S_LABEL32
```