### PR TITLE
Exclude default values from YML

### DIFF
--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from dataclasses import dataclass
-
+from io import StringIO, TextIOBase
 from pydantic import AliasChoices, BaseModel, Field
 import ruamel.yaml
 from .yml_extensions import PathSequence
@@ -20,9 +20,18 @@ class YmlFileModel(BaseModel):
     def from_str(cls, yaml: str):
         return cls.model_validate(_yaml.load(yaml))
 
+    def _write_buf(self, buf: TextIOBase):
+        data = self.model_dump(mode="json", exclude_defaults=True)
+        _yaml.dump(data=data, stream=buf)
+
     def write_file(self, filename: Path):
         with filename.open("w") as f:
-            _yaml.dump(data=self.model_dump(mode="json"), stream=f)
+            self._write_buf(f)
+
+    def to_str(self) -> str:
+        with StringIO() as buf:
+            self._write_buf(buf)
+            return buf.getvalue()
 
 
 class YmlGhidraConfig(BaseModel):

--- a/tests/test_project_yml.py
+++ b/tests/test_project_yml.py
@@ -17,8 +17,31 @@ def test_project_defaults():
 
     yml = p.to_str()
     assert "[]" not in yml
+    assert "ghidra" not in yml
+    # Check both formats just in case. (#334)
     assert "data-sources" not in yml
     assert "data_sources" not in yml
+
+
+def test_project_defaults_nested():
+    """Should create the parent element if we set any of its properties. (Using Ghidra config as an example)"""
+    p = ProjectFile.from_str("""\
+        targets:
+            TEST:
+                source-root: test
+                hash:
+                    sha256: test
+                filename: test.exe
+                ghidra:
+                    ignore-types: ['test']
+        """)
+
+    yml = p.to_str()
+    assert "ghidra" in yml
+    # Check both formats just in case. (#334)
+    assert "ignore-types" in yml or "ignore_types" in yml
+    assert "name-substitutions" not in yml
+    assert "name_substitutions" not in yml
 
 
 def test_project_without_csv():

--- a/tests/test_project_yml.py
+++ b/tests/test_project_yml.py
@@ -1,7 +1,24 @@
-"""Testing items specific to YML parsing/pydantic validation"""
+"""Testing items specific to YML serialization/deserialization"""
 
 from pathlib import Path
 from reccmp.project.config import ProjectFile
+
+
+def test_project_defaults():
+    """Make sure the project file contains the minimum settings. (No defaults or empty arrays.)"""
+    p = ProjectFile.from_str("""\
+        targets:
+            TEST:
+                source-root: test
+                hash:
+                    sha256: test
+                filename: test.exe
+        """)
+
+    yml = p.to_str()
+    assert "[]" not in yml
+    assert "data-sources" not in yml
+    assert "data_sources" not in yml
 
 
 def test_project_without_csv():


### PR DESCRIPTION
We have many optional items in the `reccmp-project.yml`, mostly lists of items that default to empty lists. The file produced by `reccmp-project create` looks like:
```yaml
targets:
  JMAN:
    filename: JMAN.EXE
    source_root: .
    hash:
      sha256: 243f62328af86447376d1d94a2458bc96e64bc9b0e70c27b1470a4c21a40f2a0
    data_sources: []
    encoding:
    ghidra:
      ignore_types: []
      ignore_functions: []
      name_substitutions: []
      allow_hash_mismatch: false
    report:
      ignore_functions: []
```

If we exclude items that are set to their default value, we get only:
```yaml
targets:
  JMAN:
    filename: JMAN.EXE
    source_root: .
    hash:
      sha256: 243f62328af86447376d1d94a2458bc96e64bc9b0e70c27b1470a4c21a40f2a0
```
One argument against doing this is our (admittedly) [minimal documentation](https://github.com/isledecomp/reccmp/blob/master/docs/project_files.md) for the project schema. Displaying all the possible options could be considered helpful to users.