### PR TITLE
Support importing `__fastcall` functions into Ghidra (#418)

### DIFF
--- a/reccmp/cvdump/symbols.py
+++ b/reccmp/cvdump/symbols.py
@@ -35,7 +35,7 @@ class SymbolsEntry:
     size: int
     func_type: CvdumpTypeKey
     name: str
-    stack_symbols: list[StackOrRegisterSymbol] = field(default_factory=list)
+    symbols: list[StackOrRegisterSymbol] = field(default_factory=list)
     static_variables: list[LdataEntry] = field(default_factory=list)
     frame_pointer_present: bool = False
     addr: int | None = None  # Absolute address. Will be set later, if at all
@@ -186,7 +186,7 @@ class CvdumpSymbolsParser:
                 data_type=CvdumpTypeKey.from_str(match.group("data_type")),
                 name=match.group("name"),
             )
-            self.current_function.stack_symbols.append(new_symbol)
+            self.current_function.symbols.append(new_symbol)
 
         elif symbol_type == "S_BLOCK32":
             self.block_level += 1

--- a/reccmp/ghidra/importer/exceptions.py
+++ b/reccmp/ghidra/importer/exceptions.py
@@ -43,7 +43,7 @@ class ClassOrNamespaceNotFoundInGhidraError(ReccmpGhidraException):
         return f"Class or namespace not found in Ghidra: {self.get_namespace_str()}"
 
 
-class StackOffsetMismatchError(ReccmpGhidraException):
+class ParameterMismatchError(ReccmpGhidraException):
     pass
 
 

--- a/reccmp/ghidra/importer/function_importer.py
+++ b/reccmp/ghidra/importer/function_importer.py
@@ -21,6 +21,7 @@ from ghidra.program.model.data import (
 from reccmp.cvdump.cvinfo import CVInfoTypeEnum
 
 from .pdb_extraction import (
+    CppStackOrRegisterSymbol,
     PdbFunction,
     CppRegisterSymbol,
     CppStackSymbol,
@@ -256,34 +257,32 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
                 )
                 return False
 
+            # compare argument names
             if ghidra_arg.isStackVariable():
-                # compare argument names
-                symbol_match = self.get_matching_stack_symbol(
+                match: CppStackOrRegisterSymbol | None = self.get_matching_stack_symbol(
                     ghidra_arg.getStackOffset()
                 )
             else:
                 ghidra_register = ghidra_arg.getRegister()
                 assert ghidra_register is not None
-                symbol_match = self.get_matching_register_symbol(
-                    ghidra_register.getName()
-                )
+                match = self.get_matching_register_symbol(ghidra_register.getName())
 
-            if symbol_match is None:
+            if match is None:
                 logger.debug("Not found on stack: %s", ghidra_arg)
                 return False
 
-            if symbol_match.name.startswith("__formal"):
+            if match.name.startswith("__formal"):
                 # "__formal" is the placeholder for arguments without a name
                 continue
 
-            if symbol_match.name == "__$ReturnUdt":
+            if match.name == "__$ReturnUdt":
                 # These appear in templates and cannot be set automatically, as they are a NOTYPE
                 continue
 
-            if symbol_match.name != ghidra_arg.getName():
+            if match.name != ghidra_arg.getName():
                 logger.debug(
                     "Argument name mismatch: expected %s, found %s",
-                    symbol_match.name,
+                    match.name,
                     ghidra_arg.getName(),
                 )
                 return False
@@ -348,7 +347,9 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
 
     def _rename_parameter(self, index: int, param: Parameter):
         if param.isStackVariable():
-            match = self.get_matching_stack_symbol(param.getStackOffset())
+            match: CppStackOrRegisterSymbol | None = self.get_matching_stack_symbol(
+                param.getStackOffset()
+            )
             if match is None:
                 raise ParameterMismatchError(
                     f"Could not find a matching symbol at offset {param.getStackOffset()} in {self.get_full_name()}"

--- a/reccmp/ghidra/importer/function_importer.py
+++ b/reccmp/ghidra/importer/function_importer.py
@@ -32,7 +32,7 @@ from .ghidra_helper import (
 )
 
 from .exceptions import (
-    StackOffsetMismatchError,
+    ParameterMismatchError,
     ReccmpGhidraException,
     TypeNotImplementedError,
 )
@@ -255,24 +255,35 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
                     ghidra_arg.getDataType(),
                 )
                 return False
-            # compare argument names
-            stack_match = self.get_matching_stack_symbol(ghidra_arg.getStackOffset())
-            if stack_match is None:
+
+            if ghidra_arg.isStackVariable():
+                # compare argument names
+                symbol_match = self.get_matching_stack_symbol(
+                    ghidra_arg.getStackOffset()
+                )
+            else:
+                ghidra_register = ghidra_arg.getRegister()
+                assert ghidra_register is not None
+                symbol_match = self.get_matching_register_symbol(
+                    ghidra_register.getName()
+                )
+
+            if symbol_match is None:
                 logger.debug("Not found on stack: %s", ghidra_arg)
                 return False
 
-            if stack_match.name.startswith("__formal"):
+            if symbol_match.name.startswith("__formal"):
                 # "__formal" is the placeholder for arguments without a name
                 continue
 
-            if stack_match.name == "__$ReturnUdt":
+            if symbol_match.name == "__$ReturnUdt":
                 # These appear in templates and cannot be set automatically, as they are a NOTYPE
                 continue
 
-            if stack_match.name != ghidra_arg.getName():
+            if symbol_match.name != ghidra_arg.getName():
                 logger.debug(
                     "Argument name mismatch: expected %s, found %s",
-                    stack_match.name,
+                    symbol_match.name,
                     ghidra_arg.getName(),
                 )
                 return False
@@ -329,26 +340,25 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
 
         # Try to add Ghidra function names
         for index, param in enumerate(ghidra_parameters):
-            if param.isStackVariable():
-                self._rename_stack_parameter(index, param)
-            else:
-                if param.getName() == "this":
-                    # 'this' parameters are auto-generated and cannot be changed
-                    continue
-
-                # Appears to never happen - could in theory be relevant to __fastcall__ functions,
-                # which we haven't seen yet
-                logger.warning(
-                    "Unhandled register variable in %s", self.get_full_name()
-                )
+            if param.isRegisterVariable() and param.getName() == "this":
+                # 'this' parameters are auto-generated and cannot be changed
                 continue
 
-    def _rename_stack_parameter(self, index: int, param: Parameter):
-        match = self.get_matching_stack_symbol(param.getStackOffset())
-        if match is None:
-            raise StackOffsetMismatchError(
-                f"Could not find a matching symbol at offset {param.getStackOffset()} in {self.get_full_name()}"
-            )
+            self._rename_parameter(index, param)
+
+    def _rename_parameter(self, index: int, param: Parameter):
+        if param.isStackVariable():
+            match = self.get_matching_stack_symbol(param.getStackOffset())
+            if match is None:
+                raise ParameterMismatchError(
+                    f"Could not find a matching symbol at offset {param.getStackOffset()} in {self.get_full_name()}"
+                )
+        else:
+            match = self.get_matching_register_symbol(param.getRegister().getName())
+            if match is None:
+                raise ParameterMismatchError(
+                    f"Could not find a matching symbol at register '{param.getRegister()}' in {self.get_full_name()}"
+                )
 
         if match.data_type == CVInfoTypeEnum.T_NOTYPE:
             logger.warning("Skipping stack parameter of type NOTYPE")
@@ -373,7 +383,7 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
         return next(
             (
                 symbol
-                for symbol in self.signature.stack_symbols
+                for symbol in self.signature.symbols
                 if isinstance(symbol, CppStackSymbol)
                 and symbol.stack_offset == stack_offset
             ),
@@ -384,8 +394,9 @@ class PdbFunctionImporterFull(PdbFunctionImporter):
         return next(
             (
                 symbol
-                for symbol in self.signature.stack_symbols
-                if isinstance(symbol, CppRegisterSymbol) and symbol.register == register
+                for symbol in self.signature.symbols
+                if isinstance(symbol, CppRegisterSymbol)
+                and symbol.register == register.lower()
             ),
             None,
         )

--- a/reccmp/ghidra/importer/pdb_extraction.py
+++ b/reccmp/ghidra/importer/pdb_extraction.py
@@ -35,7 +35,7 @@ class FunctionSignature:
     arglist: list[CvdumpTypeKey]
     return_type: CvdumpTypeKey
     class_type: CvdumpTypeKey | None
-    stack_symbols: list[CppStackOrRegisterSymbol]
+    symbols: list[CppStackOrRegisterSymbol]
     # if non-zero: an offset to the `this` parameter in a __thiscall
     this_adjust: int
 
@@ -90,15 +90,15 @@ class PdbFunctionExtractor:
         arg_list_pdb_types = arg_list_type.get("args", [])
         assert arg_list_type["argcount"] == len(arg_list_pdb_types)
 
-        stack_symbols: list[CppStackOrRegisterSymbol] = []
+        symbols: list[CppStackOrRegisterSymbol] = []
 
         # for some unexplained reason, the reported stack is offset by 4 when this flag is set.
         # Note that this affects the arguments (ebp + ...) but not the function stack (ebp - ...)
         stack_offset_delta = -4 if fn.frame_pointer_present else 0
 
-        for symbol in fn.stack_symbols:
+        for symbol in fn.symbols:
             if symbol.symbol_type == "S_REGISTER":
-                stack_symbols.append(
+                symbols.append(
                     CppRegisterSymbol(
                         symbol.name,
                         symbol.data_type,
@@ -107,7 +107,7 @@ class PdbFunctionExtractor:
                 )
             elif symbol.symbol_type == "S_BPREL32":
                 stack_offset = int(symbol.location[1:-1], 16)
-                stack_symbols.append(
+                symbols.append(
                     CppStackSymbol(
                         symbol.name,
                         symbol.data_type,
@@ -123,7 +123,7 @@ class PdbFunctionExtractor:
             arglist=arg_list_pdb_types,
             return_type=function_type["return_type"],
             class_type=class_type,
-            stack_symbols=stack_symbols,
+            symbols=symbols,
             this_adjust=this_adjust,
         )
 

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -198,7 +198,7 @@ def compare_function_stacks(udiff: CombinedDiffOutput, fn_symbol: SymbolsEntry):
 
     stack_symbols: dict[int, StackSymbol] = {}
 
-    for symbol in fn_symbol.stack_symbols:
+    for symbol in fn_symbol.symbols:
         if symbol.symbol_type == "S_BPREL32":
             # convert hex to signed 32 bit integer
             hex_bytes = bytes.fromhex(symbol.location[1:-1])

--- a/tests/test_cvdump_symbols.py
+++ b/tests/test_cvdump_symbols.py
@@ -36,8 +36,8 @@ def test_sblock32():
 
     # Make sure we can read the proc and all its stack references
     assert len(parser.symbols) == 1
-    assert len(parser.symbols[0].stack_symbols) == 8
-    assert parser.symbols[0].stack_symbols[0].data_type == CvdumpTypeKey(0x10EC)
+    assert len(parser.symbols[0].symbols) == 8
+    assert parser.symbols[0].symbols[0].data_type == CvdumpTypeKey(0x10EC)
 
 
 LOCAL_PROC = """

--- a/tests/test_ghidra_integration_function_imports.py
+++ b/tests/test_ghidra_integration_function_imports.py
@@ -42,7 +42,7 @@ def test_import_trivial_function(
         arglist=[],
         return_type=CVInfoTypeEnum.T_VOID,
         class_type=None,
-        stack_symbols=[],
+        symbols=[],
         this_adjust=0,
     )
     pdb_function = PdbFunction(
@@ -50,11 +50,12 @@ def test_import_trivial_function(
         func_signature,
         is_stub=False,
     )
-
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 void MyTestFn(void)
 
@@ -83,7 +84,7 @@ def test_import_without_signature(
         arglist=[CVInfoTypeEnum.T_INT4],
         return_type=CVInfoTypeEnum.T_VOID,
         class_type=None,
-        stack_symbols=[
+        symbols=[
             CppStackSymbol("p_mockParam", CVInfoTypeEnum.T_INT4, 4),
         ],
         this_adjust=0,
@@ -93,11 +94,12 @@ def test_import_without_signature(
         func_signature,
         is_stub=False,
     )
-
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 void __cdecl MyTestFnPart1(int p_mockParam)
 
@@ -116,12 +118,58 @@ void __cdecl MyTestFnPart1(int p_mockParam)
         signature=None,
         is_stub=False,
     )
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, second_pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 void __cdecl MyTestFnPart2(int p_mockParam)
+
+{
+  return;
+}
+
+""")
+
+
+def test_import_fastcall_convention(
+    ghidra: "FlatProgramAPI",
+    function_helper: GhidraFunctionTestHelper,
+    type_helper: GhidraTypeTestHelper,
+):
+    from reccmp.ghidra.importer.function_importer import (
+        PdbFunctionImporter,
+        PdbFunction,
+    )
+
+    function_helper.overwrite_example_function(b"\xc3")
+
+    func_signature = FunctionSignature(
+        call_type="__fastcall",
+        arglist=[CVInfoTypeEnum.T_INT4, CVInfoTypeEnum.T_INT4],
+        return_type=CVInfoTypeEnum.T_VOID,
+        class_type=None,
+        symbols=[
+            CppRegisterSymbol("p_src", CVInfoTypeEnum.T_INT4, "ecx"),
+            CppRegisterSymbol("p_dest", CVInfoTypeEnum.T_INT4, "edx"),
+        ],
+        this_adjust=0,
+    )
+    pdb_function = PdbFunction(
+        ReccmpMatch(function_helper.orig_address, 1234, {"name": "MyTestFn"}),
+        func_signature,
+        is_stub=False,
+    )
+    importer = PdbFunctionImporter.build(
+        ghidra, pdb_function, type_helper.type_importer, []
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
+
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
+    function_helper.assert_c_code("""
+void __fastcall MyTestFn(int p_src,int p_dest)
 
 {
   return;
@@ -192,7 +240,7 @@ def test_record_array_access(
         arglist=[CVInfoTypeEnum.T_INT4],
         return_type=CVInfoTypeEnum.T_32PCHAR,
         class_type=legoanim_class_key,
-        stack_symbols=[
+        symbols=[
             CppRegisterSymbol("this", legoanim_class_key, "ecx"),
             CppStackSymbol("p_index", CVInfoTypeEnum.T_INT4, 4),
         ],
@@ -207,11 +255,12 @@ def test_record_array_access(
         func_signature,
         is_stub=False,
     )
-
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 char * __thiscall LegoAnim::GetActorName(LegoAnim *this,int p_index)
 
@@ -293,7 +342,7 @@ def test_global_array_access(
         arglist=[CVInfoTypeEnum.T_INT4],
         return_type=CVInfoTypeEnum.T_32PCHAR,
         class_type=None,
-        stack_symbols=[
+        symbols=[
             CppStackSymbol("p_index", CVInfoTypeEnum.T_INT4, 4),
         ],
         this_adjust=0,
@@ -307,11 +356,12 @@ def test_global_array_access(
         func_signature,
         is_stub=False,
     )
-
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 char * LegoCharacterManager::GetActorName(int p_index)
 
@@ -395,7 +445,7 @@ def test_global_pointer_access(
         arglist=[CVInfoTypeEnum.T_INT4],
         return_type=CVInfoTypeEnum.T_32PCHAR,
         class_type=None,
-        stack_symbols=[
+        symbols=[
             CppStackSymbol("p_index", CVInfoTypeEnum.T_INT4, 4),
         ],
         this_adjust=0,
@@ -409,11 +459,12 @@ def test_global_pointer_access(
         func_signature,
         is_stub=False,
     )
-
-    PdbFunctionImporter.build(
+    importer = PdbFunctionImporter.build(
         ghidra, pdb_function, type_helper.type_importer, []
-    ).overwrite_ghidra_function(function_helper.ghidra_function)
+    )
+    importer.overwrite_ghidra_function(function_helper.ghidra_function)
 
+    assert importer.matches_ghidra_function(function_helper.ghidra_function) is True
     function_helper.assert_c_code("""
 char * LegoCharacterManager::GetActorName(int p_index)
 


### PR DESCRIPTION
Fixes #418. I also refactored some names that were no longer fitting and improved the Ghidra import tests a bit.

I have worked based off of #419, which should be reviewed and merged first.