### PR TITLE
project: add "reccmp-project update" for updating the project

### DIFF
--- a/reccmp/project/common.py
+++ b/reccmp/project/common.py
@@ -1,3 +1,17 @@
+import textwrap
+
 RECCMP_PROJECT_CONFIG = "reccmp-project.yml"
 RECCMP_USER_CONFIG = "reccmp-user.yml"
 RECCMP_BUILD_CONFIG = "reccmp-build.yml"
+
+
+def helper_create_project(target_name: str, filename: str, sha256: str) -> str:
+    """Creates YML for a project file with one target using the given parameters."""
+    return textwrap.dedent(f"""\
+        targets:
+          {target_name}:
+            filename: {filename}
+            source-root: sources
+            hash:
+              sha256: {sha256}
+    """)

--- a/reccmp/project/create.py
+++ b/reccmp/project/create.py
@@ -43,7 +43,7 @@ def executable_or_library(path: Path) -> TargetType:
 def get_default_cmakelists_txt(project_name: str, targets: dict[str, Path]) -> str:
     """Generate template CMakeLists.txt file contents to build each target."""
     result = textwrap.dedent(f"""\
-        cmake_minimum_required(VERSION 3.20)
+        cmake_minimum_required(VERSION 3.20...4.3)
         project({project_name})
 
         include("${{CMAKE_CURRENT_SOURCE_DIR}}/cmake/reccmp.cmake")
@@ -246,7 +246,7 @@ def create_project(
                 f.write(f"{RECCMP_BUILD_CONFIG}\n")
 
     if cmake:
-        # Generate tempalte files so you can start building each target with CMake.
+        # Generate template files so you can start building each target with CMake.
         project_cmake_dir = project_directory / "cmake"
         reccmp_cmake_path = project_cmake_dir / "reccmp.cmake"
         project_cmake_dir.mkdir(exist_ok=True)

--- a/reccmp/project/update.py
+++ b/reccmp/project/update.py
@@ -1,0 +1,22 @@
+import logging
+from pathlib import Path
+import shutil
+
+from reccmp.assets import get_asset_file
+
+logger = logging.getLogger(__name__)
+
+
+def update_project(
+    project_directory: Path,
+) -> None:
+    reccmp_cmake_path = project_directory / "cmake/reccmp.cmake"
+
+    if reccmp_cmake_path.is_file():
+        # Copy template CMake script that generates reccmp-build.yml
+        logger.info("Copying %s...", "cmake/reccmp.cmake")
+        shutil.copy(
+            get_asset_file("cmake/reccmp.cmake"),
+            reccmp_cmake_path,
+        )
+    logger.info("Done")

--- a/reccmp/tools/project.py
+++ b/reccmp/tools/project.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import logging
 import enum
@@ -14,6 +14,7 @@ from reccmp.project.detect import (
     find_filename_recursively,
     DetectWhat,
 )
+from reccmp.project.update import update_project
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 class ProjectSubcommand(enum.Enum):
     CREATE = enum.auto()
     DETECT = enum.auto()
+    UPDATE = enum.auto()
 
 
 def main():
@@ -93,6 +95,9 @@ def main():
         help="Detect original or recompiled binaries (default is original)",
     )
 
+    update_parser = subparsers.add_parser("update")
+    update_parser.set_defaults(subcommand=ProjectSubcommand.UPDATE)
+
     argparse_add_logging_args(parser=parser)
 
     args = parser.parse_args()
@@ -130,6 +135,22 @@ def main():
             return 0
         except RecCmpProjectException as e:
             logger.error("Project detection failed: %s", e.args[0])
+
+    elif args.subcommand == ProjectSubcommand.UPDATE:
+        project_path = find_filename_recursively(
+            directory=Path.cwd(), filename=RECCMP_PROJECT_CONFIG
+        )
+        if project_path is None:
+            parser.error(
+                f"Cannot find reccmp project. Run '{parser.prog} create' first."
+            )
+        try:
+            update_project(
+                project_directory=project_path,
+            )
+            return 0
+        except RecCmpProjectException as e:
+            logger.error("Project update failed: %s", e.args[0])
 
     return 1
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,10 +6,14 @@ from reccmp.project.common import (
     RECCMP_BUILD_CONFIG,
     RECCMP_PROJECT_CONFIG,
     RECCMP_USER_CONFIG,
+    helper_create_project,
 )
 from reccmp.project.create import (
     create_project,
     RecCmpProjectAlreadyExistsError,
+)
+from reccmp.project.update import (
+    update_project,
 )
 from reccmp.project.config import (
     ProjectFile,
@@ -398,3 +402,18 @@ def test_materialize_project_target():
     del project.targets["TEST"].source_paths
     with pytest.raises(IncompleteReccmpTargetError):
         project.get("TEST")
+
+
+def test_project_update_cmake_file(tmp_path_factory):
+    """Test `reccmp-project detect --what original --search-path <file>`"""
+    project_text = helper_create_project("LEGO1", "LEGO1.DLL", LEGO1_SHA256)
+    project_root = tmp_path_factory.mktemp("project")
+    (project_root / RECCMP_PROJECT_CONFIG).write_text(project_text)
+    reccmp_cmake_path = project_root / "cmake/reccmp.cmake"
+    reccmp_cmake_path.parent.mkdir()
+    dummy_reccmp_cmake_contents = """message(STATUS "HELLO WORLD")\n"""
+    reccmp_cmake_path.write_text(dummy_reccmp_cmake_contents)
+    assert reccmp_cmake_path.read_text() == dummy_reccmp_cmake_contents
+
+    update_project(project_root)
+    assert reccmp_cmake_path.read_text() != dummy_reccmp_cmake_contents

--- a/tests/test_project_detect.py
+++ b/tests/test_project_detect.py
@@ -1,11 +1,10 @@
 """Tests for the detect_project() function, the main part of the reccmp-project utility."""
 
-import textwrap
-
 from reccmp.project.common import (
     RECCMP_BUILD_CONFIG,
     RECCMP_PROJECT_CONFIG,
     RECCMP_USER_CONFIG,
+    helper_create_project,
 )
 from reccmp.project.config import (
     BuildFile,
@@ -17,18 +16,6 @@ from reccmp.project.detect import (
 )
 from reccmp.formats import PEImage
 from .constants import LEGO1_SHA256
-
-
-def helper_create_project(target_name: str, filename: str, sha256: str) -> str:
-    """Creates YML for a project file with one target using the given parameters."""
-    return textwrap.dedent(f"""\
-    targets:
-      {target_name}:
-        filename: {filename}
-        source-root: sources
-        hash:
-          sha256: {sha256}
-    """)
 
 
 def test_project_original_detection_miss(tmp_path_factory):


### PR DESCRIPTION
By running , reccmp will (try to) update the project files to latest. Currently, only thing it does is copy the latest version of reccmp.cmake.

https://github.com/isledecomp/reccmp/pull/376 is trying to update `cmake/reccmp.cmake`.

Running `reccmp-project update` will copy the latest files.

Thoughts and/or alternative approaches?

Will we ever need to add a migration path whenever need to add something that is backwards incompatible?
Should I rename this command to `reccmp-project migrate` instead?
Yes because it modifies the project.
No because this is not a real migration.

