### PR TITLE
Fix IndexError in asm patch helpers when recomp shorter than orig

### DIFF
--- a/reccmp/compare/asm/fixes.py
+++ b/reccmp/compare/asm/fixes.py
@@ -97,6 +97,7 @@ def patch_mov_compare_jmp(
     # return if not found, or only found on first or last line
     if (
         cmp_index in (-1, 0, len(orig) - 1)
+        or cmp_index >= len(recomp) - 1
         or
         # recomp should also have a cmp in the same line
         not recomp[cmp_index].startswith(cmp_instruction)
@@ -212,6 +213,7 @@ def patch_compare_jmp(
     # return if not found, or only found on the last line
     if (
         cmp_index in (-1, len(orig) - 1)
+        or cmp_index >= len(recomp) - 1
         or
         # recomp should also have a cmp in the same line
         not recomp[cmp_index].startswith(cmp_instruction)
@@ -249,6 +251,7 @@ def patch_fld_fmul(orig: list[str], recomp: list[str]) -> set[int]:
     # return if not found, or only found on the last line
     if (
         fld_index in (-1, len(orig) - 1)
+        or fld_index >= len(recomp) - 1
         or
         # recomp should also have a fld in the same line
         not recomp[fld_index].startswith("fld")

--- a/reccmp/compare/asm/fixes.py
+++ b/reccmp/compare/asm/fixes.py
@@ -95,6 +95,7 @@ def patch_mov_compare_jmp(
     )
 
     # return if not found, or only found on first or last line
+    # pylint: disable=too-many-boolean-expressions
     if (
         cmp_index in (-1, 0, len(orig) - 1)
         or cmp_index >= len(recomp) - 1

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,6 +1,11 @@
 import difflib
 import pytest
-from reccmp.compare.asm.fixes import find_effective_match
+from reccmp.compare.asm.fixes import (
+    find_effective_match,
+    patch_compare_jmp,
+    patch_fld_fmul,
+    patch_mov_compare_jmp,
+)
 
 
 def test_fix_cmp_jmp():
@@ -443,3 +448,28 @@ def test_and_swap_not_allowed():
     is_effective = find_effective_match(diff.get_opcodes(), orig_asm, recomp_asm)
 
     assert is_effective is False
+
+
+def test_patch_compare_jmp_recomp_shorter_than_orig():
+    """Regression: cmp_index found in orig must be bounds-checked against recomp
+    before indexing recomp[cmp_index]. Previously raised IndexError."""
+    orig = ["mov eax, 1", "mov ebx, 2", "cmp eax, ebx", "jg 0x1"]
+    recomp = ["mov eax, 1", "mov ebx, 2"]
+    assert patch_compare_jmp(orig, recomp, "cmp") == set()
+    assert patch_compare_jmp(orig, recomp, "test") == set()
+
+
+def test_patch_mov_compare_jmp_recomp_shorter_than_orig():
+    orig = [
+        "mov eax, dword ptr [ebp-4]",
+        "cmp dword ptr [ebp-8], eax",
+        "jl 0x1",
+    ]
+    recomp = ["mov eax, dword ptr [ebp-4]"]
+    assert patch_mov_compare_jmp(orig, recomp, "cmp") == set()
+
+
+def test_patch_fld_fmul_recomp_shorter_than_orig():
+    orig = ["fld dword ptr [ebp-4]", "fmul dword ptr [ebp-8]"]
+    recomp = ["fld dword ptr [ebp-4]"]
+    assert patch_fld_fmul(orig, recomp) == set()

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -450,26 +450,31 @@ def test_and_swap_not_allowed():
     assert is_effective is False
 
 
-def test_patch_compare_jmp_recomp_shorter_than_orig():
+def test_patch_compare_jmp_cmp_recomp_shorter_than_orig():
     """Regression: cmp_index found in orig must be bounds-checked against recomp
     before indexing recomp[cmp_index]. Previously raised IndexError."""
     orig = ["mov eax, 1", "mov ebx, 2", "cmp eax, ebx", "jg 0x1"]
     recomp = ["mov eax, 1", "mov ebx, 2"]
     assert patch_compare_jmp(orig, recomp, "cmp") == set()
+
+
+def test_patch_compare_jmp_test_recomp_shorter_than_orig():
+    orig = ["mov eax, 1", "mov ebx, 2", "test eax, ebx", "jg 0x1"]
+    recomp = ["mov eax, 1", "mov ebx, 2"]
     assert patch_compare_jmp(orig, recomp, "test") == set()
 
 
 def test_patch_mov_compare_jmp_recomp_shorter_than_orig():
     orig = [
-        "mov eax, dword ptr [ebp-4]",
-        "cmp dword ptr [ebp-8], eax",
+        "mov eax, dword ptr [ebp - 4]",
+        "cmp dword ptr [ebp - 8], eax",
         "jl 0x1",
     ]
-    recomp = ["mov eax, dword ptr [ebp-4]"]
+    recomp = ["mov eax, dword ptr [ebp - 4]"]
     assert patch_mov_compare_jmp(orig, recomp, "cmp") == set()
 
 
 def test_patch_fld_fmul_recomp_shorter_than_orig():
-    orig = ["fld dword ptr [ebp-4]", "fmul dword ptr [ebp-8]"]
-    recomp = ["fld dword ptr [ebp-4]"]
+    orig = ["fld dword ptr [ebp - 4]", "fmul dword ptr [ebp - 8]"]
+    recomp = ["fld dword ptr [ebp - 4]"]
     assert patch_fld_fmul(orig, recomp) == set()


### PR DESCRIPTION
## Summary

The `patch_compare_jmp`, `patch_mov_compare_jmp`, and `patch_fld_fmul`
helpers in `reccmp/compare/asm/fixes.py` find a target instruction
(`cmp`/`test`/`fld`) in the `orig` slice and then index `recomp` at the
same position without first checking that `recomp` is long enough.
When the recompiled disassembly window is shorter than the original
window — which happens in real comparisons when a function diverges
from the original near its end — this raises `IndexError` and aborts
the entire reccmp run.

Stack trace observed against an isledecomp/reccmp 0.1.1 wheel:

```
File ".../reccmp/compare/asm/fixes.py", line 217, in patch_compare_jmp
    not recomp[cmp_index].startswith(cmp_instruction)
        ~~~~~~^^^^^^^^^^^
IndexError: list index out of range
```

## Changes

- Add `cmp_index >= len(recomp) - 1` / `fld_index >= len(recomp) - 1`
  guards to the three affected helpers, matching the style already
  used in `patch_mov_commutative` (which has `inst_index >= len(recomp)`).
- Add three direct unit tests in `tests/test_fixes.py` that exercise
  each helper with a `recomp` slice shorter than `orig`. These tests
  fail with `IndexError` against current `master` and pass with the
  fix applied.

## Test plan

- [x] `pytest tests/test_fixes.py` passes (24 passed, 2 xfailed).
- [x] Reverting `reccmp/compare/asm/fixes.py` and re-running the new
      tests reproduces the original `IndexError` (3 failures).
- [x] End-to-end `reccmp-reccmp --target SERVER` run that previously
      aborted now completes against a real PE target.