### PR TITLE
Import library functions by name

### DIFF
--- a/reccmp/ghidra/importer/function_importer.py
+++ b/reccmp/ghidra/importer/function_importer.py
@@ -82,9 +82,9 @@ class PdbFunctionImporter(ABC):
         name_substitutions: CompiledRegexReplacements,
     ):
         return (
-            ThunkPdbFunctionImport(api, func, type_importer, name_substitutions)
+            PdbFunctionImporterNameOnly(api, func, type_importer, name_substitutions)
             if func.signature is None
-            else FullPdbFunctionImporter(api, func, type_importer, name_substitutions)
+            else PdbFunctionImporterFull(api, func, type_importer, name_substitutions)
         )
 
     @abstractmethod
@@ -94,8 +94,9 @@ class PdbFunctionImporter(ABC):
     def overwrite_ghidra_function(self, ghidra_function: Function): ...
 
 
-class ThunkPdbFunctionImport(PdbFunctionImporter):
-    """For importing thunk functions (like vtordisp or debug build thunks) into Ghidra.
+class PdbFunctionImporterNameOnly(PdbFunctionImporter):
+    """For importing functions known only by name (e.g. vtordisp, debug build thunks,
+    or library functions without signature) into Ghidra.
     Only the name of the function will be imported."""
 
     def matches_ghidra_function(self, ghidra_function: Function) -> bool:
@@ -112,7 +113,7 @@ class ThunkPdbFunctionImport(PdbFunctionImporter):
 
 
 # pylint: disable=too-many-instance-attributes
-class FullPdbFunctionImporter(PdbFunctionImporter):
+class PdbFunctionImporterFull(PdbFunctionImporter):
     """For importing functions into Ghidra where all information are available."""
 
     def __init__(

--- a/reccmp/ghidra/importer/pdb_extraction.py
+++ b/reccmp/ghidra/importer/pdb_extraction.py
@@ -68,7 +68,7 @@ class PdbFunctionExtractor:
     ) -> CvdumpParsedType | None:
         return None if type_key is None else self.compare.types.keys.get(type_key)
 
-    def get_func_signature(self, fn: SymbolsEntry) -> FunctionSignature | None:
+    def _get_func_signature(self, fn: SymbolsEntry) -> FunctionSignature | None:
         function_type_key = fn.func_type
         if function_type_key == CVInfoTypeEnum.T_NOTYPE:
             logger.debug("Treating NOTYPE function as thunk: %s", fn.name)
@@ -129,12 +129,12 @@ class PdbFunctionExtractor:
 
     def get_function_list(self) -> list[PdbFunction]:
         handled = (
-            self.handle_matched_function(match)
+            self._handle_matched_function(match)
             for match in self.compare.get_functions()
         )
         return [signature for signature in handled if signature is not None]
 
-    def handle_matched_function(self, match_info: ReccmpMatch) -> PdbFunction | None:
+    def _handle_matched_function(self, match_info: ReccmpMatch) -> PdbFunction | None:
         function_data = next(
             (
                 y
@@ -148,7 +148,7 @@ class PdbFunctionExtractor:
                 # this can be either a thunk (which we want) or an external function
                 # (which we don't want), so we tell them apart based on the validity of their address.
                 self.compare.orig_bin.get_relative_addr(match_info.orig_addr)
-                return PdbFunction(match_info, None, False)
+                return PdbFunction(match_info, None, is_stub=False)
             except InvalidVirtualAddressError:
                 logger.debug(
                     "Skipping external function %s (address 0x%x not in original binary)",
@@ -160,12 +160,12 @@ class PdbFunctionExtractor:
         function_symbol = function_data.symbol_entry
         if function_symbol is None:
             logger.debug(
-                "Could not find function symbol (likely a PUBLICS entry): %s",
+                "Could not find function symbol '%s' (likely a PUBLICS entry), importing by name only",
                 match_info.name,
             )
-            return None
+            return PdbFunction(match_info, None, is_stub=False)
 
-        function_signature = self.get_func_signature(function_symbol)
+        function_signature = self._get_func_signature(function_symbol)
 
         is_stub = bool(match_info.get("stub", False))
 

--- a/tests/test_ghidra_integration_function_imports.py
+++ b/tests/test_ghidra_integration_function_imports.py
@@ -65,6 +65,71 @@ void MyTestFn(void)
 """)
 
 
+def test_import_without_signature(
+    ghidra: "FlatProgramAPI",
+    function_helper: GhidraFunctionTestHelper,
+    type_helper: GhidraTypeTestHelper,
+):
+    from reccmp.ghidra.importer.function_importer import (
+        PdbFunctionImporter,
+        PdbFunction,
+    )
+
+    function_helper.overwrite_example_function(b"\xc3")
+
+    # Part 1: Import a function with non-trivial signature
+    func_signature = FunctionSignature(
+        call_type="__cdecl",
+        arglist=[CVInfoTypeEnum.T_INT4],
+        return_type=CVInfoTypeEnum.T_VOID,
+        class_type=None,
+        stack_symbols=[
+            CppStackSymbol("p_mockParam", CVInfoTypeEnum.T_INT4, 4),
+        ],
+        this_adjust=0,
+    )
+    pdb_function = PdbFunction(
+        ReccmpMatch(function_helper.orig_address, 1234, {"name": "MyTestFnPart1"}),
+        func_signature,
+        is_stub=False,
+    )
+
+    PdbFunctionImporter.build(
+        ghidra, pdb_function, type_helper.type_importer, []
+    ).overwrite_ghidra_function(function_helper.ghidra_function)
+
+    function_helper.assert_c_code("""
+void __cdecl MyTestFnPart1(int p_mockParam)
+
+{
+  return;
+}
+
+""")
+
+    # Part 2: Pretend that the previous function was detected by Ghidra
+    # and that we want to overwrite it with a function whose signature is unknown.
+    # The import is expected to change the name and preserve the signature.
+
+    second_pdb_function = PdbFunction(
+        ReccmpMatch(function_helper.orig_address, 1234, {"name": "MyTestFnPart2"}),
+        signature=None,
+        is_stub=False,
+    )
+    PdbFunctionImporter.build(
+        ghidra, second_pdb_function, type_helper.type_importer, []
+    ).overwrite_ghidra_function(function_helper.ghidra_function)
+
+    function_helper.assert_c_code("""
+void __cdecl MyTestFnPart2(int p_mockParam)
+
+{
+  return;
+}
+
+""")
+
+
 def test_record_array_access(
     ghidra: "FlatProgramAPI",
     function_helper: GhidraFunctionTestHelper,


### PR DESCRIPTION
A lot of the RACERS library functions did not get imported into Ghidra because they don't have function signature information in the PDB. It was quite easy to get the function names imported, though.

Also contains small drive-by improvements (test coverage for Ghidra name-only function import, small refactors).