### PR TITLE
Just use Python dicts for the entity db

### DIFF
--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -293,7 +293,9 @@ class EntityDb:
                 else:
                     entities[addr] = ReccmpEntity(None, addr, values)
             else:
-                entities[addr]._kvstore.update(values) # pylint: disable=protected-access
+                entities[addr]._kvstore.update(
+                    values
+                )  # pylint: disable=protected-access
 
         self._update_addr_index(image, new_addrs)
 

--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -287,15 +287,14 @@ class EntityDb:
         for addr, values in rows:
             new_addrs.add(addr)
 
+            # pylint: disable=protected-access
             if addr not in entities:
                 if image == ImageId.ORIG:
                     entities[addr] = ReccmpEntity(addr, None, values)
                 else:
                     entities[addr] = ReccmpEntity(None, addr, values)
             else:
-                entities[addr]._kvstore.update(
-                    values
-                )  # pylint: disable=protected-access
+                entities[addr]._kvstore.update(values)
 
         self._update_addr_index(image, new_addrs)
 

--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -2,67 +2,11 @@
 addresses/symbols that we want to compare between the original and recompiled binaries.
 """
 
-import sqlite3
+import bisect
 import logging
-import json
 from functools import cached_property
 from typing import Any, Iterable, Iterator
 from reccmp.types import EntityType, ImageId
-
-_SETUP_SQL = """
-    CREATE TABLE names (
-        img integer not null,
-        addr integer not null,
-        name text,
-        computed_name text,
-        primary key (img, addr)
-    );
-
-    CREATE TABLE entities (
-        orig_addr int unique,
-        recomp_addr int unique,
-        kvstore text default '{}'
-    );
-
-    -- REFS stores the destination of the JMP instruction in each thunk/vtordisp.
-    -- vtordisp functions have 1 or 2 displacement values that modify ECX.
-    -- If both are zero, this is a regular thunk with the jump only.
-    CREATE TABLE refs (
-        img integer not null,
-        addr integer not null,
-        ref integer not null,
-        disp0 integer not null default 0,
-        disp1 integer not null default 0,
-        primary key (img, addr)
-    );
-
-    CREATE VIEW matches (match_id, orig_addr, recomp_addr) AS
-        SELECT rowid, orig_addr, recomp_addr FROM entities
-        WHERE orig_addr IS NOT NULL AND recomp_addr IS NOT NULL;
-
-    CREATE VIEW matched_ids (img, addr) AS
-        SELECT 0, orig_addr FROM matches
-        UNION ALL
-        SELECT 1, recomp_addr FROM matches;
-
-    CREATE VIEW orig_unmatched (orig_addr, kvstore) AS
-        SELECT orig_addr, kvstore FROM entities
-        WHERE orig_addr is not null and recomp_addr is null
-        ORDER by orig_addr;
-
-    CREATE VIEW recomp_unmatched (recomp_addr, kvstore) AS
-        SELECT recomp_addr, kvstore FROM entities
-        WHERE recomp_addr is not null and orig_addr is null
-        ORDER by recomp_addr;
-
-    -- ReccmpEntity
-    CREATE VIEW entity_factory (orig_addr, recomp_addr, kvstore) AS
-        SELECT orig_addr, recomp_addr, kvstore FROM entities;
-
-    -- ReccmpMatch
-    CREATE VIEW matched_entity_factory AS
-        SELECT * FROM entity_factory WHERE orig_addr IS NOT NULL AND recomp_addr IS NOT NULL;
-"""
 
 
 def entity_name_from_string(text: str, wide: bool = False) -> str:
@@ -82,16 +26,22 @@ class ReccmpEntity:
 
     _orig_addr: int | None
     _recomp_addr: int | None
-    _kvstore: str
+    _kvstore: dict[str, Any]
 
     def __init__(
-        self, orig: int | None, recomp: int | None, kvstore: str = "{}"
+        self,
+        orig: int | None,
+        recomp: int | None,
+        kvstore: dict[str, Any] | None = None,
     ) -> None:
         """Requires one or both of the addresses to be defined"""
         assert orig is not None or recomp is not None
         self._orig_addr = orig
         self._recomp_addr = recomp
-        self._kvstore = kvstore
+        if kvstore:
+            self._kvstore = kvstore
+        else:
+            self._kvstore = {}
 
     def addr(self, image_id: ImageId) -> int | None:
         if image_id == ImageId.ORIG:
@@ -104,7 +54,7 @@ class ReccmpEntity:
 
     @cached_property
     def options(self) -> dict[str, Any]:
-        return json.loads(self._kvstore)
+        return self._kvstore
 
     @property
     def orig_addr(self) -> int | None:
@@ -183,7 +133,9 @@ class ReccmpMatch(ReccmpEntity):
     """To simplify type checking, use this object when a "match" is
     required or expected. Meaning: both orig and recomp addresses are set."""
 
-    def __init__(self, orig: int, recomp: int, kvstore: str = "{}") -> None:
+    def __init__(
+        self, orig: int, recomp: int, kvstore: dict[str, Any] | None = None
+    ) -> None:
         assert orig is not None and recomp is not None
         super().__init__(orig, recomp, kvstore)
 
@@ -198,16 +150,6 @@ class ReccmpMatch(ReccmpEntity):
         return self._recomp_addr
 
 
-def entity_factory(_, row: object) -> ReccmpEntity:
-    assert isinstance(row, tuple)
-    return ReccmpEntity(*row)
-
-
-def matched_entity_factory(_, row: object) -> ReccmpMatch:
-    assert isinstance(row, tuple)
-    return ReccmpMatch(*row)
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -219,30 +161,30 @@ class EntityBatch:
     _recomp: dict[int, dict[str, Any]]
     _matches: list[tuple[int, int]]
 
-    # Sets the recomp_addr of an entity with only an orig_addr.
-    # This isn't possible using set_orig() or by matching.
-    _recomp_addr: dict[int, int]
-
-    _refs: list[tuple[ImageId, int, int, int, int]]
-
     def __init__(self, backref: "EntityDb") -> None:
         self.base = backref
         self._orig = {}
         self._recomp = {}
         self._matches = []
-        self._recomp_addr = {}
-        self._refs = []
 
     def reset(self):
         """Clear all pending changes"""
         self._orig.clear()
         self._recomp.clear()
         self._matches.clear()
-        self._recomp_addr.clear()
-        self._refs.clear()
 
-    def set(self, img: ImageId, addr: int, size: int | None = None, **kwargs):
+    def set(
+        self,
+        img: ImageId,
+        addr: int,
+        ref: int | None = None,
+        size: int | None = None,
+        **kwargs,
+    ):
         assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+
+        if ref is not None:
+            kwargs["ref_orig" if img == ImageId.ORIG else "ref_recomp"] = ref
 
         if size is not None:
             kwargs["orig_size" if img == ImageId.ORIG else "recomp_size"] = size
@@ -261,13 +203,13 @@ class EntityBatch:
         ref: int,
         displacement: tuple[int, int] = (0, 0),
     ):
-        self._refs.append((img, addr, ref, *displacement))
+        self.set(img, addr, ref=ref, displacement=displacement)
 
     def match(self, orig: int, recomp: int):
         self._matches.append((orig, recomp))
 
     def set_recomp_addr(self, orig: int, recomp: int):
-        self._recomp_addr[orig] = recomp
+        self.match(orig, recomp)
 
     def _finalized_matches(self) -> Iterator[tuple[int, int]]:
         """Reduce the list of matches so that each orig and recomp addr appears once.
@@ -289,25 +231,14 @@ class EntityBatch:
                 )
 
     def commit(self):
-        # SQL transaction
-        with self.base.sql:
-            if self._orig:
-                self.base.bulk_orig_insert(self._orig.items(), upsert=True)
+        if self._orig:
+            self.base.bulk_orig_insert(self._orig.items())
 
-            if self._recomp:
-                self.base.bulk_recomp_insert(self._recomp.items(), upsert=True)
+        if self._recomp:
+            self.base.bulk_recomp_insert(self._recomp.items())
 
-            if self._refs:
-                self.base.sql.executemany(
-                    "INSERT OR REPLACE INTO refs (img, addr, ref, disp0, disp1) VALUES (?,?,?,?,?)",
-                    self._refs,
-                )
-
-            if self._matches:
-                self.base.bulk_match(self._finalized_matches())
-
-            if self._recomp_addr:
-                self.base.bulk_set_recomp_addr(self._recomp_addr.items())
+        if self._matches:
+            self.base.bulk_match(self._finalized_matches())
 
         self.reset()
 
@@ -324,117 +255,144 @@ class EntityBatch:
 class EntityDb:
     # pylint: disable=too-many-public-methods
     def __init__(self):
-        self._sql = sqlite3.connect(":memory:")
-        self._sql.executescript(_SETUP_SQL)
+        self._x_orig = {}
+        self._y_recomp = {}
+        self._x_matches = {}
+        self._y_matches = {}
 
-    @property
-    def sql(self) -> sqlite3.Connection:
-        return self._sql
+        self._x_all = []
+        self._y_all = []
 
     def batch(self) -> EntityBatch:
         return EntityBatch(self)
 
     def count(self) -> int:
-        (count,) = self._sql.execute("SELECT count(1) from entities").fetchone()
-        return count
+        # TODO: if we care
+        return len(list(self.get_all()))
 
-    def bulk_orig_insert(
-        self, rows: Iterable[tuple[int, dict[str, Any]]], upsert: bool = False
-    ):
-        if upsert:
-            self._sql.executemany(
-                """INSERT INTO entities (orig_addr, kvstore) values (?,?)
-                ON CONFLICT (orig_addr) DO UPDATE
-                SET kvstore = json_patch(kvstore, excluded.kvstore)""",
-                ((addr, json.dumps(values)) for addr, values in rows),
-            )
-        else:
-            self._sql.executemany(
-                "INSERT or ignore INTO entities (orig_addr, kvstore) values (?,?)",
-                ((addr, json.dumps(values)) for addr, values in rows),
-            )
+    def _new_orig(self, addr: int):
+        if addr not in self._x_orig and addr not in self._x_matches:
+            bisect.insort(self._x_all, addr)
 
-    def bulk_recomp_insert(
-        self, rows: Iterable[tuple[int, dict[str, Any]]], upsert: bool = False
-    ):
-        if upsert:
-            self._sql.executemany(
-                """INSERT INTO entities (recomp_addr, kvstore) values (?,?)
-                ON CONFLICT (recomp_addr) DO UPDATE
-                SET kvstore = json_patch(kvstore, excluded.kvstore)""",
-                ((addr, json.dumps(values)) for addr, values in rows),
-            )
-        else:
-            self._sql.executemany(
-                "INSERT or ignore INTO entities (recomp_addr, kvstore) values (?,?)",
-                ((addr, json.dumps(values)) for addr, values in rows),
-            )
+    def _new_recomp(self, addr: int):
+        if addr not in self._y_recomp and addr not in self._y_matches:
+            bisect.insort(self._y_all, addr)
+
+    def bulk_orig_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
+        for addr, values in rows:
+            self._new_orig(addr)
+
+            if addr not in self._x_orig:
+                self._x_orig[addr] = ReccmpEntity(addr, None)
+
+            # pylint:disable=protected-access
+            denoise = {k: v for k, v in values.items() if v is not None}
+            self._x_orig[addr]._kvstore.update(denoise)
+
+    def bulk_recomp_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
+        for addr, values in rows:
+            self._new_recomp(addr)
+
+            if addr not in self._y_recomp:
+                self._y_recomp[addr] = ReccmpEntity(None, addr)
+
+            # pylint:disable=protected-access
+            denoise = {k: v for k, v in values.items() if v is not None}
+            self._y_recomp[addr]._kvstore.update(denoise)
 
     def bulk_match(self, pairs: Iterable[tuple[int, int]]):
         """Expects iterable of `(orig_addr, recomp_addr)`."""
-        # We need to iterate over this multiple times.
-        pairlist = list(pairs)
 
-        with self._sql:
-            # Copy orig information to recomp side. Prefer recomp information except for NULLS.
-            # json_patch(X, Y) copies keys from Y into X and replaces existing values.
-            # From inner-most to outer-most:
-            # - json_patch('{}', entities.kvstore)      Eliminate NULLS on recomp side (so orig will replace)
-            # - json_patch(o.kvstore, ^)                Merge orig and recomp keys. Prefer recomp values.
-            self._sql.executemany(
-                """UPDATE entities
-                SET kvstore = json_patch(o.kvstore, json_patch('{}', entities.kvstore))
-                FROM (SELECT kvstore FROM entities WHERE orig_addr = ? and recomp_addr is null) o
-                WHERE recomp_addr = ? AND orig_addr is null""",
-                pairlist,
-            )
-            # Patch orig address into recomp and delete orig entry.
-            self._sql.executemany(
-                "UPDATE OR REPLACE entities SET orig_addr = ? WHERE recomp_addr = ? AND orig_addr is null",
-                pairlist,
-            )
+        for x, y in pairs:
+            # Cannot replace existing match.
+            if x in self._x_matches or y in self._y_matches:
+                continue
 
-    def bulk_set_recomp_addr(self, pairs: Iterable[tuple[int, int]]):
-        """Expects iterable of `(orig_addr recomp_addr)`. To be used when the orig information are complete
-        up to the recomp address and there exists no entry on the recomp side."""
-        self._sql.executemany(
-            """UPDATE entities
-                SET recomp_addr = ?
-                WHERE orig_addr = ? and recomp_addr is null""",
-            ((recomp_addr, orig_addr) for orig_addr, recomp_addr in pairs),
-        )
+            self._new_orig(x)
+            self._new_recomp(y)
 
-    def get_unmatched_strings(self) -> list[str]:
-        """Return any strings not already identified by `STRING` markers."""
+            self._x_matches[x] = y
+            self._y_matches[y] = x
 
-        cur = self._sql.execute(
-            "SELECT json_extract(kvstore,'$.name') FROM entities WHERE json_extract(kvstore, '$.type') = ? AND orig_addr IS NULL",
-            (EntityType.STRING,),
-        )
+            orig_data = {}
+            if x in self._x_orig:
+                # pylint:disable=protected-access
+                orig_data = self._x_orig[x]._kvstore
 
-        return [string for (string,) in cur.fetchall()]
+            recomp_data = {}
+            if y in self._y_recomp:
+                # pylint:disable=protected-access
+                recomp_data = self._y_recomp[y]._kvstore
+
+            match = ReccmpMatch(x, y, orig_data | recomp_data)
+
+            self._x_orig[x] = match
+            self._y_recomp[y] = match
+
+    def all(self, img: ImageId) -> Iterator[ReccmpEntity]:
+        if img == ImageId.ORIG:
+            for addr in self._x_all:
+                if addr in self._x_orig:
+                    yield self._x_orig[addr]
+
+        elif img == ImageId.RECOMP:
+            for addr in self._y_all:
+                if addr in self._y_recomp:
+                    yield self._y_recomp[addr]
+
+        else:
+            assert False, "Invalid image id"
+
+    def unmatched(self, img: ImageId) -> Iterator[ReccmpEntity]:
+        if img == ImageId.ORIG:
+            for addr in self._x_all:
+                if addr in self._x_orig and addr not in self._x_matches:
+                    yield self._x_orig[addr]
+
+        elif img == ImageId.RECOMP:
+            for addr in self._y_all:
+                if addr in self._y_recomp and addr not in self._y_matches:
+                    yield self._y_recomp[addr]
+
+        else:
+            assert False, "Invalid image id"
 
     def get_all(self) -> Iterator[ReccmpEntity]:
-        cur = self._sql.execute(
-            "SELECT * FROM entity_factory ORDER BY orig_addr NULLS LAST, recomp_addr"
-        )
-        cur.row_factory = entity_factory
-        yield from cur
+        for orig_addr in self._x_all:
+            yield self._x_orig[orig_addr]
+
+        for recomp_addr in self._y_all:
+            if recomp_addr not in self._y_matches:
+                yield self._y_recomp[recomp_addr]
 
     def get_matches(self) -> Iterator[ReccmpMatch]:
-        cur = self._sql.execute(
-            "SELECT * FROM matched_entity_factory ORDER BY orig_addr",
-        )
-        cur.row_factory = matched_entity_factory
-        yield from cur
+        for orig_addr in self._x_all:
+            if orig_addr in self._x_matches:
+                yield self._x_orig[orig_addr]
 
-    def get_one_match(self, addr: int) -> ReccmpMatch | None:
-        cur = self._sql.execute(
-            "SELECT * FROM matched_entity_factory WHERE orig_addr = ?",
-            (addr,),
-        )
-        cur.row_factory = matched_entity_factory
-        return cur.fetchone()
+    def get_one_match(self, orig_addr: int) -> ReccmpMatch | None:
+        if orig_addr not in self._x_orig:
+            return None
+
+        ent = self._x_orig[orig_addr]
+        if ent.recomp_addr is None:
+            return None
+
+        return ent
+
+    def nearest(self, img: ImageId, addr: int) -> int | None:
+        if img == ImageId.ORIG:
+            addrs = self._x_all
+        elif img == ImageId.RECOMP:
+            addrs = self._y_all
+        else:
+            assert False, "Invalid image id"
+
+        i = bisect.bisect_right(addrs, addr)
+        if i == 0:
+            return None
+
+        return addrs[i - 1]
 
     def get(
         self, img: ImageId, addr: int, *, exact: bool = True
@@ -443,84 +401,72 @@ class EntityDb:
         If there is no entry for the address and exact=True (default), return None.
         Otherwise, return the preceding (by address, in this image) entity if it exists.
         The caller should check the entity's size to make sure it covers the address."""
-        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+        if img == ImageId.ORIG:
+            if not exact and addr not in self._x_orig:
+                prev_addr = self.nearest(img, addr)
+                if prev_addr is None:
+                    return None
 
-        column = "orig_addr" if img == ImageId.ORIG else "recomp_addr"
+                addr = prev_addr
 
-        if exact:
-            query = f"SELECT * FROM entity_factory WHERE {column} = ?"
-        else:
-            query = f"SELECT * FROM entity_factory WHERE ? >= {column} ORDER BY {column} desc LIMIT 1"
+            return self._x_orig.get(addr)
 
-        cur = self._sql.execute(query, (addr,))
-        cur.row_factory = entity_factory
-        return cur.fetchone()
+        if img == ImageId.RECOMP:
+            if not exact and addr not in self._y_recomp:
+                prev_addr = self.nearest(img, addr)
+                if prev_addr is None:
+                    return None
+
+                addr = prev_addr
+
+            return self._y_recomp.get(addr)
+
+        assert False, "Invalid image id"
 
     def get_functions(self) -> Iterator[ReccmpMatch]:
         """Return all function-like matched entities. Previously, all functions
         had type=FUNCTION but there are now THUNK and VTORDISP types."""
-        cur = self._sql.execute(
-            """SELECT * FROM matched_entity_factory
-            WHERE json_extract(kvstore, '$.type') IN (?, ?, ?)
-            ORDER BY orig_addr
-            """,
-            (EntityType.FUNCTION, EntityType.THUNK, EntityType.VTORDISP),
-        )
-        cur.row_factory = matched_entity_factory
-        yield from cur
+        for ent in self.get_matches():
+            if ent.get("type") in (
+                EntityType.FUNCTION,
+                EntityType.THUNK,
+                EntityType.VTORDISP,
+            ):
+                yield ent
 
     def get_matches_by_type(self, entity_type: EntityType) -> Iterator[ReccmpMatch]:
-        cur = self._sql.execute(
-            """SELECT * FROM matched_entity_factory
-            WHERE json_extract(kvstore, '$.type') = ?
-            ORDER BY orig_addr
-            """,
-            (entity_type,),
-        )
-        cur.row_factory = matched_entity_factory
-        yield from cur
+        for ent in self.get_matches():
+            if ent.get("type") == entity_type:
+                yield ent
 
     def get_lines_in_recomp_range(
         self, start_recomp_addr: int, end_recomp_addr: int
     ) -> Iterator[ReccmpMatch]:
         """Fetches all matched annotations of the form `// LINE: TARGET 0x1234` in the given recomp address range."""
+        i = bisect.bisect_left(self._y_all, start_recomp_addr)
+        j = bisect.bisect_right(self._y_all, end_recomp_addr)
 
-        cur = self._sql.execute(
-            """SELECT * FROM matched_entity_factory
-            WHERE json_extract(kvstore, '$.type') = ?
-            AND recomp_addr >= ? AND recomp_addr <= ?
-            ORDER BY orig_addr
-            """,
-            (
-                EntityType.LINE,
-                start_recomp_addr,
-                end_recomp_addr,
-            ),
-        )
-        cur.row_factory = matched_entity_factory
-        yield from cur
+        candidates = self._y_all[i:j]
+        orig_addrs = [
+            self._y_matches[addr] for addr in candidates if addr in self._y_matches
+        ]
+
+        for orig_addr in sorted(orig_addrs):
+            match = self._x_orig[orig_addr]
+            if match.get("type") == EntityType.LINE:
+                yield match
 
     def used(self, img: ImageId, addr: int) -> bool:
         if img == ImageId.ORIG:
-            query = "SELECT 1 FROM entities WHERE orig_addr = ?"
+            return addr in self._x_orig or addr in self._x_matches
 
-        elif img == ImageId.RECOMP:
-            query = "SELECT 1 FROM entities WHERE recomp_addr = ?"
+        if img == ImageId.RECOMP:
+            return addr in self._y_recomp or addr in self._y_matches
 
-        else:
-            assert False, "Invalid image id"
-
-        cur = self._sql.execute(query, (addr,))
-        return cur.fetchone() is not None
+        assert False, "Invalid image id"
 
     def is_match(self, orig_addr: int, recomp_addr: int) -> bool:
-        return (
-            self._sql.execute(
-                "SELECT 1 FROM entities WHERE orig_addr = ? AND recomp_addr = ?",
-                (orig_addr, recomp_addr),
-            ).fetchone()
-            is not None
-        )
+        return self._x_matches.get(orig_addr) == recomp_addr
 
     def get_next_orig_addr(self, addr: int) -> int | None:
         """Return the original address (matched or not) that follows
@@ -529,52 +475,16 @@ class EntityDb:
         Skips LINE and LABEL type entities since these these are always contained
         within functions.
         """
-        result = self._sql.execute(
-            """SELECT orig_addr
-            FROM entities
-            WHERE
-              orig_addr > ?
-            AND
-              json_extract(kvstore,'$.type') IS NOT NULL
-            AND
-              json_extract(kvstore,'$.type') NOT IN (?, ?)
-            ORDER BY orig_addr
-            LIMIT 1""",
-            (addr, EntityType.LINE, EntityType.LABEL),
-        ).fetchone()
+        i = bisect.bisect_left(self._x_all, addr)
+        for next_addr in self._x_all[i:]:
+            ent = self._x_orig[next_addr]
 
-        return result[0] if result is not None else None
+            if (
+                next_addr > addr
+                and ent
+                and ent.get("type")
+                and ent.get("type") not in (EntityType.LINE, EntityType.LABEL)
+            ):
+                return next_addr
 
-    def populate_names_table(self):
-        """Copy the name/computed_name of non-thunk functions or imports into the NAMES table.
-        NAMES is keyed by (image, addr), unlike the ENTITIES table."""
-        self._sql.execute(
-            """INSERT INTO names (img, addr, name, computed_name)
-            SELECT img, addr, json_extract(kvstore, '$.name') name, json_extract(kvstore, '$.computed_name') FROM (
-                SELECT 0 img, orig_addr addr, kvstore FROM entities WHERE orig_addr IS NOT NULL
-                UNION ALL
-                SELECT 1 img, recomp_addr addr, kvstore FROM entities WHERE recomp_addr IS NOT NULL
-            )
-            WHERE name IS NOT NULL
-            AND json_extract(kvstore, '$.type') IN (?, ?)
-            """,
-            # These types are chosen because they are the possible sources for the name of a thunk function.
-            (
-                EntityType.FUNCTION,
-                EntityType.IMPORT,
-            ),
-        )
-
-    def propagate_thunk_names(self) -> bool:
-        """Copy name/computed_name from parent to child (referencing) entities.
-        Return value tells whether any entities were updated.
-        Can be repeated to cover chains of thunk/vtordisp entities."""
-        cur = self._sql.execute("""INSERT INTO names (img, addr, name, computed_name)
-            SELECT r.img, r.addr, x.name, x.computed_name
-            FROM refs r
-            INNER JOIN names x ON r.img = x.img and r.ref = x.addr
-            LEFT JOIN names y ON r.img = y.img and r.addr = y.addr
-            WHERE y.addr IS NULL
-            """)
-
-        return cur.rowcount > 0
+        return None

--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -254,11 +254,23 @@ class EntityBatch:
 
 class EntityDb:
     # pylint: disable=too-many-public-methods
+    _x_orig: dict[int, ReccmpEntity]
+    _y_recomp: dict[int, ReccmpEntity]
+    _x_matches: dict[int, int]
+    _y_matches: dict[int, int]
+    _x_set: set[int]
+    _y_set: set[int]
+    _x_all: list[int]
+    _y_all: list[int]
+
     def __init__(self):
         self._x_orig = {}
         self._y_recomp = {}
         self._x_matches = {}
         self._y_matches = {}
+
+        self._x_set = set()
+        self._y_set = set()
 
         self._x_all = []
         self._y_all = []
@@ -270,17 +282,20 @@ class EntityDb:
         # TODO: if we care
         return len(list(self.get_all()))
 
-    def _new_orig(self, addr: int):
-        if addr not in self._x_orig and addr not in self._x_matches:
-            bisect.insort(self._x_all, addr)
+    def _new_orig(self, addrs: set[int]):
+        self._x_all.extend(addrs - self._x_set)
+        self._x_all.sort()
+        self._x_set |= addrs
 
-    def _new_recomp(self, addr: int):
-        if addr not in self._y_recomp and addr not in self._y_matches:
-            bisect.insort(self._y_all, addr)
+    def _new_recomp(self, addrs: set[int]):
+        self._y_all.extend(addrs - self._y_set)
+        self._y_all.sort()
+        self._y_set |= addrs
 
     def bulk_orig_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
+        new_x = set()
         for addr, values in rows:
-            self._new_orig(addr)
+            new_x.add(addr)
 
             if addr not in self._x_orig:
                 self._x_orig[addr] = ReccmpEntity(addr, None)
@@ -289,9 +304,12 @@ class EntityDb:
             denoise = {k: v for k, v in values.items() if v is not None}
             self._x_orig[addr]._kvstore.update(denoise)
 
+        self._new_orig(new_x)
+
     def bulk_recomp_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
+        new_y = set()
         for addr, values in rows:
-            self._new_recomp(addr)
+            new_y.add(addr)
 
             if addr not in self._y_recomp:
                 self._y_recomp[addr] = ReccmpEntity(None, addr)
@@ -300,16 +318,21 @@ class EntityDb:
             denoise = {k: v for k, v in values.items() if v is not None}
             self._y_recomp[addr]._kvstore.update(denoise)
 
+        self._new_recomp(new_y)
+
     def bulk_match(self, pairs: Iterable[tuple[int, int]]):
         """Expects iterable of `(orig_addr, recomp_addr)`."""
+
+        new_x = set()
+        new_y = set()
 
         for x, y in pairs:
             # Cannot replace existing match.
             if x in self._x_matches or y in self._y_matches:
                 continue
 
-            self._new_orig(x)
-            self._new_recomp(y)
+            new_x.add(x)
+            new_y.add(y)
 
             self._x_matches[x] = y
             self._y_matches[y] = x
@@ -328,6 +351,9 @@ class EntityDb:
 
             self._x_orig[x] = match
             self._y_recomp[y] = match
+
+        self._new_orig(new_x)
+        self._new_recomp(new_y)
 
     def all(self, img: ImageId) -> Iterator[ReccmpEntity]:
         if img == ImageId.ORIG:
@@ -368,7 +394,9 @@ class EntityDb:
     def get_matches(self) -> Iterator[ReccmpMatch]:
         for orig_addr in self._x_all:
             if orig_addr in self._x_matches:
-                yield self._x_orig[orig_addr]
+                ent = self._x_orig[orig_addr]
+                assert isinstance(ent, ReccmpMatch)
+                yield ent
 
     def get_one_match(self, orig_addr: int) -> ReccmpMatch | None:
         if orig_addr not in self._x_orig:
@@ -378,6 +406,7 @@ class EntityDb:
         if ent.recomp_addr is None:
             return None
 
+        assert isinstance(ent, ReccmpMatch)
         return ent
 
     def nearest(self, img: ImageId, addr: int) -> int | None:
@@ -454,6 +483,7 @@ class EntityDb:
         for orig_addr in sorted(orig_addrs):
             match = self._x_orig[orig_addr]
             if match.get("type") == EntityType.LINE:
+                assert isinstance(match, ReccmpMatch)
                 yield match
 
     def used(self, img: ImageId, addr: int) -> bool:

--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -4,7 +4,6 @@ addresses/symbols that we want to compare between the original and recompiled bi
 
 import bisect
 import logging
-from functools import cached_property
 from typing import Any, Iterable, Iterator
 from reccmp.types import EntityType, ImageId
 
@@ -52,10 +51,6 @@ class ReccmpEntity:
 
         assert False, "Invalid image id"
 
-    @cached_property
-    def options(self) -> dict[str, Any]:
-        return self._kvstore
-
     @property
     def orig_addr(self) -> int | None:
         return self._orig_addr
@@ -66,11 +61,11 @@ class ReccmpEntity:
 
     @property
     def entity_type(self) -> int | None:
-        return self.options.get("type")
+        return self._kvstore.get("type")
 
     @property
     def name(self) -> str | None:
-        return self.options.get("name")
+        return self._kvstore.get("name")
 
     def any_size(self, image_id: ImageId = ImageId.RECOMP) -> int:
         """Returns any size for this entity: the returned value cannot be null.
@@ -78,20 +73,24 @@ class ReccmpEntity:
         With no ImageId, prefer recomp_size first, then orig_size, default to zero.
         (This matches the previous behavior.)"""
         if image_id == ImageId.RECOMP:
-            return self.options.get("recomp_size") or self.options.get("orig_size") or 0
+            return (
+                self._kvstore.get("recomp_size") or self._kvstore.get("orig_size") or 0
+            )
 
         if image_id == ImageId.ORIG:
-            return self.options.get("orig_size") or self.options.get("recomp_size") or 0
+            return (
+                self._kvstore.get("orig_size") or self._kvstore.get("recomp_size") or 0
+            )
 
         return 0
 
     def size(self, image_id: ImageId) -> int | None:
         """Return the size attribute for the provided ImageId."""
         if image_id == ImageId.ORIG:
-            return self.options.get("orig_size")
+            return self._kvstore.get("orig_size")
 
         if image_id == ImageId.RECOMP:
-            return self.options.get("recomp_size")
+            return self._kvstore.get("recomp_size")
 
         assert False, "Invalid image id"
 
@@ -100,13 +99,13 @@ class ReccmpEntity:
         return self._orig_addr is not None and self._recomp_addr is not None
 
     def get(self, key: str, default: Any = None) -> Any:
-        return self.options.get(key, default)
+        return self._kvstore.get(key, default)
 
     def best_name(self) -> str | None:
         """Return the first name that exists from our
         priority list of name attributes for this entity."""
         for key in ("computed_name", "name"):
-            if (value := self.options.get(key)) is not None:
+            if (value := self._kvstore.get(key)) is not None:
                 return str(value)
 
         return None
@@ -232,10 +231,10 @@ class EntityBatch:
 
     def commit(self):
         if self._orig:
-            self.base.bulk_orig_insert(self._orig.items())
+            self.base.bulk_insert(ImageId.ORIG, self._orig.items())
 
         if self._recomp:
-            self.base.bulk_recomp_insert(self._recomp.items())
+            self.base.bulk_insert(ImageId.RECOMP, self._recomp.items())
 
         if self._matches:
             self.base.bulk_match(self._finalized_matches())
@@ -254,157 +253,140 @@ class EntityBatch:
 
 class EntityDb:
     # pylint: disable=too-many-public-methods
-    _x_orig: dict[int, ReccmpEntity]
-    _y_recomp: dict[int, ReccmpEntity]
-    _x_matches: dict[int, int]
-    _y_matches: dict[int, int]
-    _x_set: set[int]
-    _y_set: set[int]
-    _x_all: list[int]
-    _y_all: list[int]
+    _entities: dict[ImageId, dict[int, ReccmpEntity]]
+    _matches: dict[ImageId, dict[int, int]]
+    _addr_set: dict[ImageId, set[int]]
+    _addr_order: dict[ImageId, list[int]]
 
     def __init__(self):
-        self._x_orig = {}
-        self._y_recomp = {}
-        self._x_matches = {}
-        self._y_matches = {}
+        self._entities = {ImageId.ORIG: {}, ImageId.RECOMP: {}}
+        self._matches = {ImageId.ORIG: {}, ImageId.RECOMP: {}}
 
-        self._x_set = set()
-        self._y_set = set()
-
-        self._x_all = []
-        self._y_all = []
+        self._addr_set = {ImageId.ORIG: set(), ImageId.RECOMP: set()}
+        self._addr_order = {ImageId.ORIG: [], ImageId.RECOMP: []}
 
     def batch(self) -> EntityBatch:
         return EntityBatch(self)
 
     def count(self) -> int:
-        # TODO: if we care
         return len(list(self.get_all()))
 
-    def _new_orig(self, addrs: set[int]):
-        self._x_all.extend(addrs - self._x_set)
-        self._x_all.sort()
-        self._x_set |= addrs
+    def _update_addr_index(self, img: ImageId, addrs: set[int]):
+        """Update the ordered list of addresses in this address space."""
+        extent = self._addr_set[img]
+        order = self._addr_order[img]
+        order.extend(addrs - extent)
+        order.sort()
+        extent |= addrs
 
-    def _new_recomp(self, addrs: set[int]):
-        self._y_all.extend(addrs - self._y_set)
-        self._y_all.sort()
-        self._y_set |= addrs
+    def bulk_insert(self, image: ImageId, rows: Iterable[tuple[int, dict[str, Any]]]):
+        assert image in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+        new_addrs = set()
+        entities = self._entities[image]
 
-    def bulk_orig_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
-        new_x = set()
         for addr, values in rows:
-            new_x.add(addr)
+            new_addrs.add(addr)
 
-            if addr not in self._x_orig:
-                self._x_orig[addr] = ReccmpEntity(addr, None)
+            if addr not in entities:
+                if image == ImageId.ORIG:
+                    entities[addr] = ReccmpEntity(addr, None, values)
+                else:
+                    entities[addr] = ReccmpEntity(None, addr, values)
+            else:
+                entities[addr]._kvstore.update(values) # pylint: disable=protected-access
 
-            # pylint:disable=protected-access
-            self._x_orig[addr]._kvstore.update(values)
-
-        self._new_orig(new_x)
-
-    def bulk_recomp_insert(self, rows: Iterable[tuple[int, dict[str, Any]]]):
-        new_y = set()
-        for addr, values in rows:
-            new_y.add(addr)
-
-            if addr not in self._y_recomp:
-                self._y_recomp[addr] = ReccmpEntity(None, addr)
-
-            # pylint:disable=protected-access
-            self._y_recomp[addr]._kvstore.update(values)
-
-        self._new_recomp(new_y)
+        self._update_addr_index(image, new_addrs)
 
     def bulk_match(self, pairs: Iterable[tuple[int, int]]):
         """Expects iterable of `(orig_addr, recomp_addr)`."""
+
+        orig_entities = self._entities[ImageId.ORIG]
+        recomp_entities = self._entities[ImageId.RECOMP]
 
         new_x = set()
         new_y = set()
 
         for x, y in pairs:
             # Cannot replace existing match.
-            if x in self._x_matches or y in self._y_matches:
+            if x in self._matches[ImageId.ORIG] or y in self._matches[ImageId.RECOMP]:
                 continue
 
             new_x.add(x)
             new_y.add(y)
 
-            self._x_matches[x] = y
-            self._y_matches[y] = x
+            self._matches[ImageId.ORIG][x] = y
+            self._matches[ImageId.RECOMP][y] = x
 
             orig_data = {}
-            if x in self._x_orig:
-                # pylint:disable=protected-access
-                orig_data = self._x_orig[x]._kvstore
+            if x in orig_entities:
+                # pylint: disable=protected-access
+                orig_data = orig_entities[x]._kvstore
 
             recomp_data = {}
-            if y in self._y_recomp:
+            if y in recomp_entities:
                 # Remove null values from recomp. If we don't, the merge
                 # will overwrite a value at the same key in orig.
-                # pylint:disable=protected-access
+                # pylint: disable=protected-access
                 recomp_data = {
-                    k: v for k, v in self._y_recomp[y]._kvstore.items() if v is not None
+                    k: v
+                    for k, v in recomp_entities[y]._kvstore.items()
+                    if v is not None
                 }
 
             match = ReccmpMatch(x, y, orig_data | recomp_data)
 
-            self._x_orig[x] = match
-            self._y_recomp[y] = match
+            orig_entities[x] = match
+            recomp_entities[y] = match
 
-        self._new_orig(new_x)
-        self._new_recomp(new_y)
+        self._update_addr_index(ImageId.ORIG, new_x)
+        self._update_addr_index(ImageId.RECOMP, new_y)
 
     def all(self, img: ImageId) -> Iterator[ReccmpEntity]:
-        if img == ImageId.ORIG:
-            for addr in self._x_all:
-                if addr in self._x_orig:
-                    yield self._x_orig[addr]
+        """Iterate entities in order for the given the address space."""
+        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
 
-        elif img == ImageId.RECOMP:
-            for addr in self._y_all:
-                if addr in self._y_recomp:
-                    yield self._y_recomp[addr]
+        entities = self._entities[img]
 
-        else:
-            assert False, "Invalid image id"
+        for addr in self._addr_order[img]:
+            if addr in entities:
+                yield entities[addr]
 
     def unmatched(self, img: ImageId) -> Iterator[ReccmpEntity]:
-        if img == ImageId.ORIG:
-            for addr in self._x_all:
-                if addr in self._x_orig and addr not in self._x_matches:
-                    yield self._x_orig[addr]
+        """Iterate unmatched entities only in order for the given the address space."""
+        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
 
-        elif img == ImageId.RECOMP:
-            for addr in self._y_all:
-                if addr in self._y_recomp and addr not in self._y_matches:
-                    yield self._y_recomp[addr]
+        entities = self._entities[img]
+        matches = self._matches[img]
 
-        else:
-            assert False, "Invalid image id"
+        for addr in self._addr_order[img]:
+            if addr in entities and addr not in matches:
+                yield entities[addr]
 
     def get_all(self) -> Iterator[ReccmpEntity]:
-        for orig_addr in self._x_all:
-            yield self._x_orig[orig_addr]
+        orig_entities = self._entities[ImageId.ORIG]
+        recomp_entities = self._entities[ImageId.RECOMP]
 
-        for recomp_addr in self._y_all:
-            if recomp_addr not in self._y_matches:
-                yield self._y_recomp[recomp_addr]
+        for orig_addr in self._addr_order[ImageId.ORIG]:
+            yield orig_entities[orig_addr]
+
+        for recomp_addr in self._addr_order[ImageId.RECOMP]:
+            if recomp_addr not in self._matches[ImageId.RECOMP]:
+                yield recomp_entities[recomp_addr]
 
     def get_matches(self) -> Iterator[ReccmpMatch]:
-        for orig_addr in self._x_all:
-            if orig_addr in self._x_matches:
-                ent = self._x_orig[orig_addr]
+        matches = self._matches[ImageId.ORIG]
+        entities = self._entities[ImageId.ORIG]
+        for orig_addr in self._addr_order[ImageId.ORIG]:
+            if orig_addr in matches:
+                ent = entities[orig_addr]
                 assert isinstance(ent, ReccmpMatch)
                 yield ent
 
     def get_one_match(self, orig_addr: int) -> ReccmpMatch | None:
-        if orig_addr not in self._x_orig:
+        if orig_addr not in self._entities[ImageId.ORIG]:
             return None
 
-        ent = self._x_orig[orig_addr]
+        ent = self._entities[ImageId.ORIG][orig_addr]
         if ent.recomp_addr is None:
             return None
 
@@ -412,12 +394,8 @@ class EntityDb:
         return ent
 
     def nearest(self, img: ImageId, addr: int) -> int | None:
-        if img == ImageId.ORIG:
-            addrs = self._x_all
-        elif img == ImageId.RECOMP:
-            addrs = self._y_all
-        else:
-            assert False, "Invalid image id"
+        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+        addrs = self._addr_order[img]
 
         i = bisect.bisect_right(addrs, addr)
         if i == 0:
@@ -432,27 +410,16 @@ class EntityDb:
         If there is no entry for the address and exact=True (default), return None.
         Otherwise, return the preceding (by address, in this image) entity if it exists.
         The caller should check the entity's size to make sure it covers the address."""
-        if img == ImageId.ORIG:
-            if not exact and addr not in self._x_orig:
-                prev_addr = self.nearest(img, addr)
-                if prev_addr is None:
-                    return None
+        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
 
-                addr = prev_addr
+        if not exact and addr not in self._entities[img]:
+            prev_addr = self.nearest(img, addr)
+            if prev_addr is None:
+                return None
 
-            return self._x_orig.get(addr)
+            addr = prev_addr
 
-        if img == ImageId.RECOMP:
-            if not exact and addr not in self._y_recomp:
-                prev_addr = self.nearest(img, addr)
-                if prev_addr is None:
-                    return None
-
-                addr = prev_addr
-
-            return self._y_recomp.get(addr)
-
-        assert False, "Invalid image id"
+        return self._entities[img].get(addr)
 
     def get_functions(self) -> Iterator[ReccmpMatch]:
         """Return all function-like matched entities. Previously, all functions
@@ -474,31 +441,28 @@ class EntityDb:
         self, start_recomp_addr: int, end_recomp_addr: int
     ) -> Iterator[ReccmpMatch]:
         """Fetches all matched annotations of the form `// LINE: TARGET 0x1234` in the given recomp address range."""
-        i = bisect.bisect_left(self._y_all, start_recomp_addr)
-        j = bisect.bisect_right(self._y_all, end_recomp_addr)
+        addrs = self._addr_order[ImageId.RECOMP]
+        i = bisect.bisect_left(addrs, start_recomp_addr)
+        j = bisect.bisect_right(addrs, end_recomp_addr)
 
-        candidates = self._y_all[i:j]
+        recomp_matches = self._matches[ImageId.RECOMP]
+        candidates = addrs[i:j]
         orig_addrs = [
-            self._y_matches[addr] for addr in candidates if addr in self._y_matches
+            recomp_matches[addr] for addr in candidates if addr in recomp_matches
         ]
 
         for orig_addr in sorted(orig_addrs):
-            match = self._x_orig[orig_addr]
+            match = self._entities[ImageId.ORIG][orig_addr]
             if match.get("type") == EntityType.LINE:
                 assert isinstance(match, ReccmpMatch)
                 yield match
 
     def used(self, img: ImageId, addr: int) -> bool:
-        if img == ImageId.ORIG:
-            return addr in self._x_orig or addr in self._x_matches
-
-        if img == ImageId.RECOMP:
-            return addr in self._y_recomp or addr in self._y_matches
-
-        assert False, "Invalid image id"
+        assert img in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+        return addr in self._addr_set[img]
 
     def is_match(self, orig_addr: int, recomp_addr: int) -> bool:
-        return self._x_matches.get(orig_addr) == recomp_addr
+        return self._matches[ImageId.ORIG].get(orig_addr) == recomp_addr
 
     def get_next_orig_addr(self, addr: int) -> int | None:
         """Return the original address (matched or not) that follows
@@ -507,9 +471,10 @@ class EntityDb:
         Skips LINE and LABEL type entities since these these are always contained
         within functions.
         """
-        i = bisect.bisect_left(self._x_all, addr)
-        for next_addr in self._x_all[i:]:
-            ent = self._x_orig[next_addr]
+        addrs = self._addr_order[ImageId.ORIG]
+        i = bisect.bisect_left(addrs, addr)
+        for next_addr in addrs[i:]:
+            ent = self._entities[ImageId.ORIG][next_addr]
 
             if (
                 next_addr > addr

--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -301,8 +301,7 @@ class EntityDb:
                 self._x_orig[addr] = ReccmpEntity(addr, None)
 
             # pylint:disable=protected-access
-            denoise = {k: v for k, v in values.items() if v is not None}
-            self._x_orig[addr]._kvstore.update(denoise)
+            self._x_orig[addr]._kvstore.update(values)
 
         self._new_orig(new_x)
 
@@ -315,8 +314,7 @@ class EntityDb:
                 self._y_recomp[addr] = ReccmpEntity(None, addr)
 
             # pylint:disable=protected-access
-            denoise = {k: v for k, v in values.items() if v is not None}
-            self._y_recomp[addr]._kvstore.update(denoise)
+            self._y_recomp[addr]._kvstore.update(values)
 
         self._new_recomp(new_y)
 
@@ -344,8 +342,12 @@ class EntityDb:
 
             recomp_data = {}
             if y in self._y_recomp:
+                # Remove null values from recomp. If we don't, the merge
+                # will overwrite a value at the same key in orig.
                 # pylint:disable=protected-access
-                recomp_data = self._y_recomp[y]._kvstore
+                recomp_data = {
+                    k: v for k, v in self._y_recomp[y]._kvstore.items() if v is not None
+                }
 
             match = ReccmpMatch(x, y, orig_data | recomp_data)
 

--- a/reccmp/compare/match_msvc.py
+++ b/reccmp/compare/match_msvc.py
@@ -7,6 +7,7 @@ from reccmp.compare.event import (
     reccmp_report_nop,
 )
 from reccmp.compare.queries import get_referencing_entity_matches
+from reccmp.types import ImageId
 
 
 class EntityIndex:
@@ -47,21 +48,26 @@ def match_symbols(
 
     symbol_index = EntityIndex()
 
-    for recomp_addr, symbol in db.sql.execute(
-        """SELECT recomp_addr, json_extract(kvstore, '$.symbol') as symbol
-        from recomp_unmatched where symbol is not null"""
-    ):
+    for ent in db.unmatched(ImageId.RECOMP):
+        symbol = ent.get("symbol")
+        if not symbol:
+            continue
+
         # Truncate symbol to 255 chars for older MSVC. See also: Warning C4786.
         if truncate:
             symbol = symbol[:255]
 
-        symbol_index.add(symbol, recomp_addr)
+        assert ent.recomp_addr is not None
+        symbol_index.add(symbol, ent.recomp_addr)
 
     with db.batch() as batch:
-        for orig_addr, symbol in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.symbol') as symbol
-            from orig_unmatched where symbol is not null"""
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            assert ent.orig_addr is not None
+            symbol = ent.get("symbol")
+
+            if not symbol:
+                continue
+
             # Repeat the truncate for our match search
             if truncate:
                 symbol = symbol[:255]
@@ -73,17 +79,17 @@ def match_symbols(
                 if symbol in symbol_index:
                     report(
                         ReccmpEvent.NON_UNIQUE_SYMBOL,
-                        orig_addr,
-                        msg=f"Matched 0x{orig_addr:x} using non-unique symbol '{symbol}'",
+                        ent.orig_addr,
+                        msg=f"Matched 0x{ent.orig_addr:x} using non-unique symbol '{symbol}'",
                     )
 
-                batch.match(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
 
             else:
                 report(
                     ReccmpEvent.NO_MATCH,
-                    orig_addr,
-                    msg=f"Failed to match at 0x{orig_addr:x} with symbol '{symbol}'",
+                    ent.orig_addr,
+                    msg=f"Failed to match at 0x{ent.orig_addr:x} with symbol '{symbol}'",
                 )
 
 
@@ -101,21 +107,25 @@ def match_functions(
     # TODO: We allow a match if entity_type is null.
     # This can be removed if we can more confidently declare a symbol is a function
     # when adding from the PDB.
-    for recomp_addr, name, symbol in db.sql.execute(
-        """SELECT recomp_addr, json_extract(kvstore, '$.name') as name, json_extract(kvstore, '$.symbol')
-        from recomp_unmatched where name is not null
-        and (json_extract(kvstore, '$.type') = ? or json_extract(kvstore, '$.type') is null)""",
-        (EntityType.FUNCTION,),
-    ):
+    for ent in db.unmatched(ImageId.RECOMP):
+        symbol = ent.get("symbol")
+        name = ent.get("name")
+        if ent.get("type") and ent.get("type") != EntityType.FUNCTION:
+            continue
+
+        if not name:
+            continue
+
         # Truncate function name to 255 chars for older MSVC. See also: Warning C4786.
         if truncate:
             name = name[:255]
 
-        name_index.add(name, recomp_addr)
+        assert ent.recomp_addr is not None
+        name_index.add(name, ent.recomp_addr)
 
         # Get the symbol for the error message later.
         if symbol is not None:
-            recomp_symbols[recomp_addr] = symbol
+            recomp_symbols[ent.recomp_addr] = symbol
 
     # Report if the name used in the match is not unique.
     # If the name list contained multiple addresses at the start,
@@ -123,12 +133,16 @@ def match_functions(
     non_unique_names = set()
 
     with db.batch() as batch:
-        for orig_addr, name in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.name') as name
-            from orig_unmatched where name is not null
-            and json_extract(kvstore, '$.type') = ?""",
-            (EntityType.FUNCTION,),
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            name = ent.get("name")
+            if ent.get("type") != EntityType.FUNCTION:
+                continue
+
+            if not name:
+                continue
+
+            assert ent.orig_addr is not None
+
             # Repeat the truncate for our match search
             if truncate:
                 name = name[:255]
@@ -148,19 +162,19 @@ def match_functions(
                     ]
                     report(
                         ReccmpEvent.AMBIGUOUS_MATCH,
-                        orig_addr,
-                        msg=f"Ambiguous match 0x{orig_addr:x} on name '{name}' to\n"
+                        ent.orig_addr,
+                        msg=f"Ambiguous match 0x{ent.orig_addr:x} on name '{name}' to\n"
                         + f"'{matched_symbol}'\n"
                         + "Other candidates:\n"
                         + ",\n".join(f"'{candidate}'" for candidate in other_symbols),
                     )
 
-                batch.match(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
             else:
                 report(
                     ReccmpEvent.NO_MATCH,
-                    orig_addr,
-                    msg=f"Failed to match function at 0x{orig_addr:x} with name '{name}'",
+                    ent.orig_addr,
+                    msg=f"Failed to match function at 0x{ent.orig_addr:x} with name '{name}'",
                 )
 
 
@@ -184,21 +198,24 @@ def match_vtables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
 
     vtable_name_index = EntityIndex()
 
-    for recomp_addr, name in db.sql.execute(
-        """SELECT recomp_addr, json_extract(kvstore, '$.name') as name
-        from recomp_unmatched where name is not null
-        and json_extract(kvstore, '$.type') = ?""",
-        (EntityType.VTABLE,),
-    ):
-        vtable_name_index.add(name, recomp_addr)
+    for ent in db.unmatched(ImageId.RECOMP):
+        name = ent.get("name")
+        if not name or ent.get("type") != EntityType.VTABLE:
+            continue
+
+        assert ent.recomp_addr is not None
+        vtable_name_index.add(name, ent.recomp_addr)
 
     with db.batch() as batch:
-        for orig_addr, class_name, base_class in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.name') as name, json_extract(kvstore, '$.base_class')
-            from orig_unmatched where name is not null
-            and json_extract(kvstore, '$.type') = ?""",
-            (EntityType.VTABLE,),
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            class_name = ent.get("name")
+            if not class_name or ent.get("type") != EntityType.VTABLE:
+                continue
+
+            assert ent.orig_addr is not None
+
+            base_class = ent.get("base_class")
+
             # Most classes will not use multiple inheritance, so try the regular vtable
             # first, unless a base class is provided.
             if base_class is None or base_class == class_name:
@@ -206,7 +223,7 @@ def match_vtables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
 
                 if bare_vftable in vtable_name_index:
                     recomp_addr = vtable_name_index.pop(bare_vftable)
-                    batch.match(orig_addr, recomp_addr)
+                    batch.match(ent.orig_addr, recomp_addr)
                     continue
 
             # If we didn't find a match above, search for the multiple inheritance vtable.
@@ -215,13 +232,13 @@ def match_vtables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
 
             if for_vftable in vtable_name_index:
                 recomp_addr = vtable_name_index.pop(for_vftable)
-                batch.match(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
                 continue
 
             report(
                 ReccmpEvent.NO_MATCH,
-                orig_addr,
-                msg=f"Failed to match vtable at 0x{orig_addr:x} for class '{class_name}' (base={base_class or 'None'})",
+                ent.orig_addr,
+                msg=f"Failed to match vtable at 0x{ent.orig_addr:x} for class '{class_name}' (base={base_class or 'None'})",
             )
 
 
@@ -238,19 +255,41 @@ def match_static_variables(
 
     Requirement #1 is most likely to be met by matching the entity with recomp data.
     Therefore, this function should be called after match_symbols or match_functions."""
+    symbols = {}
+
+    for recomp_ent in db.unmatched(ImageId.RECOMP):
+        if recomp_ent.get("type") and recomp_ent.get("type") != EntityType.DATA:
+            continue
+
+        recomp_sym = recomp_ent.get("symbol")
+        if not recomp_sym:
+            continue
+
+        assert recomp_ent.recomp_addr is not None
+        symbols[recomp_ent.recomp_addr] = recomp_sym
+
     with db.batch() as batch:
-        for (
-            variable_addr,
-            variable_name,
-            function_name,
-            function_symbol,
-        ) in db.sql.execute(
-            """SELECT var.orig_addr, json_extract(var.kvstore, '$.name') as name,
-            json_extract(func.kvstore, '$.name'), json_extract(func.kvstore, '$.symbol')
-            from orig_unmatched var left join entities func on json_extract(var.kvstore, '$.parent_function') = func.orig_addr
-            where json_extract(var.kvstore, '$.static_var') = 1
-            and name is not null"""
-        ):
+        for variable_ent in db.unmatched(ImageId.ORIG):
+            variable_addr = variable_ent.orig_addr
+            assert variable_addr is not None
+
+            if not variable_ent.get("static_var"):
+                continue
+
+            variable_name = variable_ent.get("name")
+            if not variable_name:
+                continue
+
+            function_name = None
+            function_symbol = None
+
+            parent_addr = variable_ent.get("parent_function")
+            if parent_addr:
+                parent_ent = db.get(ImageId.ORIG, parent_addr)
+                if parent_ent is not None:
+                    function_name = parent_ent.get("name")
+                    function_symbol = parent_ent.get("symbol")
+
             # If we could not find the parent function, or if it has no symbol:
             if function_symbol is None:
                 report(
@@ -260,18 +299,11 @@ def match_static_variables(
                 )
                 continue
 
-            # If the static variable has a symbol, it will contain the parent function's symbol.
-            # e.g. Static variable "g_startupDelay" from function "IsleApp::Tick"
-            # The function symbol is:                    "?Tick@IsleApp@@QAEXH@Z"
-            # The variable symbol is: "?g_startupDelay@?1??Tick@IsleApp@@QAEXH@Z@4HA"
-            for (recomp_addr,) in db.sql.execute(
-                """SELECT recomp_addr FROM recomp_unmatched
-                where (json_extract(kvstore, '$.type') = ? OR json_extract(kvstore, '$.type') IS NULL)
-                and json_extract(kvstore, '$.symbol') LIKE '%' || ? || '%' || ? || '%'""",
-                (EntityType.DATA, variable_name, function_symbol),
-            ):
-                batch.match(variable_addr, recomp_addr)
-                break
+            for recomp_addr, recomp_sym in symbols.items():
+                if function_symbol in recomp_sym and variable_name in recomp_sym:
+                    batch.match(variable_addr, recomp_addr)
+                    del symbols[recomp_addr]
+                    break
             else:
                 report(
                     ReccmpEvent.NO_MATCH,
@@ -286,60 +318,76 @@ def match_variables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_n
     # TODO: We allow a match if entity_type is null.
     # This can be removed if we can more confidently declare a symbol is a variable
     # when adding from the PDB.
-    for name, recomp_addr in db.sql.execute(
-        """SELECT json_extract(kvstore, '$.name') as name, recomp_addr
-        from recomp_unmatched where name is not null
-        and (json_extract(kvstore, '$.type') = ? or json_extract(kvstore, '$.type') is null)""",
-        (EntityType.DATA,),
-    ):
-        var_name_index.add(name, recomp_addr)
+    for ent in db.unmatched(ImageId.RECOMP):
+        if ent.get("type") and ent.get("type") != EntityType.DATA:
+            continue
+
+        name = ent.get("name")
+        if not name:
+            continue
+
+        assert ent.recomp_addr is not None
+        var_name_index.add(name, ent.recomp_addr)
 
     with db.batch() as batch:
-        for orig_addr, name in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.name') as name
-            from orig_unmatched where name is not null
-            and json_extract(kvstore, '$.type') = ?
-            and coalesce(json_extract(kvstore, '$.static_var'), 0) != 1""",
-            (EntityType.DATA,),
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            if ent.get("type") != EntityType.DATA:
+                continue
+
+            name = ent.get("name")
+            if not name:
+                continue
+
+            if ent.get("static_var"):
+                continue
+
+            assert ent.orig_addr is not None
+
             if name in var_name_index:
                 recomp_addr = var_name_index.pop(name)
-                batch.match(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
             else:
                 report(
                     ReccmpEvent.NO_MATCH,
-                    orig_addr,
-                    msg=f"Failed to match variable {name} at 0x{orig_addr:x}",
+                    ent.orig_addr,
+                    msg=f"Failed to match variable {name} at 0x{ent.orig_addr:x}",
                 )
 
 
 def match_strings(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop):
     string_index = EntityIndex()
 
-    for recomp_addr, text in db.sql.execute(
-        """SELECT recomp_addr, json_extract(kvstore, '$.name') as name
-        from recomp_unmatched where name is not null
-        and json_extract(kvstore,'$.type') IN (?, ?)""",
-        (EntityType.STRING, EntityType.WIDECHAR),
-    ):
-        string_index.add(text, recomp_addr)
+    for ent in db.unmatched(ImageId.RECOMP):
+        if ent.get("type") not in (EntityType.STRING, EntityType.WIDECHAR):
+            continue
+
+        text = ent.get("name")
+        if not text:
+            continue
+
+        assert ent.recomp_addr is not None
+        string_index.add(text, ent.recomp_addr)
 
     with db.batch() as batch:
-        for orig_addr, text, verified in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.name') as name,
-            coalesce(json_extract(kvstore,'$.verified'), 0)
-            from orig_unmatched where name is not null
-            and json_extract(kvstore,'$.type') IN (?, ?)""",
-            (EntityType.STRING, EntityType.WIDECHAR),
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            if ent.get("type") not in (EntityType.STRING, EntityType.WIDECHAR):
+                continue
+
+            text = ent.get("name")
+            if not text:
+                continue
+
+            verified = ent.get("verified", False)
+            assert ent.orig_addr is not None
+
             if text in string_index:
                 recomp_addr = string_index.pop(text)
-                batch.match(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
             elif verified:
                 report(
                     ReccmpEvent.NO_MATCH,
-                    orig_addr,
-                    msg=f"Failed to match string {text} at 0x{orig_addr:x}",
+                    ent.orig_addr,
+                    msg=f"Failed to match string {text} at 0x{ent.orig_addr:x}",
                 )
 
 
@@ -355,12 +403,14 @@ def match_lines(
     """
 
     with db.batch() as batch:
-        for orig_addr, filename, line in db.sql.execute(
-            """SELECT orig_addr, json_extract(kvstore, '$.filename') as filename, json_extract(kvstore, '$.line') as line
-            FROM orig_unmatched
-            WHERE json_extract(kvstore,'$.type') = ?""",
-            (EntityType.LINE,),
-        ):
+        for ent in db.unmatched(ImageId.ORIG):
+            if ent.get("type") != EntityType.LINE:
+                continue
+
+            assert ent.orig_addr is not None
+            filename = ent.get("filename")
+            line = ent.get("line")
+
             #
             # We only match the line directly below the annotation since not all lines of code result in a debug line, especially if optimizations are turned on.
             # However, this does cause false positives in cases like
@@ -380,13 +430,13 @@ def match_lines(
 
             # We match `line + 1` since `line` is the comment itself
             for recomp_addr in lines.search_line(filename, line + 1):
-                batch.set_recomp_addr(orig_addr, recomp_addr)
+                batch.match(ent.orig_addr, recomp_addr)
                 break
             else:
                 # No results
                 report(
                     ReccmpEvent.NO_MATCH,
-                    orig_addr,
+                    ent.orig_addr,
                     f"Found no matching debug symbol for {filename}:{line}",
                 )
 
@@ -419,29 +469,31 @@ def match_ref(
 
 
 def match_imports(db: EntityDb):
-    orig_query = """
-        SELECT orig_addr, json_extract(kvstore, '$.name') name
-        FROM orig_unmatched
-        WHERE json_extract(kvstore, '$.type') = ?
-        AND name IS NOT NULL
-    """
-
-    recomp_query = """
-        SELECT recomp_addr, json_extract(kvstore, '$.name') name
-        FROM recomp_unmatched
-        WHERE json_extract(kvstore, '$.type') = ?
-        AND name IS NOT NULL
-    """
+    orig_imports = {}
 
     # n.b. Case insensitive match here to preserve previous behavior.
     # The final entity will use the name from the recomp side.
-    orig_imports = {
-        name.upper(): addr
-        for addr, name in db.sql.execute(orig_query, (EntityType.IMPORT,))
-    }
+    for ent in db.unmatched(ImageId.ORIG):
+        if ent.get("type") != EntityType.IMPORT:
+            continue
+
+        name = ent.get("name")
+        if not name:
+            continue
+
+        assert isinstance(ent.orig_addr, int)
+        orig_imports[name.upper()] = ent.orig_addr
 
     with db.batch() as batch:
-        for recomp_addr, name in db.sql.execute(recomp_query, (EntityType.IMPORT,)):
+        for ent in db.unmatched(ImageId.RECOMP):
+            if ent.get("type") != EntityType.IMPORT:
+                continue
+
+            name = ent.get("name")
+            if not name:
+                continue
+
             orig_addr = orig_imports.get(name.upper())
             if orig_addr is not None:
-                batch.match(orig_addr, recomp_addr)
+                assert isinstance(ent.recomp_addr, int)
+                batch.match(orig_addr, ent.recomp_addr)

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -134,26 +134,10 @@ def match_array_elements(db: EntityDb, types: CvdumpTypesParser):
     batch.commit()
 
 
-def propagate_names(db: EntityDb):
-    """Copy the name and computed_name attributes from a parent entity
-    down to any thunks or vtordisp entities that refer back to it."""
-    db.populate_names_table()
-
-    # If there are chains of thunks (e.g. thunk -> vtordisp -> thunk -> function )
-    # we need to repeat the name propagation step to cover all entities.
-    # Stop if no names were added on this pass.
-    for _ in range(10):
-        if not db.propagate_thunk_names():
-            break
-
-
 def name_thunks(db: EntityDb):
     """Add the 'Thunk of' prefix or 'vtordisp{x,y}' suffix to thunk or vtordisp entities.
-    Should be run after propagate_names() or this will have no effect.
-    (i.e. It needs data in the NAMES table.)
     The current behavior is to use the computed_name (disambiguated) for an entity as the
     entity's "name" attribute."""
-    propagate_names(db)
 
     with db.batch() as batch:
         for img, addr, name in get_named_thunks(db):

--- a/reccmp/compare/queries.py
+++ b/reccmp/compare/queries.py
@@ -1,6 +1,6 @@
 from typing import Iterator, NamedTuple
 from reccmp.types import EntityType, ImageId
-from .db import EntityDb
+from .db import EntityDb, ReccmpEntity
 
 
 class OverloadedFunctionEntity(NamedTuple):
@@ -17,28 +17,31 @@ def get_overloaded_functions(db: EntityDb) -> Iterator[OverloadedFunctionEntity]
     Uses a SQL window function to get the number for the repeated name so the caller
     doesn't need to keep track. We assume that a better name can be derived from
     the entity's symbol so we return that too."""
-    for orig_addr, recomp_addr, name, symbol, nth in db.sql.execute(
-        """SELECT orig_addr, recomp_addr,
-        json_extract(kvstore,'$.name') AS name,
-        json_extract(kvstore,'$.symbol'),
-        row_number() OVER (PARTITION BY json_extract(kvstore,'$.name') ORDER BY orig_addr NULLS LAST, recomp_addr)
-        FROM entities WHERE json_extract(kvstore,'$.type') = ?
-            AND name IN (
-            -- Subquery: build a list of names that are
-            -- repeated among FUNCTION entities.
-            SELECT json_extract(kvstore,'$.name') AS name FROM entities
-            WHERE json_extract(kvstore,'$.type') = ?
-            AND name IS NOT NULL
-            GROUP by name HAVING COUNT(name) > 1
-        )
-        """,
-        (EntityType.FUNCTION, EntityType.FUNCTION),
-    ):
-        assert isinstance(orig_addr, int) or isinstance(recomp_addr, int)
-        assert isinstance(name, str)
-        assert isinstance(symbol, str) or symbol is None
-        assert isinstance(nth, int)
-        yield OverloadedFunctionEntity(orig_addr, recomp_addr, name, symbol, nth)
+    name_cache: dict[str, list[ReccmpEntity]] = {}
+
+    for ent in db.get_all():
+        if ent.get("type") != EntityType.FUNCTION:
+            continue
+
+        name = ent.get("name")
+        if name is None:
+            continue
+
+        name_cache.setdefault(name, []).append(ent)
+
+    for _, names in name_cache.items():
+        if len(names) < 2:
+            continue
+
+        for nth, ent in enumerate(names, start=1):
+            assert isinstance(ent.orig_addr, int) or isinstance(ent.recomp_addr, int)
+            name = ent.get("name")
+            symbol = ent.get("symbol")
+            assert isinstance(name, str)
+            assert isinstance(symbol, str) or symbol is None
+            yield OverloadedFunctionEntity(
+                ent.orig_addr, ent.recomp_addr, name, symbol, nth
+            )
 
 
 class ThunkWithName(NamedTuple):
@@ -54,24 +57,74 @@ def get_named_thunks(db: EntityDb) -> Iterator[ThunkWithName]:
     """Return a modified name to set for each thunk and vtordisp entity.
     The name is copied from the parent function entity.
     Must run db.populate_names_table() and db,propagate_thunk_names() first."""
-    for img, addr, type_, name, disp0, disp1 in db.sql.execute(
-        """SELECT n.img, n.addr, json_extract(e.kvstore, '$.type') type, coalesce(n.computed_name, n.name) name, r.disp0, r.disp1
-        FROM names n
-        INNER JOIN refs r
-            ON n.img = r.img AND n.addr = r.addr
-        INNER JOIN entities e
-            ON (r.img = 0 AND r.addr = e.orig_addr)
-            OR (r.img = 1 AND r.addr = e.recomp_addr)
-        -- Rename thunk and vtordisp entities only.
-        WHERE type IN (?, ?, ?)
-        AND name IS NOT NULL
-        -- Performance: we only need to yield one addr for a matched entity.
-        GROUP BY e.rowid""",
-        (EntityType.THUNK, EntityType.VTORDISP, EntityType.IMPORT_THUNK),
-    ):
-        assert img in (ImageId.ORIG, ImageId.RECOMP)
-        assert isinstance(addr, int)
-        assert isinstance(name, str)
+
+    # Names, propagated as we complete the graph.
+    names: dict[tuple[ImageId, int], str] = {}
+
+    # Reverse nodes from parent function into each thunk
+    graph: dict[tuple[ImageId, int], list[int]] = {}
+
+    # Cache so we only fetch once.
+    refs: dict[tuple[ImageId, int], tuple[EntityType, tuple[int, int]]] = {}
+
+    for ent in db.get_all():
+        type_ = ent.get("type")
+        if type_ not in (
+            EntityType.THUNK,
+            EntityType.VTORDISP,
+            EntityType.IMPORT_THUNK,
+        ):
+            continue
+
+        disp = ent.get("displacement")
+        if disp is None:
+            continue
+
+        # TODO: yuck
+        for ref_img, ref_key in [
+            (ImageId.ORIG, "ref_orig"),
+            (ImageId.RECOMP, "ref_recomp"),
+        ]:
+            ref_addr = ent.get(ref_key)
+            if not isinstance(ref_addr, int):
+                continue
+
+            this_addr = ent.addr(ref_img)
+            assert this_addr is not None
+
+            refs[(ref_img, this_addr)] = (type_, disp)
+
+            # Set for both address spaces. We will dedupe later.
+            graph.setdefault((ref_img, ref_addr), []).append(this_addr)
+
+            parent = db.get(ref_img, ref_addr)
+            if parent is None:
+                continue
+
+            # Only functions can be the source of a name chain
+            if parent.get("type") not in (EntityType.FUNCTION, EntityType.IMPORT):
+                continue
+
+            name = parent.best_name()
+            if name is not None:
+                names[(ref_img, ref_addr)] = name
+
+    # propagate names step.
+    # TODO: dumb. should be exhaustive with known stop.
+    for _ in range(10):
+        new_names = {}
+        for (img, addr), name in names.items():
+            if (img, addr) in graph:
+                for thunk_addr in graph[(img, addr)]:
+                    new_names[(img, thunk_addr)] = name
+
+        names.update(new_names)
+
+    # TODO: dedupe here.
+    for (img, addr), (type_, (disp0, disp1)) in refs.items():
+        name = names.get((img, addr))
+        if not name:
+            continue
 
         if type_ == EntityType.THUNK:
             yield ThunkWithName(img, addr, f"Thunk of '{name}'")
@@ -89,23 +142,20 @@ def get_floats_without_data(
     return the address and whether it has double precision."""
     assert image_id in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
 
-    for addr, size in db.sql.execute(
-        """SELECT
-            case ? when 0 then orig_addr when 1 then recomp_addr else null end addr,
-            coalesce(json_extract(kvstore,'$.recomp_size'), json_extract(kvstore,'$.orig_size')) any_size
-        FROM entities
-        WHERE json_extract(kvstore,'$.type') = ?
-        AND addr IS NOT NULL
-        AND any_size in (4, 8)
-        -- TODO: #27. We are using the name field to store the data for now,
-        -- but we should put this data in its own table.
-        AND json_extract(kvstore,'$.name') IS NULL
-        """,
-        (
-            image_id,
-            EntityType.FLOAT,
-        ),
-    ):
+    for ent in db.all(image_id):
+        if ent.get("type") != EntityType.FLOAT:
+            continue
+
+        # TODO: #27. We are using the name field to store the data for now,
+        # but we should put this data in its own table.
+        if ent.get("name") is not None:
+            continue
+
+        size = ent.any_size(image_id)
+        if size not in (4, 8):
+            continue
+
+        addr = ent.addr(image_id)
         if isinstance(addr, int):
             yield (addr, size == 8)
 
@@ -115,20 +165,19 @@ def get_strings_without_data(
 ) -> Iterator[tuple[int, int | None, bool]]:
     assert image_id in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
 
-    for addr, size, type_ in db.sql.execute(
-        """SELECT
-            case ? when 0 then orig_addr when 1 then recomp_addr else null end addr,
-            case ? when 0 then json_extract(kvstore,'$.orig_size') when 1 then json_extract(kvstore,'$.recomp_size') else null end,
-            json_extract(kvstore,'$.type') type
-        FROM entities
-        WHERE type IN (?, ?)
-        AND addr IS NOT NULL
-        -- TODO: #27. We are using the name field to store the data for now,
-        -- but we should put this data in its own table.
-        AND json_extract(kvstore,'$.name') IS NULL
-        """,
-        (image_id, image_id, EntityType.STRING, EntityType.WIDECHAR),
-    ):
+    for ent in db.all(image_id):
+        type_ = ent.get("type")
+        if type_ not in (EntityType.STRING, EntityType.WIDECHAR):
+            continue
+
+        # TODO: #27. We are using the name field to store the data for now,
+        # but we should put this data in its own table.
+        if ent.get("name") is not None:
+            continue
+
+        size = ent.size(image_id)
+        addr = ent.addr(image_id)
+
         if isinstance(addr, int):
             yield (addr, size, type_ == EntityType.WIDECHAR)
 
@@ -139,32 +188,49 @@ def get_referencing_entity_matches(db: EntityDb) -> Iterator[tuple[int, int]]:
     To match, the child entities must have the same displacement values (or none).
     If we cannot match uniquely, match by child address order in each address space.
     """
-    for orig_addr, recomp_addr in db.sql.execute("""
-        WITH linked_refs AS (
-            SELECT r.img, r.addr, m.match_id, disp0, disp1,
-            row_number() OVER (PARTITION BY r.img, m.match_id, disp0, disp1 ORDER BY r.addr) nth
-            FROM refs r
-            -- Convert the referenced address to a unique ID to allow for matching.
-            INNER JOIN matches m
-                ON (r.img = 0 AND r.ref = m.orig_addr)
-                OR (r.img = 1 AND r.ref = m.recomp_addr)
-            -- Exclude thunk entities that have been matched.
-            INNER JOIN (
-                SELECT img, addr FROM refs
-                EXCEPT
-                SELECT img, addr FROM matched_ids
-            ) x
-            ON r.img = x.img AND r.addr = x.addr
-        )
-        SELECT x.addr, y.addr FROM
-        (SELECT * FROM linked_refs WHERE img = 0) x
-        INNER JOIN
-        (SELECT * FROM linked_refs WHERE img = 1) y
-        ON  x.disp0 = y.disp0
-        AND x.disp1 = y.disp1
-        AND x.nth = y.nth
-        AND x.match_id = y.match_id
-        """):
-        assert isinstance(orig_addr, int)
-        assert isinstance(recomp_addr, int)
-        yield (orig_addr, recomp_addr)
+    orig_refs_index: dict[tuple[int, tuple], list[int]] = {}
+
+    for ent in db.unmatched(ImageId.ORIG):
+        ref = ent.get("ref_orig")
+        disp = ent.get("displacement")
+
+        # Only valid refs
+        if not ref or not disp:
+            continue
+
+        # Only matched parents
+        parent = db.get(ImageId.ORIG, ref)
+        if not parent or not parent.matched:
+            continue
+
+        assert isinstance(ent.orig_addr, int)
+        assert isinstance(ref, int)
+        assert isinstance(disp, tuple)
+        # Using ref orig addr as the match key.
+        orig_refs_index.setdefault((ref, disp), []).append(ent.orig_addr)
+
+    for ent in db.unmatched(ImageId.RECOMP):
+        ref = ent.get("ref_recomp")
+        disp = ent.get("displacement")
+
+        # Only valid refs
+        if not ref or not disp:
+            continue
+
+        # Only matched parents
+        parent = db.get(ImageId.RECOMP, ref)
+        if not parent or not parent.matched:
+            continue
+
+        assert parent.orig_addr is not None
+        assert isinstance(ref, int)
+        assert isinstance(disp, tuple)
+        key = (parent.orig_addr, disp)
+
+        if key in orig_refs_index:
+            orig_addr = orig_refs_index[key].pop(0)
+            if not orig_refs_index[key]:
+                del orig_refs_index[key]
+
+            assert isinstance(ent.recomp_addr, int)
+            yield (orig_addr, ent.recomp_addr)

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -30,10 +30,12 @@ def fixture_db():
 def get_ref_addr(db: EntityDb, img: ImageId, addr: int) -> int | None:
     """Helper function to retrieve the ref address from the refs table.
     It is not visible through the ReccmpEntity / ReccmpMatch API."""
-    for (ref,) in db.sql.execute(
-        "SELECT ref FROM refs WHERE img = ? AND addr = ?", (img, addr)
-    ):
-        return ref
+    ent = db.get(img, addr)
+    if ent is not None:
+        key = "ref_orig" if img == ImageId.ORIG else "ref_recomp"
+        ref = ent.get(key)
+        if ref:
+            return ref
 
     return None
 
@@ -43,10 +45,9 @@ def get_ref_displacement(
 ) -> tuple[int, int] | None:
     """Helper function to retrieve the displacement from the refs table.
     It is not visible through the ReccmpEntity / ReccmpMatch API."""
-    for disp in db.sql.execute(
-        "SELECT disp0, disp1 FROM refs WHERE img = ? AND addr = ?", (img, addr)
-    ):
-        return disp
+    ent = db.get(img, addr)
+    if ent is not None:
+        return ent.get("displacement")
 
     return None
 

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -1,6 +1,5 @@
 """Testing compare database behavior, particularly matching"""
 
-import sqlite3
 from unittest.mock import patch
 import pytest
 from reccmp.compare.db import EntityDb
@@ -218,13 +217,18 @@ def test_batch_match_combine_replace_null(db):
     assert db.get(ImageId.RECOMP, 200).get("test") == 123
 
 
-@pytest.mark.xfail(reason="Known limitation.")
-def test_batch_match_create(db):
-    """Matching requires either the orig or recomp entity to exist. It does not create entities."""
+def test_batch_match_create(db: EntityDb):
+    """Matching two addrs will create an entity."""
     with db.batch() as batch:
         batch.match(100, 200)
 
-    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
+    ent = db.get(ImageId.ORIG, 100)
+    assert ent is not None
+    assert ent.recomp_addr == 200
+
+    ent = db.get(ImageId.RECOMP, 200)
+    assert ent is not None
+    assert ent.orig_addr == 100
 
 
 def test_batch_commit_twice(db):
@@ -316,25 +320,6 @@ def test_batch_exception_caught(db):
 
     assert db.get(ImageId.ORIG, 100) is not None
     assert db.get(ImageId.RECOMP, 200) is not None
-
-
-def test_batch_sqlite_exception(db):
-    """Should rollback if an exception occurs during the commit."""
-
-    # Not using batch context for clarity
-    batch = db.batch()
-    batch.set(ImageId.ORIG, 100, name="Test")
-    batch.set(ImageId.RECOMP, 200, test=123)
-
-    # Insert bad data that will cause a binding error
-    batch.match(100, ("bogus",))
-
-    with pytest.raises(sqlite3.Error):
-        batch.commit()
-
-    # Should rollback everything
-    assert db.get(ImageId.ORIG, 100) is None
-    assert db.get(ImageId.RECOMP, 200) is None
 
 
 def test_generic_used_function(db: EntityDb):
@@ -542,3 +527,35 @@ def test_size_functions_matched_recomp_null(db: EntityDb):
     assert entity.any_size() == 1
     assert entity.any_size(ImageId.ORIG) == 1
     assert entity.any_size(ImageId.RECOMP) == 1
+
+
+def test_independent_sets(db: EntityDb):
+    """If we modify a matched entity, the new values should be accessible
+    whether we access the entity via ORIG or RECOMP address space."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Hello")
+        batch.set(ImageId.RECOMP, 200, name="Hello")
+        batch.match(100, 200)
+
+    # baseline
+    ent = db.get(ImageId.RECOMP, 200)
+    assert ent is not None
+    assert ent.get("name") == "Hello"
+
+    # update recomp side
+    with db.batch() as batch:
+        batch.set(ImageId.RECOMP, 200, name="asdf")
+
+    # reflected in orig
+    ent = db.get(ImageId.ORIG, 100)
+    assert ent is not None
+    assert ent.get("name") == "asdf"
+
+    # update orig side
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="test")
+
+    # reflected in recomp
+    ent = db.get(ImageId.RECOMP, 200)
+    assert ent is not None
+    assert ent.get("name") == "test"

--- a/tests/test_compare_db.py
+++ b/tests/test_compare_db.py
@@ -79,8 +79,9 @@ def test_db_all_order(db):
 
 
 def test_get_by_exact(db):
-    """get_by_orig and get_by_recomp have two parameters: the address and the 'exact' option.
-    If exact=False, we return the entity at the address OR one at the preceding address if it exists.
+    """get() has two parameters: the address and the 'exact' option.
+    If exact=False, we return the entity at the address
+    OR one at the preceding address if it exists.
     """
 
     with db.batch() as batch:
@@ -111,7 +112,7 @@ def test_get_by_exact(db):
 
 
 def test_get_by_exact_keyword(db: EntityDb):
-    """For get_by_orig and get_by_recomp, the 'exact' keyword must be used to set its value."""
+    """For get(), the 'exact' keyword must be used to set its value."""
 
     # Should fail if called without the 'exact' keyword.
     # Disable mypy checking for these calls because we've intentionally created a typing error.
@@ -237,12 +238,12 @@ def test_batch_commit_twice(db):
     batch = db.batch()
     batch.set(ImageId.ORIG, 100, name="Test")
 
-    with patch("reccmp.compare.db.EntityDb.bulk_orig_insert") as mock:
+    with patch("reccmp.compare.db.EntityDb.bulk_insert") as mock:
         batch.commit()
         batch.commit()
         mock.assert_called_once()
 
-    with patch("reccmp.compare.db.EntityDb.bulk_orig_insert") as mock:
+    with patch("reccmp.compare.db.EntityDb.bulk_insert") as mock:
         batch.commit()
         mock.assert_not_called()
 

--- a/tests/test_entity_obj.py
+++ b/tests/test_entity_obj.py
@@ -1,6 +1,5 @@
 """Tests related to the ReccmpEntity ORM object"""
 
-import json
 from reccmp.types import EntityType
 from reccmp.compare.db import ReccmpEntity, entity_name_from_string
 
@@ -9,7 +8,7 @@ def create_entity(
     orig_addr: int | None, recomp_addr: int | None, **kwargs
 ) -> ReccmpEntity:
     """Helper to create the JSON string representation of the key/value args."""
-    return ReccmpEntity(orig_addr, recomp_addr, json.dumps(kwargs))
+    return ReccmpEntity(orig_addr, recomp_addr, kwargs)
 
 
 def test_match_name_none():

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -65,7 +65,13 @@ def compare_functions(
         ReccmpMatch(
             ORIG_GLOBAL_OFFSET,
             RECOMP_GLOBAL_OFFSET,
-            f'{{"type":1,"stub":false,"name":"unittest","symbol":"?Unittest","recomp_size":{len(recomp)}}}',
+            {
+                "type": 1,
+                "stub": False,
+                "name": "unittest",
+                "symbol": "?Unittest",
+                "recomp_size": len(recomp),
+            },
         )
     )
 

--- a/tests/test_ghidra_integration_function_imports.py
+++ b/tests/test_ghidra_integration_function_imports.py
@@ -4,7 +4,6 @@
 # pylint: disable=import-outside-toplevel
 # pyright: reportMissingModuleSource=false
 
-import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -47,9 +46,7 @@ def test_import_trivial_function(
         this_adjust=0,
     )
     pdb_function = PdbFunction(
-        ReccmpMatch(
-            function_helper.orig_address, 1234, json.dumps({"name": "MyTestFn"})
-        ),
+        ReccmpMatch(function_helper.orig_address, 1234, {"name": "MyTestFn"}),
         func_signature,
         is_stub=False,
     )
@@ -140,7 +137,7 @@ def test_record_array_access(
         ReccmpMatch(
             function_helper.orig_address,
             1234,  # arbitrary
-            json.dumps({"name": "LegoAnim::GetActorName"}),
+            {"name": "LegoAnim::GetActorName"},
         ),
         func_signature,
         is_stub=False,
@@ -240,7 +237,7 @@ def test_global_array_access(
         ReccmpMatch(
             function_helper.orig_address,
             1234,  # arbitrary
-            json.dumps({"name": "LegoCharacterManager::GetActorName"}),
+            {"name": "LegoCharacterManager::GetActorName"},
         ),
         func_signature,
         is_stub=False,
@@ -342,7 +339,7 @@ def test_global_pointer_access(
         ReccmpMatch(
             function_helper.orig_address,
             1234,  # arbitrary
-            json.dumps({"name": "LegoCharacterManager::GetActorName"}),
+            {"name": "LegoCharacterManager::GetActorName"},
         ),
         func_signature,
         is_stub=False,


### PR DESCRIPTION
Closing the era of the SQLite database with JSON that began back in #25. At the time, I was thinking about:
1. The need to support as-yet-unknown entity attributes.
2. The code complexity required to get good performance from pure-Python.
3. The potential need for thread-safety and atomicity.

None of these have really been a factor in the 18 months since. We don't yet have multi-threaded data import or multi-user support (daemon job) that would demand a locking system. (And it's not like SQL is the only game in town for that.) The list of entity attributes have been somewhat stable for a while. I would say code readability is far worse because of the gymnastics required to get good performance from _SQLite_. (Never materialize `ReccmpEntity` objects and do as much work as possible inside the database at the C layer.)

On top of it all... SQLite isn't faster! The difference is less pronounced with cProfile, but the clock-on-the-wall time is faster. (At least that's the case on my somewhat outdated Windows box with Python 3.14).

There are certainly more optimization steps possible. We should get off the `kvstore` dictionary and just use named properties (with types) on `ReccmpEntity` unless this proves to be a lot slower for some reason. It might not hurt to have an index on `EntityType` since this is the most commonly used attribute in "queries".