### PR TITLE
Option to skip variables in `datacmp`

### DIFF
--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -66,7 +66,7 @@ class YmlReportConfig(BaseModel):
 
     @classmethod
     def default(cls) -> "YmlReportConfig":
-        return cls(ignore_functions=[])
+        return cls(ignore_functions=[], ignore_variables=[])
 
 
 @dataclass

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -59,6 +59,11 @@ class YmlReportConfig(BaseModel):
         validation_alias=AliasChoices("ignore-functions", "ignore_functions"),
     )
 
+    ignore_variables: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("ignore-variables", "ignore_variables"),
+    )
+
     @classmethod
     def default(cls) -> "YmlReportConfig":
         return cls(ignore_functions=[])

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -120,6 +120,10 @@ class GhidraConfig:
 @dataclass
 class ReportConfig:
     ignore_functions: list[str] = field(default_factory=list)
+    """Functions matching these names will be omitted from the reccmp-reccmp report."""
+
+    ignore_variables: list[str] = field(default_factory=list)
+    """Variables matching these names will be omitted from the reccmp-datacmp report."""
 
 
 @dataclass
@@ -368,6 +372,7 @@ class RecCmpProject:
             if target.report is not None:
                 report = ReportConfig(
                     ignore_functions=target.report.ignore_functions,
+                    ignore_variables=target.report.ignore_variables,
                 )
             else:
                 report = None

--- a/reccmp/tools/datacmp.py
+++ b/reccmp/tools/datacmp.py
@@ -87,6 +87,9 @@ def do_the_comparison(target: RecCmpTarget) -> Iterator[ComparisonItem]:
     )
 
     for var in compare.get_variables():
+        if var.name in target.report_config.ignore_variables:
+            continue
+
         yield variable_comparator.compare_variable(var)
 
 


### PR DESCRIPTION
Following the `ignore_functions` template set by #167.

See isledecomp/racers#83 and isledecomp/racers#326 for more context.