### PR TITLE
Display implemented and accuracy percentages separately

### DIFF
--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -267,9 +267,7 @@ def main():
     functions_aligned_count = report_function_alignment(report)
 
     # Number of functions compared (i.e. excluding stubs)
-    function_count, total_accuracy, total_effective_accuracy = report_function_accuracy(
-        report
-    )
+    function_count, _, total_effective_accuracy = report_function_accuracy(report)
 
     # Print diff summary to terminal
     if not args.silent and args.diff is None:
@@ -319,15 +317,22 @@ def main():
         function_count = max(function_count, int(args.total))
 
     if function_count > 0:
-        effective_accuracy = total_effective_accuracy / function_count * 100
-        actual_accuracy = total_accuracy / function_count * 100
+        implemented = implemented_funcs / function_count * 100
+        effective_accuracy = total_effective_accuracy / implemented_funcs * 100
+        # actual_accuracy = total_accuracy / implemented_funcs * 100
+        progress = total_effective_accuracy / function_count * 100
         alignment_percentage = functions_aligned_count / function_count * 100
+
         print(
-            f"\nTotal effective accuracy {effective_accuracy:.2f}% across {function_count} functions ({actual_accuracy:.2f}% actual accuracy)"
+            f"\nImplemented:  {implemented:.2f}%  ({implemented_funcs} / {function_count})"
         )
-        print(
-            f"{functions_aligned_count} functions are aligned ({alignment_percentage:.2f}%)"
-        )
+        print(f"Accuracy:     {effective_accuracy:.2f}%")
+        print(f"Progress:     {progress:.2f}%")
+
+        if functions_aligned_count > 0:
+            print(
+                f"{functions_aligned_count} functions are aligned ({alignment_percentage:.2f}%)"
+            )
 
         if args.svg is not None:
             gen_svg(

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -271,9 +271,6 @@ def main():
         report
     )
 
-    # Add known but unmatched functions to our count
-    function_count += compare.count_unmatched_functions()
-
     # Print diff summary to terminal
     if not args.silent and args.diff is None:
         for entity in report.entities.values():
@@ -311,6 +308,9 @@ def main():
         write_html_report(args.html, report)
 
     implemented_funcs = function_count
+
+    # Add known but unmatched functions to our count
+    function_count += compare.count_unmatched_functions()
 
     # If we know how many functions are in the file (via analysis with Ghidra or other tools)
     # we can substitute an alternate value to use when calculating the percentages below.


### PR DESCRIPTION
A more comprehensive realization of #343 (and fixing a bug introduced by #407).

Accuracy summary now matches the SVG display:
```
Implemented:  23.65%  (931 / 3936)
Accuracy:     98.73%
Progress:     23.35%
```
The accuracy value is the effective accuracy: functions with commutative diffs upgraded to 100%. Progress is simply `implemented_pct * accuracy`.