### PR TITLE
Allow hex numbers in `size` field in CSV parser

### DIFF
--- a/docs/csv.md
+++ b/docs/csv.md
@@ -129,5 +129,6 @@ These fields can appear in the CSV file:
 | `name` | Name for the entity (e.g. the fully-qualified function name) | text |
 | `symbol` | Linker name | text |
 | `type` | Entity type | one of: `function, template, synthetic, library, stub, global, string, widechar, float, vtable` |
+| `size` | Size of the entity in bytes | Decimal number, or hex number with `0x` prefix |
 
 All other fields are ignored.

--- a/reccmp/compare/csv.py
+++ b/reccmp/compare/csv.py
@@ -130,7 +130,7 @@ def _convert_attrs(values: Iterable[tuple[str, str]]) -> CsvValuesType:
             output["name"] = value
 
         if key == "size":
-            output["size"] = int(value)
+            output["size"] = int(value, 0)
 
         if key == "type":
             type_name = value.strip().lower()

--- a/reccmp/compare/csv.py
+++ b/reccmp/compare/csv.py
@@ -54,6 +54,10 @@ class CsvInvalidEntityTypeError(ReccmpCsvParserError):
     """The entity type string did not match any of our allowed values."""
 
 
+class CsvInvalidNumberError(ReccmpCsvParserError):
+    """The string value is not a valid hex or decimal number."""
+
+
 CsvValueOptions = int | str | bool | EntityType
 
 
@@ -108,6 +112,16 @@ def _csv_preprocess(lines: Iterable[str]) -> Iterator[tuple[int, str]]:
         yield (i, line)
 
 
+def decimal_or_hex(value: str) -> int:
+    """Parse the string as either hex (with required '0x' or '0X' prefix) or decimal (no prefix)."""
+    is_hex = value.lower().startswith("0x")
+    base = 16 if is_hex else 10
+    try:
+        return int(value, base=base)
+    except ValueError as ex:
+        raise CsvInvalidNumberError(value) from ex
+
+
 def _convert_attrs(values: Iterable[tuple[str, str]]) -> CsvValuesType:
     """Both a filter and a conversion step for the row values.
     For the incoming iterable of key/value pairs, only output the ones we want set
@@ -130,7 +144,7 @@ def _convert_attrs(values: Iterable[tuple[str, str]]) -> CsvValuesType:
             output["name"] = value
 
         if key == "size":
-            output["size"] = int(value, 0)
+            output["size"] = decimal_or_hex(value)
 
         if key == "type":
             type_name = value.strip().lower()

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -8,6 +8,7 @@ from reccmp.compare.csv import (
     CsvInvalidAddressError,
     CsvNoDelimiterError,
     CsvInvalidEntityTypeError,
+    CsvInvalidNumberError,
     ReccmpCsvParserError,
 )
 
@@ -474,3 +475,62 @@ def test_non_function_entity_types():
         (0x3000, {"type": EntityType.FLOAT}),
         (0x4000, {"type": EntityType.VTABLE}),
     ]
+
+
+def test_size_decimal_or_hex():
+    """The size column will be interpreted as hex if it has the 0x prefix."""
+
+    text = dedent("""\
+        address,size
+        0x1000,0x10
+        0x2000,10
+        0x3000,0XC0,
+        0x4000,0010""")
+    assert list(csv_parse(text)) == [
+        (0x1000, {"size": 16}),
+        (0x2000, {"size": 10}),
+        (0x3000, {"size": 192}),
+        (0x4000, {"size": 10}),  # Leading zeroes permitted
+    ]
+
+
+def test_size_empty_valid():
+    """Should not raise exception if size contains 0-to-N whitespace characters."""
+
+    text = dedent("""\
+        address,size,x-test
+        0x1000,,test
+        0x2000,    ,test
+        0x3000,\t,test""")
+
+    # The `x-test` column is ignored.
+    # It is there to more clearly show the whitespace.
+    assert list(csv_parse(text)) == [
+        (0x1000, {}),
+        (0x2000, {}),
+        (0x3000, {}),
+    ]
+
+
+def test_size_invalid_hex_without_prefix():
+    """Hex values require the `0x` prefix."""
+    with pytest.raises(CsvInvalidNumberError):
+        list(csv_parse("address,size\n1000,beef"))
+
+
+def test_size_invalid_string():
+    """Raise an exception for values that are clearly not a hex or decimal number."""
+    with pytest.raises(CsvInvalidNumberError):
+        list(csv_parse("address,size\n1000,test"))
+
+
+def test_size_invalid_hex_suffix():
+    """Hex suffix `h` not supported."""
+    with pytest.raises(CsvInvalidNumberError):
+        list(csv_parse("address,size\n1000,1000h"))
+
+
+def test_size_invalid_hex_prefix_only():
+    """Throw for hex prefix without any digits."""
+    with pytest.raises(CsvInvalidNumberError):
+        list(csv_parse("address,size\n1000,0x"))


### PR DESCRIPTION
I've added a super simple patch that allows the CSV parser to additionally parse sizes as `0x`-prefixed hex numbers. I've also documented the `size` field, since that was missing.