### PR TITLE
Analyze and match CRT startup functions

### DIFF
--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -104,7 +104,7 @@ class UsedAddressCollector:
             if inst.mnemonic in JUMP_MNEMONICS:
                 continue
 
-            if inst.mnemonic in ("mov", "lea"):
+            if inst.mnemonic in ("mov", "fstp"):
                 dst_operand, _, src_operand = inst.op_str.partition(", ")
                 self._append_addrs(dst_operand, True)
                 self._append_addrs(src_operand, False)

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -46,6 +46,9 @@ def get_crt_function_name(type_: CrtStartupArrayType) -> str:
     return _CRT_FUNCTION_NAMES[type_]
 
 
+UsedAddress = tuple[int, bool]
+
+
 @dataclass
 class CrtStartupArray:
     """Result from analyzing functions in a CRT startup array.
@@ -53,7 +56,7 @@ class CrtStartupArray:
     For example: addresses of C++ initializer functions are between
     the labels ___xc_a and ___xc_z."""
 
-    functions: dict[int, tuple[int, ...]]
+    functions: dict[int, tuple[UsedAddress, ...]]
     """Maps function address -> (sorted) list of matched entities used in
     the function, normalized to orig address space. These fingerprints are
     used to match initializer functions in orig and recomp."""
@@ -67,7 +70,7 @@ ADDR_REGEX = re.compile(r"0x[0-9a-f]{6,8}")
 
 
 class UsedAddressCollector:
-    seen_addrs: list[int]
+    seen_addrs: list[UsedAddress]
     """List of addrs that would be replaced by a name or placeholder."""
 
     is_entity: Callable[[int], bool]
@@ -76,6 +79,12 @@ class UsedAddressCollector:
     def __init__(self, is_entity: Callable[[int], bool]) -> None:
         self.is_entity = is_entity
         self.seen_addrs = []
+
+    def _append_addrs(self, text: str, is_write: bool):
+        for hex_str in ADDR_REGEX.findall(text):
+            addr = int(hex_str, 16)
+            if self.is_entity(addr):
+                self.seen_addrs.append((addr, is_write))
 
     def analyze(self, data: Buffer, start_addr: int):
         ig = InstructGen(bytes(data), start_addr, True)
@@ -95,10 +104,12 @@ class UsedAddressCollector:
             if inst.mnemonic in JUMP_MNEMONICS:
                 continue
 
-            for hex_str in ADDR_REGEX.findall(inst.op_str):
-                addr = int(hex_str, 16)
-                if self.is_entity(addr):
-                    self.seen_addrs.append(addr)
+            if inst.mnemonic in ("mov", "lea"):
+                dst_operand, _, src_operand = inst.op_str.partition(", ")
+                self._append_addrs(dst_operand, True)
+                self._append_addrs(src_operand, False)
+            else:
+                self._append_addrs(inst.op_str, False)
 
 
 def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
@@ -123,7 +134,7 @@ def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
 
 def get_function_fingerprint(
     db: EntityDb, image_id: ImageId, binfile: PEImage, addr: int
-) -> tuple[int, ...]:
+) -> tuple[UsedAddress, ...]:
     size = get_function_sample_size(db, image_id, addr)
     raw = binfile.read(addr, size)
 
@@ -134,14 +145,14 @@ def get_function_fingerprint(
     collector.analyze(raw, addr)
 
     normalized_addrs = []
-    for ca in collector.seen_addrs:
-        ent = db.get(image_id, ca)
+    for sample_addr, is_write in collector.seen_addrs:
+        ent = db.get(image_id, sample_addr)
         # Only matched entities are candidates for the fingerprint
         # because we have an address in both address spaces.
         if ent and ent.matched and ent.get("type") == EntityType.DATA:
             normalized_addr = ent.addr(ImageId.ORIG)
             assert isinstance(normalized_addr, int)
-            normalized_addrs.append(normalized_addr)
+            normalized_addrs.append((normalized_addr, is_write))
 
     return tuple(normalized_addrs)
 
@@ -232,30 +243,59 @@ def analyze_crt_startup(
 def create_crt_matches(
     orig_array: CrtStartupArray, recomp_array: CrtStartupArray
 ) -> list[tuple[int, int]]:
-    invert_orig: dict[tuple[int, ...], list[int]] = {}
-    invert_recomp: dict[tuple[int, ...], list[int]] = {}
 
-    for key, value in orig_array.functions.items():
-        invert_orig.setdefault(value, []).append(key)
-
-    for key, value in recomp_array.functions.items():
-        invert_recomp.setdefault(value, []).append(key)
-
+    combined_map: dict[UsedAddress, set[tuple[ImageId, int]]] = {}
+    eliminated: set[tuple[ImageId, int]] = set()
     matches = []
 
-    for fingerprint, orig_addrs in invert_orig.items():
-        # Don't match using blank fingerprints
-        if not fingerprint or len(orig_addrs) != 1:
-            continue
+    for image_id, array in ((ImageId.ORIG, orig_array), (ImageId.RECOMP, recomp_array)):
+        for func_addr, addr_samples in array.functions.items():
+            for sample in addr_samples:
+                combined_map.setdefault(sample, set()).add((image_id, func_addr))
 
-        if fingerprint in invert_recomp and len(invert_recomp[fingerprint]) == 1:
-            [orig_addr] = orig_addrs
-            [recomp_addr] = invert_recomp[fingerprint]
-            matches.append((orig_addr, recomp_addr))
+    while True:
+        matched_this_pass = False
 
-            if orig_addr in orig_array.thunks and recomp_addr in recomp_array.thunks:
-                orig_thunk = orig_array.thunks[orig_addr]
-                recomp_thunk = recomp_array.thunks[recomp_addr]
-                matches.append((orig_thunk, recomp_thunk))
+        # ?
+        for value in combined_map.values():
+            value -= eliminated
 
+        for (_, is_write), func_addrs in combined_map.items():
+            if is_write and len(func_addrs) == 2:
+                [(img_x, addr_x), (img_y, addr_y)] = func_addrs
+                if img_x != img_y:
+                    # Work out which is which
+                    orig_addr = addr_x if img_x == ImageId.ORIG else addr_y
+                    recomp_addr = addr_y if img_y == ImageId.RECOMP else addr_x
+                    matches.append((orig_addr, recomp_addr))
+                    eliminated.update(func_addrs)
+                    matched_this_pass = True
+                    break
+
+        if not matched_this_pass:
+            # TODO: separate?
+            for (_, is_write), func_addrs in combined_map.items():
+                if not is_write and len(func_addrs) == 2:
+                    [(img_x, addr_x), (img_y, addr_y)] = func_addrs
+                    if img_x != img_y:
+                        # Work out which is which
+                        orig_addr = addr_x if img_x == ImageId.ORIG else addr_y
+                        recomp_addr = addr_y if img_y == ImageId.RECOMP else addr_x
+                        matches.append((orig_addr, recomp_addr))
+                        eliminated.update(func_addrs)
+                        matched_this_pass = True
+                        break
+
+        if not matched_this_pass:
+            break
+
+    # Add thunks
+    thunks = []
+    for orig_addr, recomp_addr in matches:
+        if orig_addr in orig_array.thunks and recomp_addr in recomp_array.thunks:
+            thunks.append(
+                (orig_array.thunks[orig_addr], recomp_array.thunks[recomp_addr])
+            )
+
+    matches.extend(thunks)
     return matches

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -1,7 +1,8 @@
 import enum
+import re
 import struct
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Callable, Iterator
 from typing_extensions import Buffer
 from reccmp.compare.asm.const import JUMP_MNEMONICS
 from reccmp.compare.asm.instgen import (
@@ -9,9 +10,6 @@ from reccmp.compare.asm.instgen import (
     InstructGen,
     SectionType,
 )
-from reccmp.compare.asm.parse import ParseAsm
-from reccmp.compare.asm.replacement import AddrTestProtocol
-from reccmp.compare.functions import create_valid_addr_lookup
 from reccmp.formats import PEImage
 from reccmp.types import EntityType, ImageId
 from reccmp.compare.db import EntityDb
@@ -73,23 +71,22 @@ class CrtStartupArray:
     The thunk is what actually appeared in the ___xc_a/z list."""
 
 
-class UsedAddressCollector(ParseAsm):
-    """Wraps the asm sanitize mechanism that detects pointers and address literals
-    used in the function. Instead of replacing the addresses, just store them
-    in a list for review."""
+ADDR_REGEX = re.compile(r"0x[0-9a-f]{6,8}")
 
+
+class UsedAddressCollector:
     seen_addrs: list[int]
     """List of addrs that would be replaced by a name or placeholder."""
 
-    def __init__(self, addr_test: AddrTestProtocol | None = None) -> None:
-        super().__init__(addr_test, None, True)
+    is_entity: Callable[[int], bool]
+    """Test whether the address is a known entity in the database."""
+
+    def __init__(self, is_entity: Callable[[int], bool]) -> None:
+        self.is_entity = is_entity
         self.seen_addrs = []
 
-    def lookup(self, addr: int, exact: bool = False, indirect: bool = False) -> None:
-        self.seen_addrs.append(addr)
-
     def analyze(self, data: Buffer, start_addr: int):
-        ig = InstructGen(bytes(data), start_addr, self.is_32bit)
+        ig = InstructGen(bytes(data), start_addr, True)
 
         instructions = (
             inst
@@ -100,17 +97,16 @@ class UsedAddressCollector(ParseAsm):
 
         for inst in instructions:
             assert isinstance(inst, DisasmLiteInst)
-            if "0x" in inst.op_str and (
-                inst.mnemonic in JUMP_MNEMONICS or inst.size > 4 or not self.is_32bit
-            ):
-                # Reading the function will call the lookup() function
-                # and collect the addresses.
-                self.sanitize(inst)
-
-            # The functions we are looking at should not have complex logic
-            # that creates multiple exits.
             if inst.mnemonic == "ret":
                 break
+
+            if inst.mnemonic in JUMP_MNEMONICS:
+                continue
+
+            for hex_str in ADDR_REGEX.findall(inst.op_str):
+                addr = int(hex_str, 16)
+                if self.is_entity(addr):
+                    self.seen_addrs.append(addr)
 
 
 def get_function_fingerprint(
@@ -121,8 +117,10 @@ def get_function_fingerprint(
     # to read enough to create the fingerprint.
     raw = binfile.read(addr, 64)
 
-    addr_test = create_valid_addr_lookup(db, image_id, binfile)
-    collector = UsedAddressCollector(addr_test)
+    def entity_exists(test_addr: int) -> bool:
+        return db.get(image_id, test_addr, exact=True) is not None
+
+    collector = UsedAddressCollector(entity_exists)
     collector.analyze(raw, addr)
 
     normalized_addrs = []

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -109,13 +109,31 @@ class UsedAddressCollector:
                     self.seen_addrs.append(addr)
 
 
+def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
+    """How many bytes should we read to sample the addresses used in the function?
+    Use exact size if we have it, or any size estimate available."""
+    ent = db.get(image_id, addr)
+    if ent is not None:
+        size = ent.size(image_id)
+        if size is not None:
+            return size
+
+        if image_id == ImageId.ORIG:
+            # TODO: #406 changes this API.
+            next_addr = db.get_next_orig_addr(addr)
+            if next_addr:
+                return next_addr - addr
+
+    # Arbitrary value with the intent of overshooting the function's actual size
+    # and then correcting during disassembly.
+    return 1000
+
+
 def get_function_fingerprint(
     db: EntityDb, image_id: ImageId, binfile: PEImage, addr: int
 ) -> tuple[int, ...]:
-    # 64 bytes chosen arbitrarily.
-    # These functions are typically short, and we only need
-    # to read enough to create the fingerprint.
-    raw = binfile.read(addr, 64)
+    size = get_function_sample_size(db, image_id, addr)
+    raw = binfile.read(addr, size)
 
     def entity_exists(test_addr: int) -> bool:
         return db.get(image_id, test_addr, exact=True) is not None

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -224,19 +224,25 @@ def analyze_crt_startup(
 def create_crt_matches(
     orig_array: CrtStartupArray, recomp_array: CrtStartupArray
 ) -> list[tuple[int, int]]:
-    # Don't match using blank fingerprints
-    invert_orig = dict(
-        (fp, addr) for addr, fp in orig_array.functions.items() if fp is not None
-    )
-    invert_recomp = dict(
-        (fp, addr) for addr, fp in recomp_array.functions.items() if fp is not None
-    )
+    invert_orig: dict[tuple[int, ...], list[int]] = {}
+    invert_recomp: dict[tuple[int, ...], list[int]] = {}
+
+    for key, value in orig_array.functions.items():
+        invert_orig.setdefault(value, []).append(key)
+
+    for key, value in recomp_array.functions.items():
+        invert_recomp.setdefault(value, []).append(key)
 
     matches = []
 
-    for fingerprint, orig_addr in invert_orig.items():
-        if fingerprint in invert_recomp:
-            recomp_addr = invert_recomp[fingerprint]
+    for fingerprint, orig_addrs in invert_orig.items():
+        # Don't match using blank fingerprints
+        if not fingerprint or len(orig_addrs) != 1:
+            continue
+
+        if fingerprint in invert_recomp and len(invert_recomp[fingerprint]) == 1:
+            [orig_addr] = orig_addrs
+            [recomp_addr] = invert_recomp[fingerprint]
             matches.append((orig_addr, recomp_addr))
 
             if orig_addr in orig_array.thunks and recomp_addr in recomp_array.thunks:

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -275,7 +275,7 @@ def create_crt_matches(
                 [(img_x, addr_x), (img_y, addr_y)] = func_addrs
                 if img_x != img_y:
                     # These are sets, so order is not guaranteed.
-                    # Figure out which adderss is orig and which is recomp.
+                    # Figure out which address is orig and which is recomp.
                     orig_addr = addr_x if img_x == ImageId.ORIG else addr_y
                     recomp_addr = addr_y if img_y == ImageId.RECOMP else addr_x
                     matches.append((orig_addr, recomp_addr))

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -10,7 +10,7 @@ from reccmp.compare.asm.instgen import (
     InstructGen,
     SectionType,
 )
-from reccmp.formats import PEImage
+from reccmp.formats import Image, PEImage
 from reccmp.types import EntityType, ImageId
 from reccmp.compare.db import EntityDb
 
@@ -185,7 +185,12 @@ def find_crt_startup_labels(db: EntityDb, image_id: ImageId) -> dict[str, int]:
     return found
 
 
-def unwrap_jump(binfile: PEImage, addr: int) -> tuple[bool, int]:
+INITIALIZER_THUNK_MAX_JUMP_OFFSET = 16
+"""Some MSVC dynamic initializers are thunked. By observation, the thunked function is
+usually at the next 16-byte-aligned address. Tweak this value if necessary."""
+
+
+def unwrap_jump(binfile: Image, addr: int) -> tuple[bool, int]:
     """If there is a 5-byte JMP or CALL instruction at the given address,
     follow it by calculating the destination address.
     Returns either (True, jmp_destination) or (False, starting_addr)."""
@@ -193,11 +198,12 @@ def unwrap_jump(binfile: PEImage, addr: int) -> tuple[bool, int]:
     # Check for CALL (0xE8) or JMP (0xE9) opcodes.
     if jmp[0] in (0xE8, 0xE9):
         (offset,) = struct.unpack("<i", jmp[1:])
+        # Add 5 because the offset is based on the address of
+        # the *next* instruction after the JMP.
+        destination = addr + 5 + offset
         # Follow the jump only if it is small.
-        if abs(offset) <= 16:
-            # Add 5 because the offset is based on the address of
-            # the *next* instruction after the JMP.
-            return (True, addr + 5 + offset)
+        if abs(destination - addr) <= INITIALIZER_THUNK_MAX_JUMP_OFFSET:
+            return (True, destination)
 
     return (False, addr)
 

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -135,6 +135,10 @@ def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
 def get_function_fingerprint(
     db: EntityDb, image_id: ImageId, binfile: PEImage, addr: int
 ) -> tuple[UsedAddress, ...]:
+    """Create lists of addresses written to and read from by this function.
+    Filter the addresses that point to a matched variable entity.
+    These two lists of identifying characteristics about the function
+    are the "fingerprint" we can use for matching."""
     size = get_function_sample_size(db, image_id, addr)
     raw = binfile.read(addr, size)
 
@@ -229,7 +233,7 @@ def analyze_crt_startup_functions(
     return CrtStartupArray(fingerprints, thunks)
 
 
-def analyze_crt_startup(
+def detect_crt_startup_arrays(
     db: EntityDb, image_id: ImageId, binfile: PEImage
 ) -> Iterator[tuple[CrtStartupArrayType, CrtStartupArray | None]]:
     """For the CRT startup arrays in the given binary, if the start and end labels are known,

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -243,11 +243,16 @@ def analyze_crt_startup(
 def create_crt_matches(
     orig_array: CrtStartupArray, recomp_array: CrtStartupArray
 ) -> list[tuple[int, int]]:
+    """Match CRT startup functions from one array to other based on which addresses they use."""
 
     combined_map: dict[UsedAddress, set[tuple[ImageId, int]]] = {}
     eliminated: set[tuple[ImageId, int]] = set()
     matches = []
 
+    # Each array contains the list of startup functions with attached list of sampled addresses.
+    # Sampled addresses are already normalized to the original binary address space.
+    # Use this as our key to connect startup functions in both orig and recomp based on which
+    # addresses are used, and how (reads or writes).
     for image_id, array in ((ImageId.ORIG, orig_array), (ImageId.RECOMP, recomp_array)):
         for func_addr, addr_samples in array.functions.items():
             for sample in addr_samples:
@@ -256,40 +261,34 @@ def create_crt_matches(
     while True:
         matched_this_pass = False
 
-        # ?
+        # Remove startup functions matched on a previous pass.
         for value in combined_map.values():
             value -= eliminated
 
-        for (_, is_write), func_addrs in combined_map.items():
-            if is_write and len(func_addrs) == 2:
+        # Sampled address are separated by whether the function reads or writes to them.
+        # Read is not a superset for write, meaning: if the function only writes
+        # to the address, the function address will only be in the `is_write=True` bucket.
+        # With that separation, match any addresses where the bucket has
+        # exactly one sample from orig and exactly one sample from recomp.
+        for _, func_addrs in combined_map.items():
+            if len(func_addrs) == 2:
                 [(img_x, addr_x), (img_y, addr_y)] = func_addrs
                 if img_x != img_y:
-                    # Work out which is which
+                    # These are sets, so order is not guaranteed.
+                    # Figure out which adderss is orig and which is recomp.
                     orig_addr = addr_x if img_x == ImageId.ORIG else addr_y
                     recomp_addr = addr_y if img_y == ImageId.RECOMP else addr_x
                     matches.append((orig_addr, recomp_addr))
                     eliminated.update(func_addrs)
                     matched_this_pass = True
+                    # Break because we need to remove the addresses we just matched
+                    # to prevent a double match.
                     break
-
-        if not matched_this_pass:
-            # TODO: separate?
-            for (_, is_write), func_addrs in combined_map.items():
-                if not is_write and len(func_addrs) == 2:
-                    [(img_x, addr_x), (img_y, addr_y)] = func_addrs
-                    if img_x != img_y:
-                        # Work out which is which
-                        orig_addr = addr_x if img_x == ImageId.ORIG else addr_y
-                        recomp_addr = addr_y if img_y == ImageId.RECOMP else addr_x
-                        matches.append((orig_addr, recomp_addr))
-                        eliminated.update(func_addrs)
-                        matched_this_pass = True
-                        break
 
         if not matched_this_pass:
             break
 
-    # Add thunks
+    # Add any pairs of thunks that point to an already matched function.
     thunks = []
     for orig_addr, recomp_addr in matches:
         if orig_addr in orig_array.thunks and recomp_addr in recomp_array.thunks:

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -52,6 +52,10 @@ _CRT_FUNCTION_NAMES = {
 }
 
 
+def get_crt_function_name(type_: CrtStartupArrayType) -> str:
+    return _CRT_FUNCTION_NAMES[type_]
+
+
 @dataclass
 class CrtStartupArray:
     """Result from analyzing functions in a CRT startup array.
@@ -241,50 +245,3 @@ def create_crt_matches(
                 matches.append((orig_thunk, recomp_thunk))
 
     return matches
-
-
-def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
-    crt_orig = tuple(analyze_crt_startup(db, ImageId.ORIG, orig_bin))
-    crt_recomp = tuple(analyze_crt_startup(db, ImageId.RECOMP, recomp_bin))
-
-    matches = []
-
-    for (orig_type, orig_array), (recomp_type, recomp_array) in zip(
-        crt_orig, crt_recomp
-    ):
-        # Safety
-        assert orig_type == recomp_type
-        if orig_array and recomp_array:
-            matches.extend(create_crt_matches(orig_array, recomp_array))
-
-    with db.batch() as batch:
-        for image_id, crt_arrays in (
-            (ImageId.ORIG, crt_orig),
-            (ImageId.RECOMP, crt_recomp),
-        ):
-            for array_type, array in crt_arrays:
-                if array is None:
-                    continue
-
-                name = _CRT_FUNCTION_NAMES[array_type]
-                assert isinstance(name, str)
-
-                for addr in array.functions.keys():
-                    batch.set(
-                        image_id,
-                        addr,
-                        type=EntityType.FUNCTION,
-                        name=name,
-                    )
-
-                    if addr in array.thunks:
-                        thunk_addr = array.thunks[addr]
-                        batch.set(
-                            image_id,
-                            thunk_addr,
-                            type=EntityType.FUNCTION,
-                            name=name,
-                        )
-
-        for orig_addr, recomp_addr in matches:
-            batch.match(orig_addr, recomp_addr)

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -121,11 +121,9 @@ def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
         if size is not None:
             return size
 
-        if image_id == ImageId.ORIG:
-            # TODO: #406 changes this API.
-            next_addr = db.get_next_orig_addr(addr)
-            if next_addr:
-                return next_addr - addr
+        max_size = db.get_max_size(image_id, addr)
+        if max_size:
+            return max_size
 
     # Arbitrary value with the intent of overshooting the function's actual size
     # and then correcting during disassembly.

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -1,0 +1,290 @@
+import enum
+import struct
+from dataclasses import dataclass
+from typing import Iterator
+from typing_extensions import Buffer
+from reccmp.compare.asm.const import JUMP_MNEMONICS
+from reccmp.compare.asm.instgen import (
+    DisasmLiteInst,
+    InstructGen,
+    SectionType,
+)
+from reccmp.compare.asm.parse import ParseAsm
+from reccmp.compare.asm.replacement import AddrTestProtocol
+from reccmp.compare.functions import create_valid_addr_lookup
+from reccmp.formats import PEImage
+from reccmp.types import EntityType, ImageId
+from reccmp.compare.db import EntityDb
+
+
+class CrtStartupArrayType(enum.Enum):
+    C_INIT = enum.auto()
+    CPP_INIT = enum.auto()
+    C_PRE_TERM = enum.auto()
+    C_TERM = enum.auto()
+
+
+_CRT_STARTUP_ARRAY_LABELS = (
+    "___xi_a",
+    "___xi_z",
+    "___xc_a",
+    "___xc_z",
+    "___xp_a",
+    "___xp_z",
+    "___xt_a",
+    "___xt_z",
+)
+
+
+_CRT_STARTUP_ARRAY_BOUNDARIES = {
+    CrtStartupArrayType.C_INIT: ("___xi_a", "___xi_z"),
+    CrtStartupArrayType.CPP_INIT: ("___xc_a", "___xc_z"),
+    CrtStartupArrayType.C_PRE_TERM: ("___xp_a", "___xp_z"),
+    CrtStartupArrayType.C_TERM: ("___xt_a", "___xt_z"),
+}
+
+
+_CRT_FUNCTION_NAMES = {
+    CrtStartupArrayType.C_INIT: "$CRT_C_Initializer",
+    CrtStartupArrayType.CPP_INIT: "$CRT_CPP_Initializer",
+    CrtStartupArrayType.C_PRE_TERM: "$CRT_C_Pre-Terminator",
+    CrtStartupArrayType.C_TERM: "$CRT_C_Terminator",
+}
+
+
+@dataclass
+class CrtStartupArray:
+    """Result from analyzing functions in a CRT startup array.
+    The functions within are called before main() is executed.
+    For example: addresses of C++ initializer functions are between
+    the labels ___xc_a and ___xc_z."""
+
+    functions: dict[int, tuple[int, ...]]
+    """Maps function address -> (sorted) list of matched entities used in
+    the function, normalized to orig address space. These fingerprints are
+    used to match initializer functions in orig and recomp."""
+
+    thunks: dict[int, int]
+    """Maps thunked initializer function to the thunk address.
+    The thunk is what actually appeared in the ___xc_a/z list."""
+
+
+class UsedAddressCollector(ParseAsm):
+    """Wraps the asm sanitize mechanism that detects pointers and address literals
+    used in the function. Instead of replacing the addresses, just store them
+    in a list for review."""
+
+    seen_addrs: list[int]
+    """List of addrs that would be replaced by a name or placeholder."""
+
+    def __init__(self, addr_test: AddrTestProtocol | None = None) -> None:
+        super().__init__(addr_test, None, True)
+        self.seen_addrs = []
+
+    def lookup(self, addr: int, exact: bool = False, indirect: bool = False) -> None:
+        self.seen_addrs.append(addr)
+
+    def analyze(self, data: Buffer, start_addr: int):
+        ig = InstructGen(bytes(data), start_addr, self.is_32bit)
+
+        instructions = (
+            inst
+            for section in ig.sections
+            for inst in section.contents
+            if section.type == SectionType.CODE
+        )
+
+        for inst in instructions:
+            assert isinstance(inst, DisasmLiteInst)
+            if "0x" in inst.op_str and (
+                inst.mnemonic in JUMP_MNEMONICS or inst.size > 4 or not self.is_32bit
+            ):
+                # Reading the function will call the lookup() function
+                # and collect the addresses.
+                self.sanitize(inst)
+
+            # The functions we are looking at should not have complex logic
+            # that creates multiple exits.
+            if inst.mnemonic == "ret":
+                break
+
+
+def get_function_fingerprint(
+    db: EntityDb, image_id: ImageId, binfile: PEImage, addr: int
+) -> tuple[int, ...]:
+    # 64 bytes chosen arbitrarily.
+    # These functions are typically short, and we only need
+    # to read enough to create the fingerprint.
+    raw = binfile.read(addr, 64)
+
+    addr_test = create_valid_addr_lookup(db, image_id, binfile)
+    collector = UsedAddressCollector(addr_test)
+    collector.analyze(raw, addr)
+
+    normalized_addrs = []
+    for ca in collector.seen_addrs:
+        ent = db.get(image_id, ca)
+        # Only matched entities are candidates for the fingerprint
+        # because we have an address in both address spaces.
+        if ent and ent.matched and ent.get("type") == EntityType.DATA:
+            normalized_addr = ent.addr(ImageId.ORIG)
+            assert isinstance(normalized_addr, int)
+            normalized_addrs.append(normalized_addr)
+
+    return tuple(normalized_addrs)
+
+
+def read_crt_array(binfile: PEImage, span: range) -> Iterator[int]:
+    """Read 4-byte (dword) pointers from the specified range.
+    Excludes the first element, a zero."""
+    try:
+        for (addr,) in struct.iter_unpack("<I", binfile.read(span.start, len(span))):
+            if addr != 0:
+                yield addr
+    except struct.error:
+        # Don't crash on bad user input: the start or end addrs are incorrect
+        pass
+
+
+def find_crt_startup_labels(db: EntityDb, image_id: ImageId) -> dict[str, int]:
+    found = {}
+
+    for ent in db.all(image_id):
+        name = ent.get("name")
+        if name is not None and name in _CRT_STARTUP_ARRAY_LABELS:
+            addr = ent.addr(image_id)
+            assert isinstance(addr, int)
+            found[name] = addr
+
+            if len(found) == len(_CRT_STARTUP_ARRAY_LABELS):
+                break
+
+    return found
+
+
+def unwrap_jump(binfile: PEImage, addr: int) -> tuple[bool, int]:
+    """If there is a 5-byte JMP or CALL instruction at the given address,
+    follow it by calculating the destination address.
+    Returns either (True, jmp_destination) or (False, starting_addr)."""
+    jmp = binfile.read(addr, 5)
+    # Check for CALL (0xE8) or JMP (0xE9) opcodes.
+    if jmp[0] in (0xE8, 0xE9):
+        (offset,) = struct.unpack("<i", jmp[1:])
+        # Follow the jump only if it is small.
+        if abs(offset) <= 16:
+            # Add 5 because the offset is based on the address of
+            # the *next* instruction after the JMP.
+            return (True, addr + 5 + offset)
+
+    return (False, addr)
+
+
+def analyze_crt_startup_functions(
+    db: EntityDb, image_id: ImageId, binfile: PEImage, span: range
+) -> CrtStartupArray:
+    """Read the functions for a single CRT startup array and find the identifying "fingerprint"
+    of which variables are referenced."""
+    funcs = tuple(read_crt_array(binfile, span))
+
+    fingerprints = {}
+    thunks = {}
+
+    for xc_addr in funcs:
+        # n.b. The first value in the array is zero. It was excluded by read_crt_array.
+        was_thunk, real_addr = unwrap_jump(binfile, xc_addr)
+        fp = get_function_fingerprint(db, image_id, binfile, real_addr)
+        fingerprints[real_addr] = fp
+        if was_thunk:
+            thunks[real_addr] = xc_addr
+
+    return CrtStartupArray(fingerprints, thunks)
+
+
+def analyze_crt_startup(
+    db: EntityDb, image_id: ImageId, binfile: PEImage
+) -> Iterator[tuple[CrtStartupArrayType, CrtStartupArray | None]]:
+    """For the CRT startup arrays in the given binary, if the start and end labels are known,
+    analyze the functions in each array."""
+    labels = find_crt_startup_labels(db, image_id)
+    for array_type, (label_start, label_end) in _CRT_STARTUP_ARRAY_BOUNDARIES.items():
+        if label_start in labels and label_end in labels:
+            array_range = range(labels[label_start], labels[label_end])
+            yield (
+                array_type,
+                analyze_crt_startup_functions(db, image_id, binfile, array_range),
+            )
+        else:
+            yield (array_type, None)
+
+
+def create_crt_matches(
+    orig_array: CrtStartupArray, recomp_array: CrtStartupArray
+) -> list[tuple[int, int]]:
+    # Don't match using blank fingerprints
+    invert_orig = dict(
+        (fp, addr) for addr, fp in orig_array.functions.items() if fp is not None
+    )
+    invert_recomp = dict(
+        (fp, addr) for addr, fp in recomp_array.functions.items() if fp is not None
+    )
+
+    matches = []
+
+    for fingerprint, orig_addr in invert_orig.items():
+        if fingerprint in invert_recomp:
+            recomp_addr = invert_recomp[fingerprint]
+            matches.append((orig_addr, recomp_addr))
+
+            if orig_addr in orig_array.thunks and recomp_addr in recomp_array.thunks:
+                orig_thunk = orig_array.thunks[orig_addr]
+                recomp_thunk = recomp_array.thunks[recomp_addr]
+                matches.append((orig_thunk, recomp_thunk))
+
+    return matches
+
+
+def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
+    crt_orig = tuple(analyze_crt_startup(db, ImageId.ORIG, orig_bin))
+    crt_recomp = tuple(analyze_crt_startup(db, ImageId.RECOMP, recomp_bin))
+
+    matches = []
+
+    for (orig_type, orig_array), (recomp_type, recomp_array) in zip(
+        crt_orig, crt_recomp
+    ):
+        # Safety
+        assert orig_type == recomp_type
+        if orig_array and recomp_array:
+            matches.extend(create_crt_matches(orig_array, recomp_array))
+
+    with db.batch() as batch:
+        for image_id, crt_arrays in (
+            (ImageId.ORIG, crt_orig),
+            (ImageId.RECOMP, crt_recomp),
+        ):
+            for array_type, array in crt_arrays:
+                if array is None:
+                    continue
+
+                name = _CRT_FUNCTION_NAMES[array_type]
+                assert isinstance(name, str)
+
+                for addr in array.functions.keys():
+                    batch.set(
+                        image_id,
+                        addr,
+                        type=EntityType.FUNCTION,
+                        name=name,
+                    )
+
+                    if addr in array.thunks:
+                        thunk_addr = array.thunks[addr]
+                        batch.set(
+                            image_id,
+                            thunk_addr,
+                            type=EntityType.FUNCTION,
+                            name=name,
+                        )
+
+        for orig_addr, recomp_addr in matches:
+            batch.match(orig_addr, recomp_addr)

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -22,24 +22,16 @@ class CrtStartupArrayType(enum.Enum):
     C_TERM = enum.auto()
 
 
-_CRT_STARTUP_ARRAY_LABELS = (
-    "___xi_a",
-    "___xi_z",
-    "___xc_a",
-    "___xc_z",
-    "___xp_a",
-    "___xp_z",
-    "___xt_a",
-    "___xt_z",
-)
-
-
 _CRT_STARTUP_ARRAY_BOUNDARIES = {
     CrtStartupArrayType.C_INIT: ("___xi_a", "___xi_z"),
     CrtStartupArrayType.CPP_INIT: ("___xc_a", "___xc_z"),
     CrtStartupArrayType.C_PRE_TERM: ("___xp_a", "___xp_z"),
     CrtStartupArrayType.C_TERM: ("___xt_a", "___xt_z"),
 }
+
+_CRT_STARTUP_ARRAY_LABELS = [
+    label for pair in _CRT_STARTUP_ARRAY_BOUNDARIES.values() for label in pair
+]
 
 
 _CRT_FUNCTION_NAMES = {

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -57,6 +57,7 @@ from .mutate import (
     match_array_elements,
     name_thunks,
     unique_names_for_overloaded_functions,
+    match_crt_startup,
 )
 from .verify import (
     check_vtables,
@@ -153,6 +154,8 @@ class Compare:
         match_static_variables(self._db, self.report)
         match_variables(self._db, self.report)
         match_lines(self._db, self._lines_db, self.report)
+
+        match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
 
         match_array_elements(self._db, self.types)
         # Detect floats first to eliminate potential overlap with string data

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -5,7 +5,7 @@ These functions create or update entities using the current information in the d
 import logging
 from functools import cache
 from reccmp.analysis.crt_startup import (
-    analyze_crt_startup,
+    detect_crt_startup_arrays,
     create_crt_matches,
     get_crt_function_name,
 )
@@ -171,8 +171,8 @@ def unique_names_for_overloaded_functions(db: EntityDb):
 
 
 def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
-    crt_orig = tuple(analyze_crt_startup(db, ImageId.ORIG, orig_bin))
-    crt_recomp = tuple(analyze_crt_startup(db, ImageId.RECOMP, recomp_bin))
+    crt_orig = tuple(detect_crt_startup_arrays(db, ImageId.ORIG, orig_bin))
+    crt_recomp = tuple(detect_crt_startup_arrays(db, ImageId.RECOMP, recomp_bin))
 
     matches = []
 

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -4,11 +4,13 @@ These functions create or update entities using the current information in the d
 
 import logging
 from functools import cache
+from reccmp.analysis.crt_startup import match_crt_startup as _match_crt_startup
 from reccmp.cvdump.demangler import (
     get_function_arg_string,
 )
 from reccmp.cvdump import CvdumpTypesParser
 from reccmp.cvdump.types import CvdumpTypeKey
+from reccmp.formats import PEImage
 from reccmp.types import EntityType, ImageId
 from .db import EntityDb
 from .queries import get_overloaded_functions, get_named_thunks
@@ -162,3 +164,8 @@ def unique_names_for_overloaded_functions(db: EntityDb):
                 batch.set(ImageId.ORIG, func.orig_addr, computed_name=new_name)
             elif func.recomp_addr is not None:
                 batch.set(ImageId.RECOMP, func.recomp_addr, computed_name=new_name)
+
+
+def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
+    # Alias to keep this module's scope small
+    _match_crt_startup(db, orig_bin, recomp_bin)

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -4,7 +4,11 @@ These functions create or update entities using the current information in the d
 
 import logging
 from functools import cache
-from reccmp.analysis.crt_startup import match_crt_startup as _match_crt_startup
+from reccmp.analysis.crt_startup import (
+    analyze_crt_startup,
+    create_crt_matches,
+    get_crt_function_name,
+)
 from reccmp.cvdump.demangler import (
     get_function_arg_string,
 )
@@ -167,5 +171,46 @@ def unique_names_for_overloaded_functions(db: EntityDb):
 
 
 def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
-    # Alias to keep this module's scope small
-    _match_crt_startup(db, orig_bin, recomp_bin)
+    crt_orig = tuple(analyze_crt_startup(db, ImageId.ORIG, orig_bin))
+    crt_recomp = tuple(analyze_crt_startup(db, ImageId.RECOMP, recomp_bin))
+
+    matches = []
+
+    for (orig_type, orig_array), (recomp_type, recomp_array) in zip(
+        crt_orig, crt_recomp
+    ):
+        # Safety
+        assert orig_type == recomp_type
+        if orig_array and recomp_array:
+            matches.extend(create_crt_matches(orig_array, recomp_array))
+
+    with db.batch() as batch:
+        for image_id, crt_arrays in (
+            (ImageId.ORIG, crt_orig),
+            (ImageId.RECOMP, crt_recomp),
+        ):
+            for array_type, array in crt_arrays:
+                if array is None:
+                    continue
+
+                name = get_crt_function_name(array_type)
+
+                for addr in array.functions.keys():
+                    batch.set(
+                        image_id,
+                        addr,
+                        type=EntityType.FUNCTION,
+                        name=name,
+                    )
+
+                    if addr in array.thunks:
+                        thunk_addr = array.thunks[addr]
+                        batch.set(
+                            image_id,
+                            thunk_addr,
+                            type=EntityType.FUNCTION,
+                            name=name,
+                        )
+
+        for orig_addr, recomp_addr in matches:
+            batch.match(orig_addr, recomp_addr)

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -1,3 +1,4 @@
+import struct
 from reccmp.analysis.crt_startup import (
     get_function_fingerprint,
     find_crt_startup_labels,
@@ -117,6 +118,5 @@ def test_xca_fingerprints_avoid_crash(binfile: PEImage):
 
     try:
         analyze_crt_startup_functions(db, ImageId.ORIG, binfile, modified_range)
-    # pylint: disable=bare-except
-    except:
+    except struct.error:
         assert False, "Should not throw"

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -39,7 +39,7 @@ def test_get_function_fingerprint_matched(binfile: PEImage):
         batch.match(G_MUTEX_ADDR, G_MUTEX_ADDR)
 
     assert get_function_fingerprint(db, ImageId.ORIG, binfile, SET_DO_MUTEX_ADDR) == (
-        G_MUTEX_ADDR,
+        (G_MUTEX_ADDR, True),
     )
 
 
@@ -110,7 +110,7 @@ def test_xca_fingerprints_matched_variable(binfile: PEImage):
         batch.match(0x10102B28, 0x10102B28)
 
     result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
-    assert result.functions[0x1001A6D0] == (0x10102B28,)
+    assert result.functions[0x1001A6D0] == ((0x10102B28, False),)
 
 
 def test_xca_fingerprints_avoid_crash(binfile: PEImage):
@@ -133,22 +133,25 @@ def test_create_match_baseline():
 
 def test_create_match_single():
     """Should create match for unique fingerprint."""
-    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={})
-    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={})
+    write_sample = (1234, True)
+    x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={})
+    y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={})
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
 
 
 def test_create_match_single_with_thunks_one_sided():
     """Should not add thunk match unless it exists in both arrays."""
-    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={100: 500})
-    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={})
+    write_sample = (1234, True)
+    x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={100: 500})
+    y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={})
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
 
 
 def test_create_match_single_with_thunks_two_sided():
     """Should match function and thunk."""
-    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={100: 500})
-    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={200: 600})
+    write_sample = (1234, True)
+    x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={100: 500})
+    y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={200: 600})
     assert create_crt_matches(x_array, y_array) == [(100, 200), (500, 600)]
 
 
@@ -161,6 +164,11 @@ def test_create_match_blank_fingerprint():
 
 def test_create_match_non_unique_fingerprint():
     """Should not match functions if their fingerprint is not unique."""
-    x_array = CrtStartupArray(functions={100: (1234,), 200: (1234,)}, thunks={})
-    y_array = CrtStartupArray(functions={200: (1234,), 300: (1234,)}, thunks={})
+    write_sample = (1234, True)
+    x_array = CrtStartupArray(
+        functions={100: (write_sample,), 200: (write_sample,)}, thunks={}
+    )
+    y_array = CrtStartupArray(
+        functions={200: (write_sample,), 300: (write_sample,)}, thunks={}
+    )
     assert not create_crt_matches(x_array, y_array)

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -1,0 +1,122 @@
+from reccmp.analysis.crt_startup import (
+    get_function_fingerprint,
+    find_crt_startup_labels,
+    analyze_crt_startup_functions,
+)
+from reccmp.compare.db import EntityDb
+from reccmp.formats import PEImage
+from reccmp.types import ImageId, EntityType
+
+# MxCriticalSection::SetDoMutex.
+# Short function that sets the g_mutex global variable at 0x10101e78.
+SET_DO_MUTEX_ADDR = 0x100B6E00
+G_MUTEX_ADDR = 0x10101E78
+
+
+def test_get_function_fingerprint_empty(binfile: PEImage):
+    """The function fingerprint will be empty if entities it references are not known."""
+    db = EntityDb()
+    assert not get_function_fingerprint(db, ImageId.ORIG, binfile, SET_DO_MUTEX_ADDR)
+
+
+def test_get_function_fingerprint_unmatched(binfile: PEImage):
+    """The function fingerprint will be empty if entities it references are not *matched*."""
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, G_MUTEX_ADDR, name="g_mutex", type=EntityType.DATA)
+
+    assert not get_function_fingerprint(db, ImageId.ORIG, binfile, SET_DO_MUTEX_ADDR)
+
+
+def test_get_function_fingerprint_matched(binfile: PEImage):
+    """g_mutex variable is matched, and it should appear in the fingerprint for SetDoMutex"""
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, G_MUTEX_ADDR, name="g_mutex", type=EntityType.DATA)
+        batch.match(G_MUTEX_ADDR, G_MUTEX_ADDR)
+
+    assert get_function_fingerprint(db, ImageId.ORIG, binfile, SET_DO_MUTEX_ADDR) == (
+        G_MUTEX_ADDR,
+    )
+
+
+XCA_XCZ_RANGE = range(0x100F0000, 0x100F0020)
+
+
+def test_find_crt_startup_labels_empty():
+    db = EntityDb()
+    assert not find_crt_startup_labels(db, ImageId.ORIG)
+
+
+def test_find_crt_startup_labels_cpp_init():
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, XCA_XCZ_RANGE.start, name="___xc_a")
+        batch.set(ImageId.ORIG, XCA_XCZ_RANGE.stop, name="___xc_z")
+
+    labels = find_crt_startup_labels(db, ImageId.ORIG)
+    assert labels["___xc_a"] == XCA_XCZ_RANGE.start
+    assert labels["___xc_z"] == XCA_XCZ_RANGE.stop
+
+
+# Maps function addr to thunk.
+# The thunks are what appears in the ___xc_a array.
+XCA_THUNK_MAPPING = (
+    (0x10092360, 0x10092350),
+    (0x10012DB0, 0x10012DA0),
+    (0x100145A0, 0x10014590),
+    (0x1001A6D0, 0x1001A6C0),
+    (0x1002A4D0, 0x1002A4C0),
+    (0x1003FA20, 0x1003FA10),
+    (0x100537C0, 0x100537B0),
+)
+
+
+def test_xca_fingerprints_empty(binfile: PEImage):
+    db = EntityDb()
+
+    # Baseline: no entities so all fingerprints are empty
+    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
+
+    assert set(result.functions.keys()) == {addr for addr, _ in XCA_THUNK_MAPPING}
+    assert all(not v for v in result.functions.values())
+
+    assert tuple(result.thunks.items()) == XCA_THUNK_MAPPING
+
+
+def test_xca_fingerprints_not_variable(binfile: PEImage):
+    """We have the variable's entity in the database, but its type is not set.
+    This means it cannot be part of the function's fingerprint."""
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 0x10102B28, name="g_spawnLocations")
+        batch.match(0x10102B28, 0x10102B28)
+
+    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
+    assert not result.functions[0x1001A6D0]
+
+
+def test_xca_fingerprints_matched_variable(binfile: PEImage):
+    """Variable entity matched and with type set.
+    We should now see it in the function's fingerprint list."""
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG, 0x10102B28, name="g_spawnLocations", type=EntityType.DATA
+        )
+        batch.match(0x10102B28, 0x10102B28)
+
+    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
+    assert result.functions[0x1001A6D0] == (0x10102B28,)
+
+
+def test_xca_fingerprints_avoid_crash(binfile: PEImage):
+    db = EntityDb()
+    # Misaligned end address will cause struct.iter_unpack to raise struct.error.
+    modified_range = range(XCA_XCZ_RANGE.start, XCA_XCZ_RANGE.stop - 1)
+
+    try:
+        analyze_crt_startup_functions(db, ImageId.ORIG, binfile, modified_range)
+    # pylint: disable=bare-except
+    except:
+        assert False, "Should not throw"

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -5,6 +5,7 @@ from reccmp.analysis.crt_startup import (
     analyze_crt_startup_functions,
     CrtStartupArray,
     create_crt_matches,
+    UsedAddressCollector,
 )
 from reccmp.compare.db import EntityDb
 from reccmp.formats import PEImage
@@ -192,4 +193,97 @@ def test_create_match_with_elimination():
     assert create_crt_matches(x_array, y_array) == [
         (200, 300),
         (100, 200),
+    ]
+
+
+def test_collector_small_addrs_ignored():
+    """Limit tested addresses to those large enough to be an EXE imagebase."""
+    code = (
+        b"\xc6\x05\x00\x00\x00\x00\x00"  # mov byte ptr [0x0], 0
+        b"\xc6\x05\x00\x10\x00\x00\x00"  # mov byte ptr [0x1000], 0
+        b"\xc6\x05\x00\x00\x40\x00\x00"  # mov byte ptr [0x400000], 0
+        b"\xc6\x05\x00\x00\x00\x10\x00"  # mov byte ptr [0x10000000], 0
+        b"\xc3"  # ret
+    )
+
+    collector = UsedAddressCollector(lambda _: True)
+    collector.analyze(code, 0)
+
+    assert collector.seen_addrs == [
+        (0x400000, True),
+        (0x10000000, True),
+    ]
+
+
+def test_collector_repeated_addrs():
+    """Collected addresses are presented in sequence and are not deduplicated.
+    The caller can choose to reduce this to a set as needed."""
+    code = (
+        b"\xc6\x05\x00\x00\x40\x00\x00"  # mov byte ptr [0x400000], 0
+        b"\xc6\x05\x00\x00\x40\x00\x00"  # mov byte ptr [0x400000], 0
+        b"\x80\x3d\x00\x00\x40\x00\x00"  # cmp byte ptr [0x400000], 0x0
+        b"\xc3"  # ret
+    )
+
+    collector = UsedAddressCollector(lambda _: True)
+    collector.analyze(code, 0)
+
+    assert collector.seen_addrs == [
+        (0x400000, True),
+        (0x400000, True),
+        (0x400000, False),
+    ]
+
+
+def test_collector_classify_float_instructions_as_read_or_write():
+    """Capstone does not present float instructions with their implicit FPU register.
+    Make sure FSTP is identified as a write, and the others as reads."""
+    code = (
+        b"\xd9\x05\x00\x10\x40\x00"  # fld dword ptr [0x401000]
+        b"\xd8\x35\x00\x20\x40\x00"  # fdiv dword ptr [0x402000]
+        b"\xd9\x1d\x00\x30\x40\x00"  # fstp dword ptr [0x403000]
+        b"\xc3"  # ret
+    )
+
+    collector = UsedAddressCollector(lambda _: True)
+    collector.analyze(code, 0)
+
+    assert collector.seen_addrs == [
+        (0x401000, False),
+        (0x402000, False),
+        (0x403000, True),
+    ]
+
+
+def test_collector_not_all_dst_operands_are_writes():
+    code = (
+        b"\x80\x3d\x00\x00\x40\x00\x00"  # cmp byte ptr [0x400000], 0x0
+        b"\xf6\x05\x00\x00\x41\x00\x08"  # test byte ptr [0x410000], 0x8
+        b"\xc3"  # ret
+    )
+
+    collector = UsedAddressCollector(lambda _: True)
+    collector.analyze(code, 0)
+
+    assert collector.seen_addrs == [
+        (0x400000, False),
+        (0x410000, False),
+    ]
+
+
+def test_collector_calls_and_jumps():
+    """Jumps are ignored. Calls are collected as read addresses.
+    (We may choose to classify them differently in the future.)"""
+    code = (
+        b"\xe8\xfb\x0f\x00\x00"  # call 0x401000
+        b"\xe9\xf6\x1f\x00\x00"  # jmp 0x402000
+        b"\xc3"  # ret
+    )
+
+    collector = UsedAddressCollector(lambda _: True)
+    # Must set start addr here because CALLs and JMPs are relative.
+    collector.analyze(code, 0x400000)
+
+    assert collector.seen_addrs == [
+        (0x401000, False),
     ]

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -1,4 +1,5 @@
 import struct
+import pytest
 from reccmp.analysis.crt_startup import (
     get_function_fingerprint,
     find_crt_startup_labels,
@@ -6,10 +7,12 @@ from reccmp.analysis.crt_startup import (
     CrtStartupArray,
     create_crt_matches,
     UsedAddressCollector,
+    unwrap_jump,
 )
 from reccmp.compare.db import EntityDb
 from reccmp.formats import PEImage
 from reccmp.types import ImageId, EntityType
+from .raw_image import RawImage
 
 # MxCriticalSection::SetDoMutex.
 # Short function that sets the g_mutex global variable at 0x10101e78.
@@ -287,3 +290,54 @@ def test_collector_calls_and_jumps():
     assert collector.seen_addrs == [
         (0x401000, False),
     ]
+
+
+def jump_instruction(start: int, end: int, opcode: int = 0xE9) -> bytes:
+    """Create an instruction with the correct jump displacement."""
+    return struct.pack("<Bi", opcode, end - start - 5)
+
+
+CRT_THUNK_ORIENTATIONS = (
+    (0, 5),  # Thunk first, no gap
+    (0, 16),  # Thunk first, 16-byte-aligned
+    (5, 0),  # Function first, no gap
+    (16, 0),  # Function first, 16-byte-aligned
+)
+
+
+@pytest.mark.parametrize("opcode", (0xE8, 0xE9))  # CALL, JMP
+@pytest.mark.parametrize("thunk_addr, func_addr", CRT_THUNK_ORIENTATIONS)
+def test_unwrap_jump(thunk_addr: int, func_addr: int, opcode: int):
+    """Testing situations where we assume a jump or call is a thunk."""
+    thunk = jump_instruction(start=thunk_addr, end=func_addr, opcode=opcode)
+
+    # Prepare the instructions
+    memory = bytearray(128)
+    memory[thunk_addr : thunk_addr + 5] = thunk
+    memory[func_addr] = 0xC3  # RET
+
+    binfile = RawImage.from_memory(bytes(memory))
+    assert unwrap_jump(binfile, thunk_addr) == (True, func_addr)
+    assert unwrap_jump(binfile, func_addr) == (False, func_addr)
+
+
+CRT_NOT_A_THUNK_ORIENTATIONS = (
+    (0, 0x40),  # Thunk first
+    (0x60, 0),  # Function first
+)
+
+
+@pytest.mark.parametrize("opcode", (0xE8, 0xE9))  # CALL, JMP
+@pytest.mark.parametrize("thunk_addr, func_addr", CRT_NOT_A_THUNK_ORIENTATIONS)
+def test_unwrap_jump_outside_thresh(thunk_addr: int, func_addr: int, opcode: int):
+    """Testing where we do NOT assume a jump or call is a thunk."""
+    thunk = jump_instruction(start=thunk_addr, end=func_addr, opcode=opcode)
+
+    # Prepare the instructions
+    memory = bytearray(128)
+    memory[thunk_addr : thunk_addr + 5] = thunk
+    memory[func_addr] = 0xC3  # RET
+
+    binfile = RawImage.from_memory(bytes(memory))
+    assert unwrap_jump(binfile, thunk_addr) == (False, thunk_addr)
+    assert unwrap_jump(binfile, func_addr) == (False, func_addr)

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -172,3 +172,24 @@ def test_create_match_non_unique_fingerprint():
         functions={200: (write_sample,), 300: (write_sample,)}, thunks={}
     )
     assert not create_crt_matches(x_array, y_array)
+
+
+def test_create_match_with_elimination():
+    """Can create unique matches by eliminating already-matched functions."""
+    write_sample = (1234, True)
+    read_sample = (5000, False)
+    # `write_sample` can be used to match uniquely on the first pass.
+    # `read_sample` will provide a unique match after deleting the functions that contain `write_sample`.
+    x_array = CrtStartupArray(
+        functions={100: (read_sample,), 200: (write_sample, read_sample)},
+        thunks={},
+    )
+    y_array = CrtStartupArray(
+        functions={200: (read_sample,), 300: (write_sample, read_sample)},
+        thunks={},
+    )
+    # Must be this order:
+    assert create_crt_matches(x_array, y_array) == [
+        (200, 300),
+        (100, 200),
+    ]

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -3,6 +3,8 @@ from reccmp.analysis.crt_startup import (
     get_function_fingerprint,
     find_crt_startup_labels,
     analyze_crt_startup_functions,
+    CrtStartupArray,
+    create_crt_matches,
 )
 from reccmp.compare.db import EntityDb
 from reccmp.formats import PEImage
@@ -120,3 +122,45 @@ def test_xca_fingerprints_avoid_crash(binfile: PEImage):
         analyze_crt_startup_functions(db, ImageId.ORIG, binfile, modified_range)
     except struct.error:
         assert False, "Should not throw"
+
+
+def test_create_match_baseline():
+    """No errors or exceptions for empty CRT arrays."""
+    x_array = CrtStartupArray(functions={}, thunks={})
+    y_array = CrtStartupArray(functions={}, thunks={})
+    assert not create_crt_matches(x_array, y_array)
+
+
+def test_create_match_single():
+    """Should create match for unique fingerprint."""
+    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={})
+    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={})
+    assert create_crt_matches(x_array, y_array) == [(100, 200)]
+
+
+def test_create_match_single_with_thunks_one_sided():
+    """Should not add thunk match unless it exists in both arrays."""
+    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={100: 500})
+    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={})
+    assert create_crt_matches(x_array, y_array) == [(100, 200)]
+
+
+def test_create_match_single_with_thunks_two_sided():
+    """Should match function and thunk."""
+    x_array = CrtStartupArray(functions={100: (1234,)}, thunks={100: 500})
+    y_array = CrtStartupArray(functions={200: (1234,)}, thunks={200: 600})
+    assert create_crt_matches(x_array, y_array) == [(100, 200), (500, 600)]
+
+
+def test_create_match_blank_fingerprint():
+    """Should not match functions if their fingerprint has no addresses."""
+    x_array = CrtStartupArray(functions={100: ()}, thunks={})
+    y_array = CrtStartupArray(functions={200: ()}, thunks={})
+    assert not create_crt_matches(x_array, y_array)
+
+
+def test_create_match_non_unique_fingerprint():
+    """Should not match functions if their fingerprint is not unique."""
+    x_array = CrtStartupArray(functions={100: (1234,), 200: (1234,)}, thunks={})
+    y_array = CrtStartupArray(functions={200: (1234,), 300: (1234,)}, thunks={})
+    assert not create_crt_matches(x_array, y_array)


### PR DESCRIPTION
Fixes #426.

If the start and end labels for each of the four [CRT startup arrays](https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-170) are in the database, we will create function entities for each. For example, C++ initializers use the arrays `___xc_a` and `___xc_z`. The array begins with `0`, which we skip.

To match the functions between arrays, we need to figure out which variable is being initialized/destroyed. To do this, we read a snippet of code (64 bytes) and disassemble until we reach a `ret` instruction. From the disassembly, collect the addresses referenced in the function. Of those, we create a list of already matched entities identified as variables (`EntityType.DATA`). This is the function's "fingerprint".

For each fingerprint list that is not empty, match functions that are in the same CRT array in each binary.