### PR TITLE
Add option to use custom encoding for strings

### DIFF
--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -225,7 +225,7 @@ def complete_partial_floats(db: EntityDb, image_id: ImageId, binfile: PEImage):
 
 
 def complete_partial_strings(
-    db: EntityDb, image_id: ImageId, binfile: PEImage, encoding: str = "utf-8"
+    db: EntityDb, image_id: ImageId, binfile: PEImage, encoding: str = "latin1"
 ):
     """For each string/widechar entity without any data,
     read the value from the binary and set the entity name.

--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -225,7 +225,7 @@ def complete_partial_floats(db: EntityDb, image_id: ImageId, binfile: PEImage):
 
 
 def complete_partial_strings(
-    db: EntityDb, image_id: ImageId, binfile: PEImage, encoding: str = "latin1"
+    db: EntityDb, image_id: ImageId, binfile: PEImage, encoding: str = "utf-8"
 ):
     """For each string/widechar entity without any data,
     read the value from the binary and set the entity name.

--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -31,13 +31,15 @@ def match_entry(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
         batch.match(orig_bin.entry, recomp_bin.entry)
 
 
-def create_analysis_strings(db: EntityDb, img_id: ImageId, binfile: PEImage):
+def create_analysis_strings(
+    db: EntityDb, img_id: ImageId, binfile: PEImage, encoding: str = "latin1"
+):
     """Search both binaries for Latin1 strings.
     We use the insert_() method so that thse strings will not overwrite
     an existing entity. It's possible that some variables or pointers
     will be mistakenly identified as short strings."""
     with db.batch() as batch:
-        for addr, string in binfile.iter_string("latin1"):
+        for addr, string in binfile.iter_string(encoding):
             # If the address is the site of a relocation, this is a pointer, not a string.
             if addr in binfile.relocations:
                 continue
@@ -222,7 +224,9 @@ def complete_partial_floats(db: EntityDb, image_id: ImageId, binfile: PEImage):
                 )
 
 
-def complete_partial_strings(db: EntityDb, image_id: ImageId, binfile: PEImage):
+def complete_partial_strings(
+    db: EntityDb, image_id: ImageId, binfile: PEImage, encoding: str = "latin1"
+):
     """For each string/widechar entity without any data,
     read the value from the binary and set the entity name.
     If the entity has no size, read until we hit a null-terminator."""
@@ -248,7 +252,7 @@ def complete_partial_strings(db: EntityDb, image_id: ImageId, binfile: PEImage):
                         raw = binfile.read_string(addr)
                         string_size = len(raw) + 1
 
-                    decoded_string = raw.decode("latin1")
+                    decoded_string = raw.decode(encoding)
 
                 batch.set(
                     image_id,

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -76,7 +76,8 @@ class Compare:
     recomp_bin: Image
     report: ReccmpReportProtocol
     target_id: str
-    encoding: str
+    src_encoding: str
+    bin_encoding: str
     types: CvdumpTypesParser
     function_comparator: FunctionComparator
     data_sources: list[TextFile]
@@ -89,7 +90,7 @@ class Compare:
         recomp_bin: Image,
         pdb_file: CvdumpAnalysis,
         target_id: str,
-        encoding: str = "utf-8",
+        encoding: str | None = None,
         code_files: list[TextFile] | None = None,
         data_sources: list[TextFile] | None = None,
     ):
@@ -97,7 +98,8 @@ class Compare:
         self.recomp_bin = recomp_bin
         self.cvdump_analysis = pdb_file
         self.target_id = target_id
-        self.encoding = encoding
+        self.src_encoding = encoding or "utf-8"
+        self.bin_encoding = encoding or "latin1"
 
         if isinstance(code_files, list):
             self.code_files = code_files
@@ -142,7 +144,7 @@ class Compare:
             self.orig_bin,
             self.target_id,
             self._db,
-            self.encoding,
+            self.src_encoding,
             self.report,
         )
 
@@ -165,12 +167,12 @@ class Compare:
             create_imports(self._db, img_id, binfile)
             create_import_thunks(self._db, img_id, binfile)
             create_analysis_floats(self._db, img_id, binfile)
-            create_analysis_strings(self._db, img_id, binfile, self.encoding)
+            create_analysis_strings(self._db, img_id, binfile, self.bin_encoding)
             create_seh_entities(self._db, img_id, binfile)
             create_thunks(self._db, img_id, binfile)
             create_analysis_vtordisps(self._db, img_id, binfile)
             complete_partial_floats(self._db, img_id, binfile)
-            complete_partial_strings(self._db, img_id, binfile, self.encoding)
+            complete_partial_strings(self._db, img_id, binfile, self.bin_encoding)
 
         match_imports(self._db)
         match_exports(self._db, self.orig_bin, self.recomp_bin)
@@ -201,12 +203,16 @@ class Compare:
 
         code_paths = source_code_search(target.source_paths)
         code_files = list(
-            TextFile.from_files(code_paths, allow_error=True, encoding=target.encoding)
+            TextFile.from_files(
+                code_paths, allow_error=True, encoding=target.encoding or "utf-8"
+            )
         )
 
         data_sources = list(
             TextFile.from_files(
-                target.data_sources, allow_error=True, encoding=target.encoding
+                target.data_sources,
+                allow_error=True,
+                encoding=target.encoding or "utf-8",
             )
         )
 

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -76,6 +76,7 @@ class Compare:
     recomp_bin: Image
     report: ReccmpReportProtocol
     target_id: str
+    encoding: str
     types: CvdumpTypesParser
     function_comparator: FunctionComparator
     data_sources: list[TextFile]
@@ -88,6 +89,7 @@ class Compare:
         recomp_bin: Image,
         pdb_file: CvdumpAnalysis,
         target_id: str,
+        encoding: str = "latin1",
         code_files: list[TextFile] | None = None,
         data_sources: list[TextFile] | None = None,
     ):
@@ -95,6 +97,7 @@ class Compare:
         self.recomp_bin = recomp_bin
         self.cvdump_analysis = pdb_file
         self.target_id = target_id
+        self.encoding = encoding
 
         if isinstance(code_files, list):
             self.code_files = code_files
@@ -139,6 +142,7 @@ class Compare:
             self.orig_bin,
             self.target_id,
             self._db,
+            self.encoding,
             self.report,
         )
 
@@ -161,12 +165,12 @@ class Compare:
             create_imports(self._db, img_id, binfile)
             create_import_thunks(self._db, img_id, binfile)
             create_analysis_floats(self._db, img_id, binfile)
-            create_analysis_strings(self._db, img_id, binfile)
+            create_analysis_strings(self._db, img_id, binfile, self.encoding)
             create_seh_entities(self._db, img_id, binfile)
             create_thunks(self._db, img_id, binfile)
             create_analysis_vtordisps(self._db, img_id, binfile)
             complete_partial_floats(self._db, img_id, binfile)
-            complete_partial_strings(self._db, img_id, binfile)
+            complete_partial_strings(self._db, img_id, binfile, self.encoding)
 
         match_imports(self._db)
         match_exports(self._db, self.orig_bin, self.recomp_bin)
@@ -196,15 +200,22 @@ class Compare:
         pdb_file = CvdumpAnalysis(cvdump)
 
         code_paths = source_code_search(target.source_paths)
-        code_files = list(TextFile.from_files(code_paths, allow_error=True))
+        code_files = list(
+            TextFile.from_files(code_paths, allow_error=True, encoding=target.encoding)
+        )
 
-        data_sources = list(TextFile.from_files(target.data_sources, allow_error=True))
+        data_sources = list(
+            TextFile.from_files(
+                target.data_sources, allow_error=True, encoding=target.encoding
+            )
+        )
 
         compare = cls(
             origfile,
             recompfile,
             pdb_file,
             target_id=target.target_id,
+            encoding=target.encoding,
             data_sources=data_sources,
             code_files=code_files,
         )

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -144,7 +144,7 @@ class Compare:
             self.orig_bin,
             self.target_id,
             self._db,
-            self.src_encoding,
+            self.bin_encoding,
             self.report,
         )
 

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -89,7 +89,7 @@ class Compare:
         recomp_bin: Image,
         pdb_file: CvdumpAnalysis,
         target_id: str,
-        encoding: str = "latin1",
+        encoding: str = "utf-8",
         code_files: list[TextFile] | None = None,
         data_sources: list[TextFile] | None = None,
     ):

--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -147,6 +147,7 @@ def load_markers(
     orig_bin: PEImage,
     target_id: str,
     db: EntityDb,
+    encoding: str = "latin1",
     report: ReccmpReportProtocol = reccmp_report_nop,
 ):
     lines_db.add_local_paths((f.path for f in code_files))
@@ -236,9 +237,9 @@ def load_markers(
                     raw = orig_bin.read(string.offset, string_size)
                     orig = raw.decode("utf-16-le")
                 else:
-                    string_size = len(string.name) + 1
+                    string_size = len(string.name.encode(encoding)) + 1
                     raw = orig_bin.read(string.offset, string_size)
-                    orig = raw.decode("latin1")
+                    orig = raw.decode(encoding)
 
                 string_correct = orig[-1] == "\0" and string.name == orig[:-1]
 

--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -147,7 +147,7 @@ def load_markers(
     orig_bin: PEImage,
     target_id: str,
     db: EntityDb,
-    encoding: str = "utf-8",
+    encoding: str = "latin1",
     report: ReccmpReportProtocol = reccmp_report_nop,
 ):
     lines_db.add_local_paths((f.path for f in code_files))

--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -140,14 +140,14 @@ def load_cvdump_lines(
     lines_db.mark_function_starts(tuple(seen_addrs))
 
 
-# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-positional-arguments, too-many-arguments
 def load_markers(
     code_files: Sequence[TextFile],
     lines_db: LinesDb,
     orig_bin: PEImage,
     target_id: str,
     db: EntityDb,
-    encoding: str = "latin1",
+    encoding: str = "utf-8",
     report: ReccmpReportProtocol = reccmp_report_nop,
 ):
     lines_db.add_local_paths((f.path for f in code_files))

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -82,6 +82,7 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("data-sources", "data_sources"),
         default_factory=list,
     )
+    encoding: str = Field(default="latin1")
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
     report: YmlReportConfig = Field(default_factory=YmlReportConfig.default)
 

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -82,7 +82,7 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("data-sources", "data_sources"),
         default_factory=list,
     )
-    encoding: str = Field(default="latin1")
+    encoding: str = Field(default="utf-8")
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
     report: YmlReportConfig = Field(default_factory=YmlReportConfig.default)
 

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -82,7 +82,7 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("data-sources", "data_sources"),
         default_factory=list,
     )
-    encoding: str = Field(default="utf-8")
+    encoding: str | None = Field(default=None)
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
     report: YmlReportConfig = Field(default_factory=YmlReportConfig.default)
 

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -147,7 +147,7 @@ class RecCmpPartialTarget:
     sha256: str
 
     # Encoding of the source code files for this target.
-    encoding: str = "latin1"
+    encoding: str = "utf-8"
 
     # Relative (to project root) directory of source code files for this target.
     source_paths: tuple[Path, ...] = tuple()
@@ -439,7 +439,7 @@ class RecCmpPathsAction(argparse.Action):
             original_path=original,
             recompiled_path=recompiled,
             recompiled_pdb=pdb,
-            encoding="latin1",
+            encoding="utf-8",
             source_paths=(source_paths,),
             ghidra_config=GhidraConfig(),
             report_config=ReportConfig(),

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -147,7 +147,7 @@ class RecCmpPartialTarget:
     sha256: str
 
     # Encoding of the source code files for this target.
-    encoding: str = "utf-8"
+    encoding: str | None = None
 
     # Relative (to project root) directory of source code files for this target.
     source_paths: tuple[Path, ...] = tuple()
@@ -186,7 +186,7 @@ class RecCmpTarget:
     sha256: str
 
     # Encoding of the source code files for this target.
-    encoding: str
+    encoding: str | None
 
     # Relative (to project root) directory of source code files for this target.
     source_paths: tuple[Path, ...]

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -146,6 +146,9 @@ class RecCmpPartialTarget:
     # SHA-256 checksum of the original binary.
     sha256: str
 
+    # Encoding of the source code files for this target.
+    encoding: str = "latin1"
+
     # Relative (to project root) directory of source code files for this target.
     source_paths: tuple[Path, ...] = tuple()
 
@@ -181,6 +184,9 @@ class RecCmpTarget:
 
     # SHA-256 checksum of the original binary.
     sha256: str
+
+    # Encoding of the source code files for this target.
+    encoding: str
 
     # Relative (to project root) directory of source code files for this target.
     source_paths: tuple[Path, ...]
@@ -267,6 +273,7 @@ class RecCmpProject:
             original_path=target.original_path,
             recompiled_path=target.recompiled_path,
             recompiled_pdb=target.recompiled_pdb,
+            encoding=target.encoding,
             source_paths=target.source_paths,
             ghidra_config=ghidra,
             data_sources=data_sources,
@@ -378,6 +385,7 @@ class RecCmpProject:
                 target_id=target_id,
                 filename=target.filename,
                 sha256=target.hash.sha256,
+                encoding=target.encoding,
                 source_paths=source_paths,
                 ghidra_config=ghidra,
                 data_sources=data_sources,
@@ -431,6 +439,7 @@ class RecCmpPathsAction(argparse.Action):
             original_path=original,
             recompiled_path=recompiled,
             recompiled_pdb=pdb,
+            encoding="latin1",
             source_paths=(source_paths,),
             ghidra_config=GhidraConfig(),
             report_config=ReportConfig(),

--- a/reccmp/tools/decomplint.py
+++ b/reccmp/tools/decomplint.py
@@ -74,6 +74,12 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help="Fail if syntax warnings are found.",
     )
+    parser.add_argument(
+        "--encoding",
+        default="latin1",
+        type=str,
+        help="The encoding of the checked files.",
+    )
     argparse_add_logging_args(parser)
 
     args = parser.parse_args()
@@ -109,6 +115,7 @@ def process_files(
 def main():
     args = parse_args()
     search_paths: list[Path] = []
+    codefiles: list[TextFile] = []
 
     if not args.paths:
         # No path specified. Try to find the project file.
@@ -120,18 +127,24 @@ def main():
         # Read each target from the reccmp-project file
         # then get all filenames from each code directory.
         for target in project.targets.values():
-            search_paths.extend(target.source_paths)
+            reduced_file_list = source_code_search(target.source_paths)
+            codefiles.extend(
+                TextFile.from_files(
+                    reduced_file_list, allow_error=True, encoding=target.encoding
+                )
+            )
     else:
         for path in args.paths:
             if path.is_dir() or path.is_file():
                 search_paths.append(path)
             else:
                 logger.error("Invalid path: %s", path)
-
-    # Use set() so we check each file only once.
-    reduced_file_list = source_code_search(search_paths)
-
-    codefiles = list(TextFile.from_files(reduced_file_list, allow_error=True))
+        reduced_file_list = source_code_search(search_paths)
+        codefiles = list(
+            TextFile.from_files(
+                reduced_file_list, allow_error=True, encoding=args.encoding
+            )
+        )
 
     warning_count, error_count = process_files(codefiles, module=args.module)
 

--- a/reccmp/tools/decomplint.py
+++ b/reccmp/tools/decomplint.py
@@ -76,7 +76,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--encoding",
-        default="latin1",
+        default="utf-8",
         type=str,
         help="The encoding of the checked files.",
     )

--- a/reccmp/tools/decomplint.py
+++ b/reccmp/tools/decomplint.py
@@ -130,7 +130,9 @@ def main():
             reduced_file_list = source_code_search(target.source_paths)
             codefiles.extend(
                 TextFile.from_files(
-                    reduced_file_list, allow_error=True, encoding=target.encoding
+                    reduced_file_list,
+                    allow_error=True,
+                    encoding=target.encoding or "utf-8",
                 )
             )
     else:

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -272,6 +272,26 @@ def test_complete_partial_strings_custom_encoding(db: EntityDb):
     assert e.name == '"你吃饭了吗"'.encode("unicode_escape").decode()
 
 
+def test_complete_partial_strings_extended_ascii(db: EntityDb):
+    """Should assume extended ASCII for non-widechar strings unless directed otherwise."""
+    text = "8½"
+
+    # UTF-8 and Latin1 only overlap up to 0x7f.
+    assert len(text.encode("utf-8")) != len(text.encode("latin1"))
+
+    binfile = Mock(spec=[])
+    binfile.read_string = Mock(return_value=text.encode("latin1"))
+
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, type=EntityType.STRING)
+
+    complete_partial_strings(db, ImageId.ORIG, binfile)
+
+    e = db.get(ImageId.ORIG, 100)
+    assert e is not None
+    assert e.size == len(text) + 1
+
+
 PARTIAL_STRING_EXCEPTIONS = (
     InvalidVirtualAddressError,
     InvalidVirtualReadError,

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -255,6 +255,23 @@ def test_complete_partial_strings_widechar(db: EntityDb):
     assert e.name == 'L"Hello"'
 
 
+def test_complete_partial_strings_custom_encoding(db: EntityDb):
+    """Should read data for a custom encoded string entity."""
+    binfile = Mock(spec=[])
+    binfile.read_string = Mock(return_value="你吃饭了吗".encode("gb2312"))
+
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, type=EntityType.STRING)
+
+    complete_partial_strings(db, ImageId.ORIG, binfile, "gb2312")
+
+    # Entity size set according to string length in bytes plus null-terminator.
+    e = db.get(ImageId.ORIG, 100)
+    assert e is not None
+    assert e.get("size") == 11
+    assert e.name.encode() == '"你吃饭了吗"'.encode("unicode_escape")
+
+
 PARTIAL_STRING_EXCEPTIONS = (
     InvalidVirtualAddressError,
     InvalidVirtualReadError,

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -269,7 +269,7 @@ def test_complete_partial_strings_custom_encoding(db: EntityDb):
     e = db.get(ImageId.ORIG, 100)
     assert e is not None
     assert e.get("size") == 11
-    assert e.name.encode() == '"你吃饭了吗"'.encode("unicode_escape")
+    assert e.name == '"你吃饭了吗"'.encode("unicode_escape").decode()
 
 
 PARTIAL_STRING_EXCEPTIONS = (

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -2,6 +2,7 @@
 
 from pathlib import PurePath, PureWindowsPath
 from textwrap import dedent
+from unittest.mock import Mock
 import pytest
 from reccmp.types import EntityType, ImageId
 from reccmp.formats import PEImage, TextFile
@@ -160,7 +161,7 @@ def test_load_code_function_nameref_variants(
 
                 // LIBRARY: TEST 0x1008b400
                 // _atol
-                
+
                 // STUB: TEST 0x1008b4b0
                 // _atoi
 
@@ -354,6 +355,36 @@ def test_load_code_widechar(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     assert entity.get("type") == EntityType.STRING
     assert entity.get("size") == 14
     assert entity.get("name") == 'L"(null)"'
+
+
+def test_read_gb2312_string(db: EntityDb, lines_db: LinesDb):
+    """Make sure we read the full length of the string in GB 2312 encoding and create the entity. GH #364"""
+    string_text = "你吃饭了吗"
+    string_bytes = string_text.encode("gb2312") + b"\x00"
+
+    # Can't use RawImage here; it is missing some functions from PEImage.
+    orig_bin = Mock(spec=[])
+    orig_bin.read = lambda _, size: string_bytes[:size]
+    orig_bin.imagebase = 0
+    orig_bin.is_valid_vaddr = Mock(return_value=True)
+
+    files = (
+        TextFile(
+            PurePath("test.cpp"),
+            dedent(f"""\
+                // STRING: TEST 0x1000
+                const char* test = "{string_text}";
+                """),
+        ),
+    )
+
+    load_markers(files, lines_db, orig_bin, "TEST", db, "gb2312")
+
+    entity = db.get(ImageId.ORIG, 0x1000)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert entity.get("size") == len(string_bytes)
+    assert entity.name == f'"{string_text}"'.encode("unicode_escape").decode()
 
 
 def test_load_code_string_with_nulls(db: EntityDb, lines_db: LinesDb, binfile: PEImage):

--- a/tests/test_compare_init.py
+++ b/tests/test_compare_init.py
@@ -31,7 +31,7 @@ def test_nested_paths(source_dir: Path):
         target_id="TEST",
         filename="TEST.exe",
         sha256="",
-        encoding="latin1",
+        encoding="utf-8",
         source_paths=nested_paths,
         original_path=Path("TEST.exe"),
         recompiled_path=Path("build/TEST.exe"),

--- a/tests/test_compare_init.py
+++ b/tests/test_compare_init.py
@@ -31,6 +31,7 @@ def test_nested_paths(source_dir: Path):
         target_id="TEST",
         filename="TEST.exe",
         sha256="",
+        encoding="latin1",
         source_paths=nested_paths,
         original_path=Path("TEST.exe"),
         recompiled_path=Path("build/TEST.exe"),


### PR DESCRIPTION
Fixes #229, probably. Adds a per-target option to specify encoding of source files in the project YAML.