### PR TITLE
Derive more data from the finalized `ReccmpStatusReport`

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -68,7 +68,6 @@ logger = logging.getLogger(__name__)
 class Compare:
     # pylint: disable=too-many-instance-attributes
     _db: EntityDb
-    _debug: bool
     _lines_db: LinesDb
     code_files: list[TextFile]
     cvdump_analysis: CvdumpAnalysis
@@ -110,9 +109,6 @@ class Compare:
             self.data_sources = data_sources
         else:
             self.data_sources = []
-
-        # Controls whether we dump the asm output to a file
-        self._debug = False
 
         self._lines_db = LinesDb()
         self._db = EntityDb()
@@ -227,15 +223,6 @@ class Compare:
         )
         compare.run()
         return compare
-
-    @property
-    def debug(self) -> bool:
-        return self._debug
-
-    @debug.setter
-    def debug(self, debug: bool):
-        self._debug = debug
-        self.function_comparator.debug = debug
 
     def _compare_vtable(self, match: ReccmpMatch) -> EntityCompareResult:
         vtable_size = match.any_size()

--- a/reccmp/compare/functions.py
+++ b/reccmp/compare/functions.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dataclasses import dataclass
 from functools import cache
 import struct
@@ -20,10 +19,6 @@ from reccmp.formats.exceptions import (
 )
 from reccmp.formats import Image, PEImage
 from reccmp.types import ImageId
-
-
-def timestamp_string() -> str:
-    return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
 def has_asserts(image: Image) -> bool:
@@ -86,8 +81,6 @@ class FunctionComparator:
     orig_bin: Image
     recomp_bin: Image
     report: ReccmpReportProtocol
-    runid: str = timestamp_string()
-    debug: bool = False
     is_32bit: bool = True
 
     def __post_init__(self):
@@ -111,22 +104,6 @@ class FunctionComparator:
             ),
             is_32bit=self.is_32bit,
         )
-
-    def _dump_asm(self, orig_combined, recomp_combined):
-        """Append the provided assembly output to the debug files"""
-        with open(f"reccmp-{self.runid}-orig.txt", "a", encoding="utf-8") as f:
-            for addr, line in orig_combined:
-                if addr:
-                    f.write(f"{addr:8x}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
-
-        with open(f"reccmp-{self.runid}-recomp.txt", "a", encoding="utf-8") as f:
-            for addr, line in recomp_combined:
-                if addr:
-                    f.write(f"{addr:8x}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
 
     def _source_ref_of_recomp_addr(self, recomp_addr: int | None) -> str | None:
         if recomp_addr is None:
@@ -173,9 +150,6 @@ class FunctionComparator:
 
         orig_combined = self.orig_sanitize.parse_asm(orig_raw, match.orig_addr)
         recomp_combined = self.recomp_sanitize.parse_asm(recomp_raw, match.recomp_addr)
-
-        if self.debug:
-            self._dump_asm(orig_combined, recomp_combined)
 
         # Check for assert calls only if we expect to find them
         if has_asserts(self.orig_bin):

--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -4,7 +4,7 @@ from typing import Literal, Iterable, Iterator
 from pydantic import BaseModel, ValidationError
 from pydantic_core import from_json
 from reccmp.types import EntityType
-from .diff import CombinedDiffOutput, RawDiffOutput, raw_diff_to_udiff
+from .diff import CombinedDiffOutput, DiffReport, RawDiffOutput, raw_diff_to_udiff
 
 
 class ReccmpReportDeserializeError(Exception):
@@ -65,6 +65,21 @@ class ReccmpStatusReport:
             self.timestamp = datetime.now().replace(microsecond=0)
 
         self.entities = {}
+
+    def add_match(self, match: DiffReport):
+        orig_addr = f"0x{match.orig_addr:x}"
+        recomp_addr = f"0x{match.recomp_addr:x}"
+
+        self.entities[orig_addr] = ReccmpComparedEntity(
+            orig_addr=orig_addr,
+            name=match.name,
+            type=match.match_type,
+            accuracy=match.ratio,
+            recomp_addr=recomp_addr,
+            is_effective_match=match.is_effective_match,
+            is_stub=match.is_stub,
+            rdiff=match.result.diff,
+        )
 
     def has_same_source(self, other: "ReccmpStatusReport") -> bool:
         """Were both reports derived from the same reccmp target?"""

--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -31,6 +31,10 @@ class ReccmpComparedEntity:
     # Legacy field for importing version 1 files (aggregate).
     udiff: CombinedDiffOutput | None = None
 
+    @property
+    def effective_accuracy(self) -> float:
+        return 1.0 if self.is_effective_match else self.accuracy
+
 
 class ReccmpStatusReport:
     # The filename of the original binary.
@@ -65,6 +69,54 @@ class ReccmpStatusReport:
     def has_same_source(self, other: "ReccmpStatusReport") -> bool:
         """Were both reports derived from the same reccmp target?"""
         return self.filename.lower() == other.filename.lower()
+
+
+def report_function_alignment(report: ReccmpStatusReport) -> int:
+    """Report the count of all (non-contiguous) functions where
+    the address is the same in both binaries."""
+    count = 0
+    for ent in report.entities.values():
+        if ent.type == EntityType.FUNCTION and ent.orig_addr == ent.recomp_addr:
+            count += 1
+
+    return count
+
+
+def report_function_accuracy(report: ReccmpStatusReport) -> tuple[int, float, float]:
+    """Collects the accuracy and effective accuracy of all compared functions in the report.
+    Returns (function_count, total_accuracy, total_effective_accuracy).
+    Stubs are not compared so they are excluded.
+    The accuracy scores are raw score values. Divide by the function_count to get the percentage.
+    """
+    function_count = 0
+    total_accuracy = 0.0
+    total_effective_accuracy = 0.0
+
+    for ent in report.entities.values():
+        if ent.type == EntityType.FUNCTION and not ent.is_stub:
+            function_count += 1
+            total_accuracy += ent.accuracy
+            total_effective_accuracy += ent.effective_accuracy
+
+    return (function_count, total_accuracy, total_effective_accuracy)
+
+
+def report_progress_stats(report: ReccmpStatusReport) -> tuple[int, float]:
+    """Count comparable functions in the report and sum their effective-match accuracy.
+
+    Returns (implemented_funcs, raw_accuracy). Stubs and non-FUNCTION entities are excluded.
+    Entities with no recorded type (older reports that did not serialize the field) are
+    treated as functions to preserve backward-compatible behavior."""
+    implemented = 0
+    raw_accuracy = 0.0
+    for entity in report.entities.values():
+        if entity.is_stub:
+            continue
+        if entity.type is not None and entity.type != EntityType.FUNCTION:
+            continue
+        implemented += 1
+        raw_accuracy += entity.effective_accuracy
+    return implemented, raw_accuracy
 
 
 def _get_entity_for_addr(

--- a/reccmp/tools/aggregate.py
+++ b/reccmp/tools/aggregate.py
@@ -5,7 +5,7 @@ import argparse
 import logging
 from typing import Sequence
 from pathlib import Path
-from reccmp.utils import diff_json, gen_svg, progress_stats, write_html_report
+from reccmp.utils import diff_json, gen_svg, write_html_report
 from reccmp.compare.report import (
     ReccmpStatusReport,
     combine_reports,
@@ -13,6 +13,7 @@ from reccmp.compare.report import (
     ReccmpReportSameSourceError,
     deserialize_reccmp_report,
     serialize_reccmp_report,
+    report_progress_stats,
 )
 
 logger = logging.getLogger(__name__)
@@ -191,7 +192,7 @@ def main():
             write_html_report(args.html, agg_report)
 
         if args.svg is not None:
-            implemented_funcs, raw_accuracy = progress_stats(agg_report)
+            implemented_funcs, raw_accuracy = report_progress_stats(agg_report)
             if implemented_funcs == 0:
                 logger.error(
                     "No comparable functions in aggregate report; skipping SVG."

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Callable
 import argparse
 import logging
 import os
@@ -24,6 +23,8 @@ from reccmp.compare.report import (
     ReccmpComparedEntity,
     deserialize_reccmp_report,
     serialize_reccmp_report,
+    report_function_alignment,
+    report_function_accuracy,
 )
 from reccmp.types import EntityType
 from reccmp.project.logging import argparse_add_logging_args, argparse_parse_logging
@@ -87,16 +88,16 @@ def print_match_verbose(
 
 
 def print_match_oneline(
-    match: DiffReport, show_both_addrs: bool = False, is_plain: bool = False
+    match: ReccmpComparedEntity, show_both_addrs: bool = False, is_plain: bool = False
 ):
     percenttext = percent_string(
-        match.effective_ratio, match.is_effective_match, is_plain
+        match.effective_accuracy, match.is_effective_match, is_plain
     )
 
     if show_both_addrs:
-        addrs = f"0x{match.orig_addr:x} / 0x{match.recomp_addr:x}"
+        addrs = f"{match.orig_addr} / {match.recomp_addr}"
     else:
-        addrs = hex(match.orig_addr)
+        addrs = match.orig_addr
 
     if match.is_stub:
         print(f"  {match.name} ({addrs}) is a stub.")
@@ -146,6 +147,11 @@ def parse_args() -> argparse.Namespace:
         help="Diff against summary in JSON file",
     )
     parser.add_argument(
+        "--dump",
+        action="store_true",
+        help="Write decompiled assembly to debug files.",
+    )
+    parser.add_argument(
         "--html",
         "-H",
         metavar="<file>",
@@ -181,39 +187,8 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def calculate_alignment(
-    matches: Sequence[DiffReport], should_include_match: Callable[[DiffReport], bool]
-) -> int:
-    count = 0
-    for match in matches:
-        if (
-            match.match_type == EntityType.FUNCTION
-            and match.orig_addr == match.recomp_addr
-            and should_include_match(match)
-        ):
-            count += 1
-
-    return count
-
-
-def calculate_accuracy(
-    matches: Sequence[DiffReport], should_include_match: Callable[[DiffReport], bool]
-) -> tuple[int, float, float]:
-    function_count = 0
-    total_accuracy = 0.0
-    total_effective_accuracy = 0.0
-
-    for match in matches:
-        if match.match_type == EntityType.FUNCTION and should_include_match(match):
-            if not match.is_stub:
-                function_count += 1
-                total_accuracy += match.ratio
-                total_effective_accuracy += match.effective_ratio
-
-    return (function_count, total_accuracy, total_effective_accuracy)
-
-
 def dump_all_matched_functions(matches: Sequence[DiffReport]):
+    logger.info("Creating assembly dump files.")
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     orig_order = sorted(matches, key=lambda m: m.orig_addr)
     recomp_order = sorted(matches, key=lambda m: m.recomp_addr)
@@ -269,6 +244,9 @@ def main():
 
     compared = list(compare.compare_all())
 
+    if args.dump:
+        dump_all_matched_functions(compared)
+
     def should_include_match(match: DiffReport) -> bool:
         if (
             match.match_type == EntityType.FUNCTION
@@ -281,25 +259,6 @@ def main():
 
         return True
 
-    # Count how many functions have the same virtual address in orig and recomp.
-    functions_aligned_count = calculate_alignment(compared, should_include_match)
-
-    # Number of functions compared (i.e. excluding stubs)
-    function_count, total_accuracy, total_effective_accuracy = calculate_accuracy(
-        compared, should_include_match
-    )
-
-    # Print diff summary to terminal
-    if not args.silent and args.diff is None:
-        for match in compared:
-            if should_include_match(match):
-                print_match_oneline(
-                    match, show_both_addrs=args.print_rec_addr, is_plain=args.no_color
-                )
-
-    if args.loglevel == logging.DEBUG:
-        dump_all_matched_functions(compared)
-
     report = ReccmpStatusReport(filename=target.original_path.name)
 
     # Build report:
@@ -308,7 +267,6 @@ def main():
         if not should_include_match(match):
             continue
 
-        # If html, record the diffs to an HTML file
         orig_addr = f"0x{match.orig_addr:x}"
         recomp_addr = f"0x{match.recomp_addr:x}"
 
@@ -322,6 +280,21 @@ def main():
             is_stub=match.is_stub,
             rdiff=match.result.diff,
         )
+
+    # Count how many functions have the same virtual address in orig and recomp.
+    functions_aligned_count = report_function_alignment(report)
+
+    # Number of functions compared (i.e. excluding stubs)
+    function_count, total_accuracy, total_effective_accuracy = report_function_accuracy(
+        report
+    )
+
+    # Print diff summary to terminal
+    if not args.silent and args.diff is None:
+        for entity in report.entities.values():
+            print_match_oneline(
+                entity, show_both_addrs=args.print_rec_addr, is_plain=args.no_color
+            )
 
     # Compare with saved diff report.
     if args.diff is not None:

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Callable
 import argparse
 import logging
 import os
@@ -178,6 +181,62 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
+def calculate_alignment(
+    matches: Sequence[DiffReport], should_include_match: Callable[[DiffReport], bool]
+) -> int:
+    count = 0
+    for match in matches:
+        if (
+            match.match_type == EntityType.FUNCTION
+            and match.orig_addr == match.recomp_addr
+            and should_include_match(match)
+        ):
+            count += 1
+
+    return count
+
+
+def calculate_accuracy(
+    matches: Sequence[DiffReport], should_include_match: Callable[[DiffReport], bool]
+) -> tuple[int, float, float]:
+    function_count = 0
+    total_accuracy = 0.0
+    total_effective_accuracy = 0.0
+
+    for match in matches:
+        if match.match_type == EntityType.FUNCTION and should_include_match(match):
+            if not match.is_stub:
+                function_count += 1
+                total_accuracy += match.ratio
+                total_effective_accuracy += match.effective_ratio
+
+    return (function_count, total_accuracy, total_effective_accuracy)
+
+
+def dump_all_matched_functions(matches: Sequence[DiffReport]):
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    orig_order = sorted(matches, key=lambda m: m.orig_addr)
+    recomp_order = sorted(matches, key=lambda m: m.recomp_addr)
+
+    with open(f"reccmp-{timestamp}-orig.txt", "w+", encoding="utf-8") as f:
+        for match in orig_order:
+            f.write(f"; {match.name}\n")
+            for addr, line in match.result.diff.orig_inst:
+                if addr:
+                    f.write(f"{addr:10}: {line}\n")
+                else:
+                    f.write(f"        : {line}\n")
+
+    with open(f"reccmp-{timestamp}-recomp.txt", "w+", encoding="utf-8") as f:
+        for match in recomp_order:
+            f.write(f"; {match.name}\n")
+            for addr, line in match.result.diff.recomp_inst:
+                if addr:
+                    f.write(f"{addr:10}: {line}\n")
+                else:
+                    f.write(f"        : {line}\n")
+
+
 def main():
     args = parse_args()
 
@@ -190,9 +249,6 @@ def main():
     logging.basicConfig(level=args.loglevel, format="[%(levelname)s] %(message)s")
 
     compare = Compare.from_target(target)
-
-    if args.loglevel == logging.DEBUG:
-        compare.debug = True
 
     print()
 
@@ -211,41 +267,46 @@ def main():
 
     ### Compare everything.
 
-    # Count how many functions have the same virtual address in orig and recomp.
-    functions_aligned_count = 0
+    compared = list(compare.compare_all())
 
-    # Number of functions compared (i.e. excluding stubs)
-    function_count = 0
-    total_accuracy = 0.0
-    total_effective_accuracy = 0.0
-
-    report = ReccmpStatusReport(filename=target.original_path.name)
-
-    for match in compare.compare_all():
-        # if we are ignoring this function, skip to next one and don't add it to the entities list
+    def should_include_match(match: DiffReport) -> bool:
         if (
             match.match_type == EntityType.FUNCTION
             and match.name in target.report_config.ignore_functions
         ):
-            continue
+            return False
+
         if args.nolib and match.is_library:
+            return False
+
+        return True
+
+    # Count how many functions have the same virtual address in orig and recomp.
+    functions_aligned_count = calculate_alignment(compared, should_include_match)
+
+    # Number of functions compared (i.e. excluding stubs)
+    function_count, total_accuracy, total_effective_accuracy = calculate_accuracy(
+        compared, should_include_match
+    )
+
+    # Print diff summary to terminal
+    if not args.silent and args.diff is None:
+        for match in compared:
+            if should_include_match(match):
+                print_match_oneline(
+                    match, show_both_addrs=args.print_rec_addr, is_plain=args.no_color
+                )
+
+    if args.loglevel == logging.DEBUG:
+        dump_all_matched_functions(compared)
+
+    report = ReccmpStatusReport(filename=target.original_path.name)
+
+    # Build report:
+    for match in compared:
+        # if we are ignoring this function, skip to next one and don't add it to the entities list
+        if not should_include_match(match):
             continue
-
-        if not args.silent and args.diff is None:
-            print_match_oneline(
-                match, show_both_addrs=args.print_rec_addr, is_plain=args.no_color
-            )
-
-        if (
-            match.match_type == EntityType.FUNCTION
-            and match.orig_addr == match.recomp_addr
-        ):
-            functions_aligned_count += 1
-
-        if match.match_type == EntityType.FUNCTION and not match.is_stub:
-            function_count += 1
-            total_accuracy += match.ratio
-            total_effective_accuracy += match.effective_ratio
 
         # If html, record the diffs to an HTML file
         orig_addr = f"0x{match.orig_addr:x}"

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -247,25 +247,21 @@ def main():
     if args.dump:
         dump_all_matched_functions(compared)
 
-    def should_include_match(match: DiffReport) -> bool:
-        if (
-            match.match_type == EntityType.FUNCTION
-            and match.name in target.report_config.ignore_functions
-        ):
-            return False
-
-        if args.nolib and match.is_library:
-            return False
-
-        return True
-
     report = ReccmpStatusReport(filename=target.original_path.name)
 
     # Build report:
     for match in compared:
         # if we are ignoring this function, skip to next one and don't add it to the entities list
-        if should_include_match(match):
-            report.add_match(match)
+        if (
+            match.match_type == EntityType.FUNCTION
+            and match.name in target.report_config.ignore_functions
+        ):
+            continue
+
+        if args.nolib and match.is_library:
+            continue
+
+        report.add_match(match)
 
     # Count how many functions have the same virtual address in orig and recomp.
     functions_aligned_count = report_function_alignment(report)

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -264,22 +264,8 @@ def main():
     # Build report:
     for match in compared:
         # if we are ignoring this function, skip to next one and don't add it to the entities list
-        if not should_include_match(match):
-            continue
-
-        orig_addr = f"0x{match.orig_addr:x}"
-        recomp_addr = f"0x{match.recomp_addr:x}"
-
-        report.entities[orig_addr] = ReccmpComparedEntity(
-            orig_addr=orig_addr,
-            name=match.name,
-            type=match.match_type,
-            accuracy=match.effective_ratio,
-            recomp_addr=recomp_addr,
-            is_effective_match=match.is_effective_match,
-            is_stub=match.is_stub,
-            rdiff=match.result.diff,
-        )
+        if should_include_match(match):
+            report.add_match(match)
 
     # Count how many functions have the same virtual address in orig and recomp.
     functions_aligned_count = report_function_alignment(report)

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -334,9 +334,6 @@ def main():
 
     compare = Compare.from_target(target)
 
-    if args.loglevel == logging.DEBUG:
-        compare.debug = True
-
     print()
 
     match = compare.compare_address(args.address)

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -10,7 +10,6 @@ from reccmp.compare.report import (
     ReccmpComparedEntity,
     serialize_reccmp_report,
 )
-from reccmp.types import EntityType
 
 
 def reccmp_pack_generator(lines: Iterable[str]) -> Iterator[str]:
@@ -43,24 +42,6 @@ def read_js_file(filename: str) -> str:
 
     file_header = f"/{'*' * 78}/\n// {filename}\n"
     return file_header + "".join(lines)
-
-
-def progress_stats(report: ReccmpStatusReport) -> tuple[int, float]:
-    """Count comparable functions in the report and sum their effective-match accuracy.
-
-    Returns (implemented_funcs, raw_accuracy). Stubs and non-FUNCTION entities are excluded.
-    Entities with no recorded type (older reports that did not serialize the field) are
-    treated as functions to preserve backward-compatible behavior."""
-    implemented = 0
-    raw_accuracy = 0.0
-    for entity in report.entities.values():
-        if entity.is_stub:
-            continue
-        if entity.type is not None and entity.type != EntityType.FUNCTION:
-            continue
-        implemented += 1
-        raw_accuracy += entity.accuracy
-    return implemented, raw_accuracy
 
 
 # pylint: disable=too-many-positional-arguments
@@ -272,7 +253,9 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
             new_pct = (
                 "stub"
                 if new.is_stub
-                else percent_string(new.accuracy, new.is_effective_match, is_plain)
+                else percent_string(
+                    new.effective_accuracy, new.is_effective_match, is_plain
+                )
             )
 
             # Prefer the current name of this function if we have it.
@@ -285,7 +268,9 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
             old_pct = (
                 "stub"
                 if saved.is_stub
-                else percent_string(saved.accuracy, saved.is_effective_match, is_plain)
+                else percent_string(
+                    saved.effective_accuracy, saved.is_effective_match, is_plain
+                )
             )
 
             if name == "":
@@ -379,7 +364,10 @@ def diff_json(
         for key, (saved, new) in combined.items()
         if saved is not None
         and new is not None
-        and (new.accuracy > saved.accuracy or (not new.is_stub and saved.is_stub))
+        and (
+            new.effective_accuracy > saved.effective_accuracy
+            or (not new.is_stub and saved.is_stub)
+        )
     }
 
     # Any non-stub function with decreased match percentage
@@ -388,7 +376,7 @@ def diff_json(
         for key, (saved, new) in combined.items()
         if saved is not None
         and new is not None
-        and new.accuracy < saved.accuracy
+        and new.effective_accuracy < saved.effective_accuracy
         and not saved.is_stub
         and not new.is_stub
     }
@@ -399,8 +387,8 @@ def diff_json(
         for key, (saved, new) in combined.items()
         if saved is not None
         and new is not None
-        and new.accuracy == 1.0
-        and saved.accuracy == 1.0
+        and new.effective_accuracy == 1.0
+        and saved.effective_accuracy == 1.0
         and new.is_effective_match != saved.is_effective_match
     }
 

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -12,6 +12,9 @@ from reccmp.compare.report import (
     ReccmpComparedEntity,
     deserialize_reccmp_report,
     serialize_reccmp_report,
+    report_function_alignment,
+    report_function_accuracy,
+    report_progress_stats,
 )
 from reccmp.types import EntityType, ImageId
 from reccmp.cvdump import CvdumpAnalysis
@@ -39,7 +42,7 @@ def to_report(compare: Compare) -> ReccmpStatusReport:
             orig_addr=orig_addr,
             name=match.name,
             type=match.match_type,
-            accuracy=match.effective_ratio,
+            accuracy=match.ratio,
             recomp_addr=recomp_addr,
             is_effective_match=match.is_effective_match,
             is_stub=match.is_stub,
@@ -254,7 +257,9 @@ def test_compare_function_effective_match():
 
     e = report.entities["0x0"]
     assert e is not None
-    assert e.accuracy == 1.0
+    # Should retain non-effective accuracy.
+    assert e.accuracy != 1.0
+    assert e.effective_accuracy == 1.0
     assert e.is_effective_match is True
 
     udiff = get_udiff(e)
@@ -451,3 +456,136 @@ def test_aggregate_workflow():
     # We should be able to serialize with and without diff data.
     serialize_reccmp_report(report, diff_included=False)
     serialize_reccmp_report(report, diff_included=True)
+
+
+def test_report_function_alignment():
+    def test_entity(
+        orig_addr: int, recomp_addr: int, entity_type: EntityType
+    ) -> tuple[str, ReccmpComparedEntity]:
+        return (
+            hex(orig_addr),
+            ReccmpComparedEntity(
+                orig_addr=hex(orig_addr),
+                recomp_addr=hex(recomp_addr),
+                name="hello",
+                accuracy=1.0,
+                type=entity_type,
+            ),
+        )
+
+    report = ReccmpStatusReport(filename="test")
+
+    # Baseline
+    report.entities = {}
+    assert report_function_alignment(report) == 0
+
+    # Non-contiguous alignment allowed
+    report.entities = dict(
+        [
+            test_entity(0, 0, EntityType.FUNCTION),
+            test_entity(1, 4, EntityType.FUNCTION),
+            test_entity(5, 5, EntityType.FUNCTION),
+        ]
+    )
+    assert report_function_alignment(report) == 2
+
+    # Vtables ignored
+    report.entities = dict(
+        [
+            test_entity(0, 0, EntityType.FUNCTION),
+            test_entity(5, 5, EntityType.VTABLE),
+        ]
+    )
+    assert report_function_alignment(report) == 1
+
+
+def test_report_function_accuracy():
+    """report_function_accuracy and report_progress_stats are similar, so test both here to save space."""
+
+    def test_entity(
+        addr: int,
+        entity_type: EntityType | None,
+        accuracy: float,
+        *,
+        effective: bool = False,
+        stub: bool = False,
+    ) -> tuple[str, ReccmpComparedEntity]:
+        return (
+            hex(addr),
+            ReccmpComparedEntity(
+                orig_addr=hex(addr),
+                recomp_addr=hex(addr),
+                name="hello",
+                accuracy=accuracy,
+                type=entity_type,
+                is_stub=stub,
+                is_effective_match=effective,
+            ),
+        )
+
+    report = ReccmpStatusReport(filename="test")
+
+    # Baseline
+    report.entities = {}
+    assert report_function_accuracy(report) == (0, 0, 0)
+    assert report_progress_stats(report) == (0, 0)
+
+    # All matching
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.FUNCTION, 1.0),
+            test_entity(1, EntityType.FUNCTION, 1.0),
+        ]
+    )
+    assert report_function_accuracy(report) == (2, 2.0, 2.0)
+    assert report_progress_stats(report) == (2, 2.0)
+
+    # Some diffs
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.FUNCTION, 1.0),
+            test_entity(1, EntityType.FUNCTION, 0.5),
+        ]
+    )
+    assert report_function_accuracy(report) == (2, 1.5, 1.5)
+    assert report_progress_stats(report) == (2, 1.5)
+
+    # Effective match
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.FUNCTION, 1.0),
+            test_entity(1, EntityType.FUNCTION, 0.5, effective=True),
+        ]
+    )
+    assert report_function_accuracy(report) == (2, 1.5, 2.0)
+    assert report_progress_stats(report) == (2, 2.0)
+
+    # Stubs ignored
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.FUNCTION, 0.8),
+            test_entity(1, EntityType.FUNCTION, 0.5, stub=True),
+        ]
+    )
+    assert report_function_accuracy(report) == (1, 0.8, 0.8)
+    assert report_progress_stats(report) == (1, 0.8)
+
+    # Vtables ignored
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.VTABLE, 1.0),
+        ]
+    )
+    assert report_function_accuracy(report) == (0, 0, 0)
+    assert report_progress_stats(report) == (0, 0)
+
+    # Progress stats assumes type=None is a function.
+    # This is to preserve compatibility with files that existed before #392.
+    report.entities = dict(
+        [
+            test_entity(0, EntityType.FUNCTION, 1.0),
+            test_entity(1, None, 0.5),
+        ]
+    )
+    assert report_function_accuracy(report) == (1, 1.0, 1.0)
+    assert report_progress_stats(report) == (2, 1.5)

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -35,19 +35,7 @@ def to_report(compare: Compare) -> ReccmpStatusReport:
     The goal is to see the state of the data after serialization."""
     report = ReccmpStatusReport(filename=compare.target_id)
     for match in compare.compare_all():
-        orig_addr = f"0x{match.orig_addr:x}"
-        recomp_addr = f"0x{match.recomp_addr:x}"
-
-        report.entities[orig_addr] = ReccmpComparedEntity(
-            orig_addr=orig_addr,
-            name=match.name,
-            type=match.match_type,
-            accuracy=match.ratio,
-            recomp_addr=recomp_addr,
-            is_effective_match=match.is_effective_match,
-            is_stub=match.is_stub,
-            rdiff=match.result.diff,
-        )
+        report.add_match(match)
 
     json_text = serialize_reccmp_report(report, diff_included=True)
     return deserialize_reccmp_report(json_text)

--- a/tests/test_function_comparator.py
+++ b/tests/test_function_comparator.py
@@ -59,7 +59,7 @@ def compare_functions(
     recomp_bin.is_relocated_addr = is_relocated_addr or Mock(return_value=False)
     recomp_bin.is_debug = Mock(return_value=False)
 
-    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report, "unittest")
+    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report)
 
     return comp.compare_function(
         ReccmpMatch(
@@ -592,7 +592,7 @@ def test_compare_without_distinct_size(
     orig_bin = RawImage.from_memory(orig_code)
     recomp_bin = RawImage.from_memory(recomp_code)
 
-    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report, "unittest")
+    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report)
     (entity,) = list(db.get_functions())
     diffreport = comp.compare_function(entity)
 
@@ -629,7 +629,7 @@ def test_compare_with_distinct_size(
     orig_bin = RawImage.from_memory(orig_code)
     recomp_bin = RawImage.from_memory(recomp_code)
 
-    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report, "unittest")
+    comp = FunctionComparator(db, lines_db, orig_bin, recomp_bin, report)
     (entity,) = list(db.get_functions())
     diffreport = comp.compare_function(entity)
 

--- a/webui/e2e/entityTable.spec.js
+++ b/webui/e2e/entityTable.spec.js
@@ -12,3 +12,9 @@ test('Entity names with HTML-escaped characters', async ({ page }) => {
   await expect(page.locator('tr[data-address]').getByText('list<ROI *,allocator<ROI *> >::_Buynode')).toBeAttached();
   await expect(page.locator('tr[data-address]').getByText("MxParam::`scalar deleting destructor'")).toBeAttached();
 });
+
+test('Effective match display', async ({ page }) => {
+  // Should display '100.00%*' for effective matches even though the raw accuracy is less than 1.
+  const effectiveRow = page.locator('tr[data-address]').filter({ hasText: 'WndProc' });
+  await expect(effectiveRow).toContainText('100.00%*');
+});

--- a/webui/testdata.json
+++ b/webui/testdata.json
@@ -255,7 +255,7 @@
         ]
       ],
       "effective": true,
-      "matching": 1.0,
+      "matching": 0.8,
       "name": "WndProc",
       "recomp": "0x501d20"
     },
@@ -380,7 +380,7 @@
         ]
       ],
       "effective": true,
-      "matching": 1.0,
+      "matching": 0.8,
       "name": "_MemPoolPreAllocate@12",
       "recomp": "0x503180"
     },
@@ -635,7 +635,7 @@
         ]
       ],
       "effective": true,
-      "matching": 1.0,
+      "matching": 0.8,
       "name": "_MemReAllocPtr@12",
       "recomp": "0x504260"
     },
@@ -681,7 +681,7 @@
         ]
       ],
       "effective": true,
-      "matching": 1.0,
+      "matching": 0.8,
       "name": "@_shi_resizeAny@16",
       "recomp": "0x5043b0"
     },
@@ -1518,7 +1518,7 @@
         ]
       ],
       "effective": true,
-      "matching": 1.0,
+      "matching": 0.9,
       "name": "@shi_isBlockInUseSmall@8",
       "recomp": "0x507530"
     },


### PR DESCRIPTION
Until #307, it was not possible to access the full generated asm for a function outside of the function comparator. The debug feature that dumps all assembly in both binaries to two files can now be moved up to `asmcmp.py`. We no longer need a `debug` option in `Compare` and `FunctionComparator` to enable the debug dump, so this is removed.

As of #371, `--debug` is now used to display matching errors and other `logging.DEBUG` messages. Dumping the asm files is now enabled via the `--dump` option on `asmcmp.py`. A user may want to see matching errors but not create a lot of unneeded files.

The main loop on compared entities in `asmcmp.py` does a lot of work inline:
- Create the `ReccmpStatusReport`
- Prints the oneline diff summary of all entities
- Count aligned functions
- Compute raw accuracy and effective accuracy

Since all of these can be derived from the report data, I created new utility functions to do this. I moved the SVG progress function from #392 so they are now all neighbors in `report.py`. There are a few quick-n-dirty tests to demonstrate the behavior.

To make this possible I had to make a slight change to `ReccmpComparedEntity` that should be seamless. We had been storing `100.0` as the accuracy for effective matches, so the raw accuracy was lost. However, because we have always recorded `is_effective_match`, it's possible to use the raw accuracy instead and compute effective accuracy whenever it's needed.