### PR TITLE
Code annotation aliases

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -5,6 +5,7 @@ from typing import Iterable, Iterator
 from typing_extensions import Self
 from reccmp.project.detect import RecCmpTarget
 from reccmp.compare.diff import EntityCompareResult, RawDiffOutput
+from reccmp.parser.marker import ProjectAliases, normalize_project_aliases
 from reccmp.dir import source_code_search
 from reccmp.compare.functions import FunctionComparator
 from reccmp.formats import (
@@ -82,6 +83,7 @@ class Compare:
     types: CvdumpTypesParser
     function_comparator: FunctionComparator
     data_sources: list[TextFile]
+    project_aliases: ProjectAliases
 
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-positional-arguments
@@ -94,6 +96,7 @@ class Compare:
         encoding: str | None = None,
         code_files: list[TextFile] | None = None,
         data_sources: list[TextFile] | None = None,
+        project_aliases: ProjectAliases | None = None,
     ):
         self.orig_bin = orig_bin
         self.recomp_bin = recomp_bin
@@ -101,6 +104,7 @@ class Compare:
         self.target_id = target_id
         self.src_encoding = encoding or "utf-8"
         self.bin_encoding = encoding or "latin1"
+        self.project_aliases = normalize_project_aliases(project_aliases or {})
 
         if isinstance(code_files, list):
             self.code_files = code_files
@@ -146,6 +150,7 @@ class Compare:
             self.target_id,
             self._db,
             self.bin_encoding,
+            self.project_aliases,
             self.report,
         )
 
@@ -237,6 +242,8 @@ class Compare:
             )
         )
 
+        project_aliases = {target.target_id : target.marker_aliases}
+
         compare = cls(
             origfile,
             recompfile,
@@ -245,6 +252,7 @@ class Compare:
             encoding=target.encoding,
             data_sources=data_sources,
             code_files=code_files,
+            project_aliases=project_aliases,
         )
         compare.run()
         return compare

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -242,7 +242,7 @@ class Compare:
             )
         )
 
-        project_aliases = {target.target_id : target.marker_aliases}
+        project_aliases = {target.target_id: target.marker_aliases}
 
         compare = cls(
             origfile,

--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -11,6 +11,7 @@ from reccmp.formats.exceptions import (
 from reccmp.formats import PEImage, TextFile
 from reccmp.cvdump import CvdumpTypesParser, CvdumpAnalysis
 from reccmp.parser import DecompCodebase
+from reccmp.parser.marker import ProjectAliases
 from reccmp.types import EntityType, ImageId
 from reccmp.compare.event import (
     ReccmpEvent,
@@ -148,10 +149,11 @@ def load_markers(
     target_id: str,
     db: EntityDb,
     encoding: str = "latin1",
+    project_aliases: ProjectAliases | None = None,
     report: ReccmpReportProtocol = reccmp_report_nop,
 ):
     lines_db.add_local_paths((f.path for f in code_files))
-    codebase = DecompCodebase(code_files, target_id)
+    codebase = DecompCodebase(code_files, target_id, aliases=project_aliases)
 
     # If the address of any annotation would cause an exception,
     # remove it and report an error.

--- a/reccmp/parser/codebase.py
+++ b/reccmp/parser/codebase.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Iterable, Iterator
 from reccmp.formats import TextFile
+from .marker import ProjectAliases
 from .parser import DecompParser
 from .node import (
     ParserLineSymbol,
@@ -14,10 +15,15 @@ from .node import (
 
 
 class DecompCodebase:
-    def __init__(self, files: Iterable[TextFile], module: str) -> None:
+    def __init__(
+        self,
+        files: Iterable[TextFile],
+        module: str,
+        aliases: ProjectAliases | None = None,
+    ) -> None:
         self._symbols: list[ParserSymbol] = []
 
-        parser = DecompParser()
+        parser = DecompParser(aliases)
         for f in files:
             parser.reset_and_set_filename(f.path)
             parser.read(f.text)

--- a/reccmp/parser/error.py
+++ b/reccmp/parser/error.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from dataclasses import dataclass
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 
 class AlertCode(Enum):
@@ -54,6 +54,9 @@ class AlertCode(Enum):
     # This makes no sense, so we ignore the option.
     SYMBOL_OPTION_IGNORED = 113
 
+    # WARN: The alias does not point to a valid marker type and has no effect.
+    ALIAS_GOES_NOWHERE = 114
+
     # This code or higher is an error, not a warning
     DECOMP_ERROR_START = 200
 
@@ -86,6 +89,13 @@ class AlertCode(Enum):
     # is implemented so we can match with the PDB.
     NO_IMPLEMENTATION = 207
 
+    # ERROR: An alias was reused. Only the first occurrence of each
+    # case-insensitive key is used. The rest are ignored.
+    ALIAS_DUPLICATE_KEY = 208
+
+    # ERROR: An alias matches a built-in marker type string, and was dropped.
+    ALIAS_REDEFINES_BUILTIN = 209
+
     # This code or higher is a critical error
     DECOMP_CRITICAL_START = 300
 
@@ -99,7 +109,7 @@ class AlertCode(Enum):
 @dataclass
 class ParserAlert:
     code: AlertCode
-    path: PurePath
+    path: PurePath | Path
     line_number: int = -1
     detail: str | None = None
     target: str | None = None

--- a/reccmp/parser/error.py
+++ b/reccmp/parser/error.py
@@ -7,8 +7,8 @@ class AlertCode(Enum):
     # WARN: Stub function exceeds some line number threshold
     UNLIKELY_STUB = 100
 
-    # WARN: Decomp marker is close enough to be recognized, but does not follow syntax exactly
-    BAD_DECOMP_MARKER = 101
+    # WARN: Decomp marker does not follow strict syntax.
+    NOT_STRICT_FORMAT = 101
 
     # WARN: Multiple markers in sequence do not have distinct modules
     DUPLICATE_MODULE = 102
@@ -18,7 +18,7 @@ class AlertCode(Enum):
 
     # WARN: We read a line that matches the decomp marker pattern, but we are not set up
     # to handle it
-    BOGUS_MARKER = 104
+    UNKNOWN_ANNOTATION = 104
 
     # WARN: New function marker appeared while we were inside a function
     MISSED_END_OF_FUNCTION = 105
@@ -100,8 +100,8 @@ class AlertCode(Enum):
 class ParserAlert:
     code: AlertCode
     path: PurePath
-    line_number: int
-    line: str | None = None
+    line_number: int = -1
+    detail: str | None = None
     target: str | None = None
 
     def is_warning(self) -> bool:

--- a/reccmp/parser/linter.py
+++ b/reccmp/parser/linter.py
@@ -95,7 +95,7 @@ def check_offset_uniqueness(results: Sequence[ReccmpParserResult]) -> list[Parse
                         code=AlertCode.DUPLICATE_OFFSET,
                         path=result.path,
                         line_number=marker.line_number,
-                        line=f"0x{marker.offset:08x}",
+                        detail=f"0x{marker.offset:08x}",
                         target=marker.module,
                     )
                 )
@@ -125,7 +125,7 @@ def check_string_text(results: Sequence[ReccmpParserResult]) -> list[ParserAlert
                             code=AlertCode.WRONG_STRING,
                             path=result.path,
                             line_number=marker.line_number,
-                            line=f"0x{marker.offset:08x}, {repr(existing_string)} vs. {repr(marker.name)}",
+                            detail=f"0x{marker.offset:08x}, {repr(existing_string)} vs. {repr(marker.name)}",
                             target=marker.module,
                         )
                     )

--- a/reccmp/parser/marker.py
+++ b/reccmp/parser/marker.py
@@ -1,6 +1,9 @@
 import re
 from enum import Enum
 
+TargetAliases = dict[str, str]
+ProjectAliases = dict[str, TargetAliases]
+
 
 class MarkerCategory(Enum):
     """For the purposes of grouping multiple different DecompMarkers together,
@@ -133,14 +136,67 @@ class DecompMarker:
         return self._type in (MarkerType.GLOBAL, MarkerType.STRING, MarkerType.LINE)
 
 
-def match_marker(line: str) -> DecompMarker | None:
+def normalize_target_aliases(aliases: TargetAliases) -> TargetAliases:
+    """Drop invalid aliases that meet one of these criteria:
+    1. They try to overwrite a built-in marker type. e.g. FUNCTION -> GLOBAL
+    2. They do not point to a built-in marker type. e.g. TEST -> HELLO
+    3. They repeat a previous alias. e.g. aliases on "Func" and "func" (different case)
+    """
+    builtin_types = {t.name for t in MarkerType}
+    allowed_pairs = []
+    seen_keys = set()
+
+    for key, value in aliases.items():
+        if (
+            key.upper() not in builtin_types
+            and value.upper() in builtin_types
+            and key.upper() not in seen_keys
+        ):
+            # Key name converted for lookup
+            seen_keys.add(key.upper())
+            allowed_pairs.append((key.upper(), value))
+
+    return dict(allowed_pairs)
+
+
+def normalize_project_aliases(project_aliases: ProjectAliases) -> ProjectAliases:
+    output = {}
+
+    for target, aliases in project_aliases.items():
+        normalized = normalize_target_aliases(aliases)
+        # Drop this target if there are no valid aliases left.
+        if normalized:
+            # Target name converted for lookup
+            output[target.upper()] = normalized
+
+    return output
+
+
+def resolve_alias(marker_type: str, target_name: str, aliases: ProjectAliases) -> str:
+    if not aliases or target_name.upper() not in aliases:
+        return marker_type
+
+    return aliases[target_name.upper()].get(marker_type.upper(), marker_type)
+
+
+def match_marker(
+    line: str, aliases: ProjectAliases | None = None
+) -> DecompMarker | None:
+    if aliases is None:
+        aliases = {}
+
     match = markerRegex.match(line)
     if match is None:
         return None
 
+    marker_type = match.group("type")
+    target_name = match.group("module")
+
+    marker_type = resolve_alias(marker_type, target_name, aliases)
+
     return DecompMarker(
-        marker_type=match.group("type"),
-        module=match.group("module"),
+        marker_type=marker_type,
+        module=target_name,
         offset=int(match.group("offset"), 16),
         extra=match.group("extra"),
     )

--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -222,7 +222,7 @@ class DecompParser:
                 path=self.filename,
                 line_number=self.line_number,
                 code=code,
-                line=self.last_line.strip(),
+                detail=self.last_line.strip(),
             )
         )
 
@@ -461,7 +461,7 @@ class DecompParser:
             self._line_marker(marker)
 
         else:
-            self._syntax_warning(AlertCode.BOGUS_MARKER)
+            self._syntax_warning(AlertCode.UNKNOWN_ANNOTATION)
 
     def read_line(self, line: str):
         if self.state == ReaderState.DONE:
@@ -475,7 +475,7 @@ class DecompParser:
             # TODO: what's the best place for this?
             # Does it belong with reading or marker handling?
             if not is_marker_exact(self.last_line):
-                self._syntax_warning(AlertCode.BAD_DECOMP_MARKER)
+                self._syntax_warning(AlertCode.NOT_STRICT_FORMAT)
             self._handle_marker(marker)
             return
 

--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -20,6 +20,7 @@ from .marker import (
     MarkerCategory,
     match_marker,
     is_marker_exact,
+    ProjectAliases,
 )
 from .node import (
     ParserLineSymbol,
@@ -133,7 +134,7 @@ class DecompParser:
     # pylint: disable=too-many-instance-attributes
     # Could combine output lists into a single list to get under the limit,
     # but not right now
-    def __init__(self) -> None:
+    def __init__(self, aliases: ProjectAliases | None = None) -> None:
         # The lists to be populated as we parse
         self._symbols: list[ParserSymbol] = []
         self.alerts: list[ParserAlert] = []
@@ -166,6 +167,8 @@ class DecompParser:
         self.function_sig: str = ""
 
         self.filename: PurePath = PurePath("")
+
+        self.aliases = aliases or {}
 
     def reset_and_set_filename(self, filename: PurePath):
         self._symbols = []
@@ -470,7 +473,7 @@ class DecompParser:
         self.last_line = line  # TODO: Useful or hack for error reporting?
         self.line_number += 1
 
-        marker = match_marker(line)
+        marker = match_marker(line, aliases=self.aliases)
         if marker is not None:
             # TODO: what's the best place for this?
             # Does it belong with reading or marker handling?

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -90,6 +90,10 @@ class ProjectFileTarget(BaseModel):
     encoding: str | None = Field(default=None)
     ghidra: YmlGhidraConfig = Field(default_factory=YmlGhidraConfig.default)
     report: YmlReportConfig = Field(default_factory=YmlReportConfig.default)
+    marker_aliases: dict[str, str] = Field(
+        validation_alias=AliasChoices("marker-aliases", "marker_aliases"),
+        default_factory=dict,
+    )
 
 
 class ProjectFile(YmlFileModel):

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -169,6 +169,8 @@ class RecCmpPartialTarget:
     # Data to set directly in the database (addresses refer to orig binary)
     data_sources: list[Path] | None = None
 
+    marker_aliases: dict[str, str] | None = None
+
 
 @dataclass
 class RecCmpTarget:
@@ -207,6 +209,8 @@ class RecCmpTarget:
 
     # Data to set directly in the database (addresses refer to orig binary)
     data_sources: list[Path] = field(default_factory=list)
+
+    marker_aliases: dict[str, str] = field(default_factory=dict)
 
 
 class RecCmpProject:
@@ -264,6 +268,7 @@ class RecCmpProject:
             ghidra = GhidraConfig()
 
         data_sources = target.data_sources or []
+        marker_aliases = target.marker_aliases or {}
 
         if target.report_config is not None:
             report = target.report_config
@@ -281,6 +286,7 @@ class RecCmpProject:
             source_paths=target.source_paths,
             ghidra_config=ghidra,
             data_sources=data_sources,
+            marker_aliases=marker_aliases,
             report_config=report,
         )
 
@@ -394,6 +400,7 @@ class RecCmpProject:
                 source_paths=source_paths,
                 ghidra_config=ghidra,
                 data_sources=data_sources,
+                marker_aliases=target.marker_aliases,
                 report_config=report,
             )
 

--- a/reccmp/tools/decomplint.py
+++ b/reccmp/tools/decomplint.py
@@ -40,6 +40,7 @@ def display_errors(alerts: Iterable[ParserAlert], filename: Path | PurePath):
     print(filename)
 
     for alert in sorted_alerts:
+        line_number = alert.line_number if alert.line_number > 0 else ""
         error_type = (
             f"{reccmp.color.Fore.RED}error: "
             if alert.is_error()
@@ -48,7 +49,7 @@ def display_errors(alerts: Iterable[ParserAlert], filename: Path | PurePath):
         components = [
             "  ",
             reccmp.color.Fore.LIGHTWHITE_EX,
-            f"{alert.line_number:4}",
+            f"{line_number:4}",
             " : ",
             " ",
             error_type,
@@ -58,8 +59,8 @@ def display_errors(alerts: Iterable[ParserAlert], filename: Path | PurePath):
         ]
         print("".join(components), end="")
 
-        if alert.line is not None:
-            print(f"{reccmp.color.Fore.WHITE}  {alert.line}", end="")
+        if alert.detail is not None:
+            print(f"{reccmp.color.Fore.WHITE}  {alert.detail}", end="")
 
         print()
 
@@ -184,18 +185,14 @@ def lint_all_targets(lint_targets: tuple[DecomplintTarget, ...]) -> list[ParserA
             parser_results[(path, encoding)] = parse_file(file)
 
         except FileNotFoundError:
-            all_alerts.append(
-                ParserAlert(code=AlertCode.FILE_NOT_FOUND, path=path, line_number=-1)
-            )
+            all_alerts.append(ParserAlert(code=AlertCode.FILE_NOT_FOUND, path=path))
 
         except UnicodeDecodeError:
-            # Encoding is here as the "line" of the alert just so it's displayed to the user.
             all_alerts.append(
                 ParserAlert(
                     code=AlertCode.UNICODE_DECODE_ERROR,
                     path=path,
-                    line_number=-1,
-                    line=encoding,
+                    detail=encoding,
                 )
             )
 

--- a/reccmp/tools/decomplint.py
+++ b/reccmp/tools/decomplint.py
@@ -10,6 +10,7 @@ import reccmp
 import reccmp.color
 from reccmp.dir import source_code_search
 from reccmp.parser import DecompParser, ReccmpParserResult
+from reccmp.parser.marker import MarkerType, ProjectAliases, normalize_project_aliases
 from reccmp.parser.linter import (
     check_byname_allowed,
     check_function_order,
@@ -116,6 +117,9 @@ class DecomplintTarget:
     paths: tuple[Path, ...]
     module: str | None
     encoding: str
+    # Project-file only:
+    project_file_path: Path | None = None
+    aliases: dict[str, str] | None = None
 
 
 def decomplint_parse_args(
@@ -149,17 +153,76 @@ def decomplint_parse_args(
         module = target.target_id
         encoding = target.encoding or "utf-8"
 
-        options.append(DecomplintTarget(paths, module, encoding))
+        options.append(
+            DecomplintTarget(
+                paths,
+                module,
+                encoding,
+                project_file_path=project.project_config_path,
+                aliases=target.marker_aliases,
+            )
+        )
 
     return tuple(options)
 
 
-def parse_file(file: TextFile) -> ReccmpParserResult:
-    parser = DecompParser()
+def parse_file(file: TextFile, aliases: ProjectAliases | None) -> ReccmpParserResult:
+    parser = DecompParser(aliases)
     parser.reset_and_set_filename(file.path)
     parser.read(file.text)
     parser.finish()
     return parser.to_result()
+
+
+def check_aliases(lint_targets: tuple[DecomplintTarget, ...]) -> list[ParserAlert]:
+    """Verify the marker aliases applied to each target."""
+    builtin_types = {t.name for t in MarkerType}
+    alerts = []
+
+    for target in lint_targets:
+        if target.aliases is None:
+            continue
+
+        # mypy
+        project_file_path = target.project_file_path or PurePath("")
+
+        assert isinstance(target.aliases, dict)
+
+        seen_keys = set()
+        for key, value in target.aliases.items():
+            if key.upper() in builtin_types:
+                alerts.append(
+                    ParserAlert(
+                        code=AlertCode.ALIAS_REDEFINES_BUILTIN,
+                        path=project_file_path,
+                        detail=f"{key} : {value}",
+                        target=target.module,
+                    )
+                )
+
+            if value.upper() not in builtin_types:
+                alerts.append(
+                    ParserAlert(
+                        code=AlertCode.ALIAS_GOES_NOWHERE,
+                        path=project_file_path,
+                        detail=f"{key} : {value}",
+                        target=target.module,
+                    )
+                )
+
+            if key.upper() in seen_keys:
+                alerts.append(
+                    ParserAlert(
+                        code=AlertCode.ALIAS_DUPLICATE_KEY,
+                        path=project_file_path,
+                        detail=f"{key} : {value}",
+                        target=target.module,
+                    )
+                )
+
+            seen_keys.add(key.upper())
+
+    return alerts
 
 
 def lint_all_targets(lint_targets: tuple[DecomplintTarget, ...]) -> list[ParserAlert]:
@@ -177,12 +240,22 @@ def lint_all_targets(lint_targets: tuple[DecomplintTarget, ...]) -> list[ParserA
     # Collect all parser/linter alerts here and worry about sorting/collating later.
     all_alerts = []
 
+    # Combine aliases for each target by their target name.
+    # We need them all together because we read all markers from all files once.
+    # (It's not currently possible to provide aliases at the command line.)
+    project_aliases = {
+        target.module: target.aliases
+        for target in lint_targets
+        if target.module is not None and target.aliases is not None
+    }
+    project_aliases = normalize_project_aliases(project_aliases)
+
     # Open each (path, encoding) combination once, then collect code annotations.
     parser_results = {}
     for path, encoding in all_paths:
         try:
             file = TextFile.from_file(path, encoding=encoding)
-            parser_results[(path, encoding)] = parse_file(file)
+            parser_results[(path, encoding)] = parse_file(file, project_aliases)
 
         except FileNotFoundError:
             all_alerts.append(ParserAlert(code=AlertCode.FILE_NOT_FOUND, path=path))
@@ -227,6 +300,7 @@ def main() -> int:
         return 1
 
     all_alerts = lint_all_targets(lint_targets)
+    all_alerts.extend(check_aliases(lint_targets))
 
     # Finished linting: report errors.
     error_count = 0

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -624,3 +624,35 @@ def test_load_code_folded(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     assert entity is not None
     assert entity.recomp_addr == 0x5555
     assert entity.get("type") == EntityType.FUNCTION
+
+
+def test_load_code_with_alias(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
+    """Should ignore unknown annotations until we provide a valid alias."""
+    files = (
+        TextFile(
+            PurePath("test.cpp"),
+            dedent("""\
+                // fun: TEST 0x10001000
+                // Hello::Test"""),
+        ),
+    )
+
+    # Nothing created for custom annotation.
+    load_markers(files, lines_db, binfile, "TEST", db)
+    entity = db.get(ImageId.ORIG, 0x10001000)
+    assert entity is None
+
+    # Should create function entity after adding alias.
+    load_markers(
+        files,
+        lines_db,
+        binfile,
+        "TEST",
+        db,
+        # Aliases have been normalized, so "FUN" here matches "fun" in the code.
+        project_aliases={"TEST": {"FUN": "FUNCTION"}},
+    )
+    entity = db.get(ImageId.ORIG, 0x10001000)
+    assert entity is not None
+    assert entity.get("name") == "Hello::Test"
+    assert entity.get("type") == EntityType.FUNCTION

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,7 +34,7 @@ def test_not_exact_syntax(parser):
     Doing this means we don't have to save the actual text."""
     parser.read("// function: test 0x1234")
     assert len(parser.alerts) == 1
-    assert parser.alerts[0].code == AlertCode.BAD_DECOMP_MARKER
+    assert parser.alerts[0].code == AlertCode.NOT_STRICT_FORMAT
 
 
 def test_invalid_marker(parser):
@@ -43,7 +43,7 @@ def test_invalid_marker(parser):
     assert parser.state == ReaderState.SEARCH
 
     assert len(parser.alerts) == 1
-    assert parser.alerts[0].code == AlertCode.BOGUS_MARKER
+    assert parser.alerts[0].code == AlertCode.UNKNOWN_ANNOTATION
 
 
 def test_incompatible_marker(parser):
@@ -732,7 +732,7 @@ def test_mixed_case_module_name(parser):
 
     # Syntax warning for mixed-case module name.
     assert len(parser.alerts) == 1
-    assert parser.alerts[0].code == AlertCode.BAD_DECOMP_MARKER
+    assert parser.alerts[0].code == AlertCode.NOT_STRICT_FORMAT
 
 
 def test_folded_option(parser):

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -5,6 +5,7 @@ from reccmp.parser.marker import (
     MarkerType,
     match_marker,
     is_marker_exact,
+    normalize_project_aliases,
 )
 from reccmp.parser.util import (
     is_blank_or_comment,
@@ -220,3 +221,50 @@ def test_marker_trailing_spaces():
     assert marker is not None
     assert marker.offset == 0x1234
     assert marker.extra is None
+
+
+def test_marker_aliases():
+    # No alias
+    marker = match_marker("// FUNC: TEST 0x1234")
+    assert marker and marker.type == MarkerType.UNKNOWN
+
+    # Alias demo
+    marker = match_marker("// FUNC: TEST 0x1234", {"TEST": {"FUNC": "FUNCTION"}})
+    assert marker and marker.type == MarkerType.FUNCTION
+
+    # Aliases are scoped by target
+    marker = match_marker("// FUNC: TEST 0x1234", {"HELLO": {"FUNC": "FUNCTION"}})
+    assert marker and marker.type == MarkerType.UNKNOWN
+
+    # Alias goes nowhere
+    marker = match_marker("// FUNC: TEST 0x1234", {"TEST": {"FUNC": "FUNCTINO"}})
+    assert marker and marker.type == MarkerType.UNKNOWN
+
+    # Double alias not followed
+    marker = match_marker(
+        "// FUNC: TEST 0x1234", {"TEST": {"FUNC": "FUNCTINO", "FUNCTION": "FUNCTION"}}
+    )
+    assert marker and marker.type == MarkerType.UNKNOWN
+
+
+def test_normalize_project_aliases():
+    assert not normalize_project_aliases({})
+
+    # Normalize target and alias names for lookup
+    assert normalize_project_aliases({"test": {"func": "FUNCTION"}}) == {
+        "TEST": {"FUNC": "FUNCTION"}
+    }
+
+    # Drop empty alias lists
+    assert not normalize_project_aliases({"TEST": {}})
+
+    # Drop aliases that point to nothing
+    assert not normalize_project_aliases({"TEST": {"func": "FUNC"}})
+
+    # Drop aliases that try to reassign a built-in type
+    assert not normalize_project_aliases({"TEST": {"FUNCTION": "GLOBAL"}})
+
+    # Drop duplicated alias
+    assert normalize_project_aliases(
+        {"TEST": {"func": "FUNCTION", "FUNC": "TEMPLATE"}}
+    ) == {"TEST": {"FUNC": "FUNCTION"}}

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -224,6 +224,7 @@ def test_marker_trailing_spaces():
 
 
 def test_marker_aliases():
+    """Testing with aliases that have been normalized by normalize_project_aliases()"""
     # No alias
     marker = match_marker("// FUNC: TEST 0x1234")
     assert marker and marker.type == MarkerType.UNKNOWN
@@ -237,12 +238,12 @@ def test_marker_aliases():
     assert marker and marker.type == MarkerType.UNKNOWN
 
     # Alias goes nowhere
-    marker = match_marker("// FUNC: TEST 0x1234", {"TEST": {"FUNC": "FUNCTINO"}})
+    marker = match_marker("// FUNC: TEST 0x1234", {"TEST": {"FUNC": "HELLO"}})
     assert marker and marker.type == MarkerType.UNKNOWN
 
     # Double alias not followed
     marker = match_marker(
-        "// FUNC: TEST 0x1234", {"TEST": {"FUNC": "FUNCTINO", "FUNCTION": "FUNCTION"}}
+        "// FUNC: TEST 0x1234", {"TEST": {"FUNC": "HELLO", "HELLO": "FUNCTION"}}
     )
     assert marker and marker.type == MarkerType.UNKNOWN
 

--- a/tests/test_project_yml.py
+++ b/tests/test_project_yml.py
@@ -134,3 +134,27 @@ def test_project_source_root_missing_key():
 
     assert isinstance(p.targets["TEST"].source_root, tuple)
     assert p.targets["TEST"].source_root == ()
+
+
+def test_project_marker_aliases():
+    p = ProjectFile.from_str("""\
+        targets:
+            TEST:
+                hash:
+                    sha256: test
+                filename: test.exe
+        """)
+
+    assert not p.targets["TEST"].marker_aliases
+
+    p = ProjectFile.from_str("""\
+        targets:
+            TEST:
+                hash:
+                    sha256: test
+                filename: test.exe
+                marker-aliases:
+                    fun: FUNCTION
+        """)
+
+    assert p.targets["TEST"].marker_aliases == {"fun": "FUNCTION"}


### PR DESCRIPTION
Adds support for aliases of annotation types, effectively providing custom annotations.
e.g.
```cpp
// func: test 0x123456
```
will work with
```yml
targets:
  test:
    # ...
    marker-aliases:
      func: FUNCTION
```

Aliases must follow these rules:
1. They must point directly to a built-in type. Double aliases are not evaluated.
2. They must be unique (case-insensitive) among the set. Only the first is used if there are duplicates. You cannot have `func` and `Func` alias two different internal types.
3. They must not overwrite a built-in annotation type.

`decomplint` will alert to any problems.

I took the opportunity to rename some linter errors to be more useful:
- `bad_decomp_marker` is now `not_strict_format` to suggest that we read the annotation without a problem, but it does not follow the style guide we established on `LEGO1`. (We probably should give users the option to disable this check altogether since the syntax parameters are not customizable. See #123 for some discussion on how we could do this.)
- The Bill and Ted inspired `bogus_marker` is now `unknown_annotation` so it's more clear that we did not do anything with the value. This is a warning and not an error because there is the potential for regular comments to be mistaken for reccmp markers. Without an indicator character (e.g. javadoc `/**`) I don't think we can spot these with 100% accuracy.

And finally, I changed some parameters in `ParserAlert` to be more broadly useful.

I don't love the prop drilling of the aliases, but I don't want to delay this further while I figure that out. The list of parameters in `Compare.__init__()` is getting unmanageable; this is also something I want to address in a future update.
