### PR TITLE
ci: add codespell check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.14'
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       working-directory: ./webui

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,18 +16,22 @@ jobs:
 
     - name: Install python libraries
       shell: bash
+      id: install
       run: |
         pip install -r requirements.txt -r requirements-tests.txt
 
     - name: Run black
+      if: ${{ always() && steps.install.outcome == 'success' }}
       shell: bash
       run: black --check .
 
     - name: Run pylint
+      if: ${{ always() && steps.install.outcome == 'success' }}
       shell: bash
       run: pylint reccmp tests
 
     - name: Run mypy
+      if: ${{ always() && steps.install.outcome == 'success' }}
       shell: bash
       run: mypy ./reccmp ./tests
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -35,6 +35,17 @@ jobs:
       shell: bash
       run: mypy ./reccmp ./tests
 
+    - name: Run codespell
+      if: ${{ always() && steps.install.outcome == 'success' }}
+      shell: bash
+      run: |
+        codespell \
+          --ignore-multiline-regex \
+            '# codespell:ignore-begin.*?codespell:ignore-end *\n' \
+          --ignore-regex remote-checkin-comment \
+          -L SEH \
+          ./reccmp ./tests
+
   js-format:
     name: 'Javascript Format'
     runs-on: ubuntu-latest

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/unittest-ghidra.yml
+++ b/.github/workflows/unittest-ghidra.yml
@@ -14,7 +14,7 @@ jobs:
         GHIDRA_INSTALL_DIR: '/ghidra'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     # We cannot reuse the fetch-deps step from the other unit tests because the cache is not shared if different
     # container images are used, see https://github.com/actions/cache/issues/1361#issuecomment-2611294058

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,9 +21,9 @@ jobs:
           - { name: 'Linux',   os: 'ubuntu-latest' }
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/docs/csv.md
+++ b/docs/csv.md
@@ -96,7 +96,7 @@ If you need to escape the _escape character_, use two backslashes, as in:
 
 ```csv
 address,name
-10004000,te\\st
+10004000,de\\mo
 ```
 
 ### Non-standard syntax

--- a/reccmp/cvdump/types.py
+++ b/reccmp/cvdump/types.py
@@ -234,7 +234,7 @@ class CvdumpTypesParser:
         (
             r"\s+Return type = (?P<return_type>[^,]+), Call type = (?P<call_type>[^\n]+)\n"
             r"\s+Func attr = (?P<func_attr>[^\n]+)\n"
-            r"\s+# Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+)"
+            r"\s+# Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+)"  # codespell:ignore
         )
     )
 
@@ -242,7 +242,7 @@ class CvdumpTypesParser:
         (
             r"\s+Return type = (?P<return_type>[^,]+), Class type = (?P<class_type>[^,]+), This type = (?P<this_type>[^,]+),\s*\n"
             r"\s+Call type = (?P<call_type>[^,]+), Func attr = (?P<func_attr>[^\n,]+)\n"
-            r"\s+Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+), This adjust = (?P<this_adjust>[0-9a-f]+)"
+            r"\s+Parms = (?P<num_params>\d+), Arg list type = (?P<arg_list_type>\w+), This adjust = (?P<this_adjust>[0-9a-f]+)"  # codespell:ignore
         )
     )
 

--- a/reccmp/formats/elf.py
+++ b/reccmp/formats/elf.py
@@ -190,7 +190,7 @@ class ElfMachine(IntEnum):
     EM_CLOUDSHIELD = 192  # CloudShield
     EM_COREA_1ST = 193  # KIPO-KAIST Core-A 1st gen.
     EM_COREA_2ND = 194  # KIPO-KAIST Core-A 2nd gen.
-    EM_ARCV2 = 195  # Synopsys ARCv2 ISA.
+    EM_ARCV2 = 195  # Synopsys ARCv2 ISA.  (codespell:ignore)
     EM_OPEN8 = 196  # Open8 RISC
     EM_RL78 = 197  # Renesas RL78
     EM_VIDEOCORE5 = 198  # Broadcom VideoCore V

--- a/reccmp/ghidra/README.md
+++ b/reccmp/ghidra/README.md
@@ -25,7 +25,7 @@ This assumes that you have already installed `reccmp`, e.g. in a virtual environ
   - Local project: `reccmp-ghidra-import --target <reccmp-target> --local-project-name <ghidra-project-name> --file <file-inside-ghidra-project>`
     - If necessary, also provide `--local-project-dir`, especially if your Ghidra project is not located in the default directory.
   - Shared project: `RECCMP_GHIDRA_USER=user RECCMP_GHIDRA_PASSWORD=password reccmp-ghidra-import --target <reccmp-target> --remote-url ghidra://<host>[:<port>]/<project-name> --file <file-inside-ghidra-project>`
-    - You can optionally provide `--remote-checkin-comment` if you want to customize the checkin comment.
+    - You can optionally provide `--remote-checkin-comment` if you want to customize the check-in comment.
     - If you know what you are doing security wise, you can also provide the username and password via the URL: `--remote-url ghidra://user:password@<host>[:<port>]/<project-name`.
 
 ## Setup for Ghidrathon

--- a/reccmp/ghidra/ghidra_import.py
+++ b/reccmp/ghidra/ghidra_import.py
@@ -221,7 +221,9 @@ def shared_repository_program(args: argparse.Namespace):
                     create_keep_file,
                 )
 
-                dom_file.checkin(checkin_handler, TaskMonitor.DUMMY)
+                dom_file.checkin(  # codespell:ignore checkin
+                    checkin_handler, TaskMonitor.DUMMY
+                )
 
                 logger.debug("DomainFile checked in successfully.")
 

--- a/reccmp/parser/marker.py
+++ b/reccmp/parser/marker.py
@@ -97,7 +97,7 @@ class DecompMarker:
     def is_regular_function(self) -> bool:
         """Regular function, meaning: not an explicit byname lookup. FUNCTION
         markers can be _implicit_ byname.
-        FUNCTION and STUB markers are (currently) the only heterogenous marker types that
+        FUNCTION and STUB markers are (currently) the only heterogeneous marker types that
         can be lumped together, although the reasons for doing so are a little vague."""
         return self._type in (MarkerType.FUNCTION, MarkerType.STUB)
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 pytest==9.0.2
 black==26.3.1
+codespell==2.4.2
 pylint==4.0.5
 mypy==1.20.0
 types-colorama>=0.4.6

--- a/tests/test_compare_ingest_csv.py
+++ b/tests/test_compare_ingest_csv.py
@@ -115,6 +115,7 @@ def test_load_csv_overwrite(db: EntityDb):
 
 def test_load_csv_with_errors(db: EntityDb):
     """Should skip lines with a syntax error and create entities for the rest."""
+    # codespell:ignore-begin
     csv_file = TextFile(
         PurePath("test.csv"),
         dedent("""\
@@ -125,6 +126,7 @@ def test_load_csv_with_errors(db: EntityDb):
             4321|template
             """),
     )
+    # codespell:ignore-end
 
     load_csv(db, csv_file)
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -301,6 +301,7 @@ def test_function_type_side_effects():
 
 def test_continuable():
     """Make sure we can continue parsing after handling a non-fatal error."""
+    # codespell:ignore-begin
     text = dedent("""\
         address|type
         5555|libary
@@ -308,8 +309,9 @@ def test_continuable():
         zzzz|function
         4321|template
         """)
+    # codespell:ignore-end
 
-    # Should throw for "libary"
+    # Should throw for "libary"  (codespell:ignore libary)
     with pytest.raises(ReccmpCsvParserError):
         list(csv_parse(text))
 
@@ -334,6 +336,7 @@ def test_continuable():
 def test_exception_details():
     """Should capture the original line number (before removing blank lines)
     and the value that led to the exception and report both."""
+    # codespell:ignore-begin
     text = dedent("""\
         address|type
 
@@ -343,13 +346,14 @@ def test_exception_details():
         zzzz|function
         4321|template
         """)
+    # codespell:ignore-end
 
     reader = csv_parse(text)
 
-    # 5555|libary
+    # 5555|libary (codespell:ignore libary)
     with pytest.raises(CsvInvalidEntityTypeError) as excinfo:
         next(reader)
-        assert excinfo.value.illegal_value == "libary"
+        assert excinfo.value.illegal_value == "libary"  # codespell:ignore libary
         assert excinfo.value.line_number == 3
 
     # 1234|function
@@ -425,10 +429,10 @@ def test_docs_example_escape_escape():
     """Can escape the escape character if this is needed."""
     text = dedent("""\
         address,name
-        10004000,te\\\\st
+        10004000,de\\\\mo
         """)
     assert list(csv_parse(text)) == [
-        (0x10004000, {"name": "te\\st"}),
+        (0x10004000, {"name": "de\\mo"}),
     ]
 
 

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -18,6 +18,7 @@ from reccmp.cvdump.types import (
     VirtualBasePointer,
 )
 
+# codespell:ignore-begin
 TEST_LINES = """
 0x1018 : Length = 18, Leaf = 0x1201 LF_ARGLIST argument count = 3
 	list[0] = 0x100D
@@ -361,6 +362,7 @@ NESTED,     enum name = JukeBox::JukeBoxScript, UDT(0x00003cc2)
 	Derivation list type 0x0000, VT shape type 0x2d1e
 	Size = 512, class name = LegoRaceCar, UDT(0x000055bb)
 """
+# codespell:ignore-end
 
 
 def simplify_scalars(scalars: Iterable[ScalarType]) -> list[tuple[int, str | None, TK]]:
@@ -790,6 +792,7 @@ def test_arglist_unknown_type(empty_parser: CvdumpTypesParser):
     assert t["args"][5] == TK(0x47C)
 
 
+# codespell:ignore-begin
 FUNC_ATTR_EXAMPLES = """
 0x1216 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
     Return type = 0x1209, Class type = 0x1209, This type = T_NOTYPE(0000),
@@ -806,6 +809,7 @@ FUNC_ATTR_EXAMPLES = """
     Call type = ThisCall, Func attr = ****Warning**** unused field non-zero!
     Parms = 0, Arg list type = 0x1018, This adjust = 0
 """
+# codespell:ignore-end
 
 
 def test_mfunction_func_attr(empty_parser: CvdumpTypesParser):
@@ -834,12 +838,14 @@ def test_union_without_udt(empty_parser: CvdumpTypesParser):
     assert empty_parser.keys[TK(0x3352)]["name"] == "<unnamed-tag>"
 
 
+# codespell:ignore-begin
 MFUNCTION_UNK_RETURN_TYPE = """
 0x11d8 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
     Return type = ???(047C), Class type = 0x1136, This type = T_NOTYPE(0000),
     Call type = C Near, Func attr = none
     Parms = 3, Arg list type = 0x11d7, This adjust = 0
 """
+# codespell:ignore-end
 
 
 def test_mfunction_unk_return_type(empty_parser: CvdumpTypesParser):
@@ -1009,11 +1015,13 @@ def test_enum_with_whitespace_and_comma(
 def test_this_adjust_hex(empty_parser: CvdumpTypesParser):
     """The 'this adjust' attribute is a hex number.
     Make sure we parse it correctly."""
+    # codespell:ignore-begin
     empty_parser.read_all("""\
 0x657a : Length = 26, Leaf = 0x1009 LF_MFUNCTION
     Return type = T_VOID(0003), Class type = 0x15ED, This type = 0x15EE, 
     Call type = ThisCall, Func attr = none
     Parms = 3, Arg list type = 0x6579, This adjust = 24""")
+    # codespell:ignore-end
 
     assert empty_parser.keys[TK(0x657A)]["this_adjust"] == TK(0x24)
 

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -224,12 +224,14 @@ def test_should_skip_regardless_of_register():
         mock.assert_not_called()
 
 
+# codespell:ignore-begin
 def test_no_placeholder_for_jumps():
     """Some JMP instructions point at the start of another function (e.g. destructors
     called in the SEH Unwind section.) These would be candidates for a placeholder
     but doing this would cause the placeholder number to vary with annotation
     coverage. The compromise is to use the name if we have it, but not use a
     placeholder OR bump the placeholder number."""
+    # codespell:ignore-end
     p = ParseAsm()
     _, op_str = p.sanitize(DisasmLiteInst(0x1000, 5, "jmp", "0x2000"))
 


### PR DESCRIPTION
This adds a codespell ci actions.

[Example run where I added a few typos](https://github.com/madebr/reccmp/actions/runs/24613503988/job/71971825337#step:8:17)