### PR TITLE
Add `__fastcall` to Ghidra call type map

### DIFF
--- a/reccmp/ghidra/importer/pdb_extraction.py
+++ b/reccmp/ghidra/importer/pdb_extraction.py
@@ -60,6 +60,7 @@ class PdbFunctionExtractor:
         "ThisCall": "__thiscall",
         "C Near": "default",
         "STD Near": "__stdcall",
+        "Fast Near": "__fastcall",
     }
 
     def _get_cvdump_type(


### PR DESCRIPTION
Function:
```cpp
void __fastcall GolMath::FUN_1002f4e0(const GolVec2*, GolVec2*)
{
  // ...
}
```

Cvdump:
```
0x107f : Length = 26, Leaf = 0x1009 LF_MFUNCTION
      Return type = T_VOID(0003), Class type = 0x1073, This type = T_NOTYPE(0000),
      Call type = Fast Near, Func attr = none
      Parms = 2, Arg list type = 0x107e, This adjust = 0

0x109a : Length = 294, Leaf = 0x1203 LF_FIELDLIST
      list[0] = LF_ONEMETHOD, public, STATIC, index = 0x1075, name = 'FUN_00449170'
      list[1] = LF_ONEMETHOD, public, STATIC, index = 0x1079, name = 'FUN_00449190'
      list[2] = LF_ONEMETHOD, public, STATIC, index = 0x107F, name = 'FUN_1002f4e0'
      ...
```