### PR TITLE
Avoid divide by zero in asmcmp summary

### DIFF
--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -13,6 +13,7 @@ from reccmp.utils import (
     print_combined_diff,
     diff_json,
     percent_string,
+    safe_denominator,
     write_html_report,
 )
 
@@ -302,33 +303,36 @@ def main() -> int:
         # Use the alternate value if it exceeds the number of annotated functions
         function_count = max(function_count, int(args.total))
 
-    if function_count > 0:
-        implemented = implemented_funcs / function_count * 100
-        effective_accuracy = total_effective_accuracy / implemented_funcs * 100
-        # actual_accuracy = total_accuracy / implemented_funcs * 100
-        progress = total_effective_accuracy / function_count * 100
-        alignment_percentage = functions_aligned_count / function_count * 100
+    implemented = implemented_funcs / safe_denominator(function_count) * 100
 
+    effective_accuracy = (
+        total_effective_accuracy / safe_denominator(implemented_funcs) * 100
+    )
+    progress = total_effective_accuracy / safe_denominator(function_count) * 100
+    alignment_percentage = (
+        functions_aligned_count / safe_denominator(function_count) * 100
+    )
+
+    print(
+        f"\nImplemented:  {implemented:.2f}%  ({implemented_funcs} / {function_count})"
+    )
+    print(f"Accuracy:     {effective_accuracy:.2f}%")
+    print(f"Progress:     {progress:.2f}%")
+
+    if functions_aligned_count > 0:
         print(
-            f"\nImplemented:  {implemented:.2f}%  ({implemented_funcs} / {function_count})"
+            f"{functions_aligned_count} functions are aligned ({alignment_percentage:.2f}%)"
         )
-        print(f"Accuracy:     {effective_accuracy:.2f}%")
-        print(f"Progress:     {progress:.2f}%")
 
-        if functions_aligned_count > 0:
-            print(
-                f"{functions_aligned_count} functions are aligned ({alignment_percentage:.2f}%)"
-            )
-
-        if args.svg is not None:
-            gen_svg(
-                args.svg,
-                os.path.basename(target.original_path),
-                args.svg_icon,
-                implemented_funcs,
-                function_count,
-                total_effective_accuracy,
-            )
+    if args.svg is not None:
+        gen_svg(
+            args.svg,
+            os.path.basename(target.original_path),
+            args.svg_icon,
+            implemented_funcs,
+            function_count,
+            total_effective_accuracy,
+        )
     return 0
 
 

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -12,6 +12,12 @@ from reccmp.compare.report import (
 )
 
 
+def safe_denominator(v: int) -> int:
+    if v == 0:
+        return 1
+    return v
+
+
 def reccmp_pack_generator(lines: Iterable[str]) -> Iterator[str]:
     """Emits only lines between the "reccmp-pack-begin" and "reccmp-pack-end" markers.
     Intended to remove ES6 imports and exports that are not compatible with our
@@ -66,8 +72,8 @@ def gen_svg(
         {
             "name": name_svg,
             "icon": icon_data,
-            "implemented": f"{(svg_implemented_funcs / total_funcs * 100):.2f}% ({svg_implemented_funcs}/{total_funcs})",
-            "accuracy": f"{(raw_accuracy / svg_implemented_funcs * 100):.2f}%",
+            "implemented": f"{(svg_implemented_funcs / safe_denominator(total_funcs) * 100):.2f}% ({svg_implemented_funcs}/{total_funcs})",
+            "accuracy": f"{(raw_accuracy / safe_denominator(svg_implemented_funcs) * 100):.2f}%",
             "progbar": total_statistic * full_percentbar_width,
             "percent": f"{(total_statistic * 100):.2f}%",
         },


### PR DESCRIPTION
Fixes this error:
```
Traceback (most recent call last):
  File "/home/maarten/.local/bin/reccmp-reccmp", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/maarten/projects/reccmp/reccmp/tools/asmcmp.py", line 307, in main
    effective_accuracy = total_effective_accuracy / implemented_funcs * 100
                         ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
ZeroDivisionError: division by zero
```