### PR TITLE
Improve regular expression that extracts variable names

### DIFF
--- a/reccmp/parser/util.py
+++ b/reccmp/parser/util.py
@@ -106,7 +106,19 @@ def get_class_name(line: str) -> str | None:
     return None
 
 
-global_regex = re.compile(r"(?P<name>(?:\w+::)*\w+)(?:\)\(|\[.*|\s*=.*|;)")
+global_regex = re.compile(
+    r"""
+    (?P<name>(?:\w+::)*\w+)       # Any identifier with 0-N namespace qualifiers
+    (?:                           # Suffix options:
+        \(\w|                     # - Open paren: call constructor
+        \)\(|                     # - Close paren, open paren: function pointer variable
+        \[.*|                     # - Open bracket: array with or without size
+        \s*=.*|                   # - Direct assignment
+        ;                         # - Not initialized
+    )
+""",
+    flags=re.X,
+)
 
 
 def get_variable_name(line: str) -> str | None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -780,3 +780,15 @@ def test_folded_mixed_by_module(parser):
     assert parser.functions[1].is_folded is False
 
     assert len(parser.alerts) == 0
+
+
+def test_variables_calling_constructor(parser):
+    """Can extract the variable name for variables intialized by a constructor."""
+    parser.read("""\
+        // GLOBAL: GOLDP 0x10065b54
+        const FloatConstant g_floatConst4096(4096.0f);
+        """)
+
+    assert len(parser.alerts) == 0
+    assert parser.variables[0].offset == 0x10065B54
+    assert parser.variables[0].name == "g_floatConst4096"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -783,7 +783,7 @@ def test_folded_mixed_by_module(parser):
 
 
 def test_variables_calling_constructor(parser):
-    """Can extract the variable name for variables intialized by a constructor."""
+    """Can extract the variable name for variables initialized by a constructor."""
     parser.read("""\
         // GLOBAL: GOLDP 0x10065b54
         const FloatConstant g_floatConst4096(4096.0f);

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -147,10 +147,11 @@ def test_get_class_name_none(line: str):
 
 
 variable_name_cases = [
-    # with prefix for easy access
+    # With "g_" prefix, formerly a requirement for variables in reccmp-enabled code.
     ("char* g_test;", "g_test"),
     ("g_test;", "g_test"),
     ("void (*g_test)(int);", "g_test"),
+    ("void (*g_test)(char*, int);", "g_test"),
     ("char g_test[50];", "g_test"),
     ("char g_test[50] = {1234,", "g_test"),
     ("int g_test = 500;", "g_test"),
@@ -158,10 +159,16 @@ variable_name_cases = [
     ("char* hello;", "hello"),
     ("hello;", "hello"),
     ("void (*hello)(int);", "hello"),
+    ("char hello[];", "hello"),
+    ("char hello[][];", "hello"),
     ("char hello[50];", "hello"),
+    ("char hello[10][50];", "hello"),
     ("char hello[50] = {1234,", "hello"),
     ("int hello = 500;", "hello"),
     ("char* gBoring_material_names[2];", "gBoring_material_names"),
+    ("const FloatConstant g_floatConst4096(4096.0f);", "g_floatConst4096"),
+    ("int really::really::qualified::variable hello;", "hello"),
+    ("fully::qualified::type test = 5;", "test"),
 ]
 
 


### PR DESCRIPTION
Fixes an issue where we failed to identify variables initialized by a constructor. For example:
```cpp
// GLOBAL: GOLDP 0x10065b54
const FloatConstant g_floatConst4096(4096.0f);
```

See isledecomp/racers#326.

I used the [verbose option](https://docs.python.org/3/library/re.html#re.X) on the regular expression to add inline comments. Fortunately we had good test coverage on the `get_variable_name` function, which I have expanded further here.