### PR TITLE
`roadmap`: Avoid `IndexError` crash if there are no section contributions

### DIFF
--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -69,6 +69,10 @@ class ModuleMap:
         ]
 
     def get_module(self, addr: int) -> tuple[str, str] | None:
+        # Avoid a crash if we did not read any section contributions.
+        if not self.section_contrib:
+            return None
+
         i = bisect.bisect_left(self.contrib_starts, addr)
         # If the addr matches the section contribution start, we are in the
         # right spot. Otherwise, we need to subtract one here.


### PR DESCRIPTION
`reccmp-roadmap` will crash if we did not read any section contributions from the PDB.

Error:
```
  File "C:\work\reccmp\reccmp\tools\roadmap.py", line 427, in to_roadmap_row
    if (module_ref := module_map.get_module(match.recomp_addr)) is not None:
                      ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "C:\work\reccmp\reccmp\tools\roadmap.py", line 78, in get_module
    potential_start, _, __ = self.section_contrib[i]
                             ~~~~~~~~~~~~~~~~~~~~^^^
```

You can simulate by commenting out a line in `runner.py`. This causes us to never order section contributions when calling `cvdump.exe`:

```python
def section_contributions(self):
    # self.options.add(DumpOpt.SECTION_CONTRIB)
    return self
```
