### PR TITLE
Improve JSON diff reporting

### DIFF
--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -293,7 +293,7 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
 
 
 class ReccmpDiffJudgement(enum.Enum):
-    NOTHING = enum.auto()
+    NO_CHANGE = enum.auto()
     """The entity did not change in a way worth reporting."""
     NEW = enum.auto()
     """This entity did not appear in the saved report."""
@@ -322,7 +322,7 @@ def entity_diff_change(
     # Do not report changes if the entity is a stub in both reports.
     # (Regression in GH #405)
     if saved.is_stub and new.is_stub:
-        return ReccmpDiffJudgement.NOTHING
+        return ReccmpDiffJudgement.NO_CHANGE
 
     if saved.is_stub and not new.is_stub:
         return ReccmpDiffJudgement.INCREASE
@@ -341,7 +341,7 @@ def entity_diff_change(
 
     # Don't report internal accuracy changes if it is still an effective match.
     if saved.is_effective_match and new.is_effective_match:
-        return ReccmpDiffJudgement.NOTHING
+        return ReccmpDiffJudgement.NO_CHANGE
 
     # Don't consider accuracy if either report has an effective match.
     if saved.is_effective_match and not new.is_effective_match:
@@ -357,7 +357,7 @@ def entity_diff_change(
     if saved.accuracy > new.accuracy:
         return ReccmpDiffJudgement.DECREASE
 
-    return ReccmpDiffJudgement.NOTHING
+    return ReccmpDiffJudgement.NO_CHANGE
 
 
 def diff_json(

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -1,4 +1,5 @@
 import base64
+import enum
 from datetime import datetime
 from typing import Iterable, Iterator
 import logging
@@ -291,6 +292,64 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
     return formatter
 
 
+class ReccmpDiffJudgement(enum.Enum):
+    NOTHING = enum.auto()
+    """The entity did not change in a way worth reporting."""
+    NEW = enum.auto()
+    """This entity did not appear in the saved report."""
+    INCREASE = enum.auto()
+    """This entity's accuracy increased from the saved report."""
+    DECREASE = enum.auto()
+    """This entity's accuracy decreased from the saved report."""
+    DROPPED = enum.auto()
+    """This entity no longer exists."""
+    ENTROPY = enum.auto()
+    """This entity's accuracy changed, but we have determined it to be functionally-equivalent."""
+
+
+# pylint: disable=too-many-return-statements
+def entity_diff_change(
+    saved: ReccmpComparedEntity | None, new: ReccmpComparedEntity | None
+) -> ReccmpDiffJudgement:
+    if saved is None:
+        return ReccmpDiffJudgement.NEW
+
+    if new is None or (
+        new is not None and saved is not None and new.is_stub and not saved.is_stub
+    ):
+        return ReccmpDiffJudgement.DROPPED
+
+    if (
+        saved is not None
+        and new is not None
+        and (
+            new.effective_accuracy > saved.effective_accuracy
+            or (not new.is_stub and saved.is_stub)
+        )
+    ):
+        return ReccmpDiffJudgement.INCREASE
+
+    if (
+        saved is not None
+        and new is not None
+        and new.effective_accuracy < saved.effective_accuracy
+        and not saved.is_stub
+        and not new.is_stub
+    ):
+        return ReccmpDiffJudgement.DECREASE
+
+    if (
+        saved is not None
+        and new is not None
+        and new.effective_accuracy == 1.0
+        and saved.effective_accuracy == 1.0
+        and new.is_effective_match != saved.is_effective_match
+    ):
+        return ReccmpDiffJudgement.ENTROPY
+
+    return ReccmpDiffJudgement.NOTHING
+
+
 def diff_json(
     saved_data: ReccmpStatusReport,
     new_data: ReccmpStatusReport,
@@ -339,70 +398,24 @@ def diff_json(
         for addr in sorted(all_addrs)
     }
 
-    DiffSubsectionType = dict[
-        str, tuple[ReccmpComparedEntity | None, ReccmpComparedEntity | None]
-    ]
-
-    # The criteria for diff judgement is in these dict comprehensions:
-    # Any function not in the saved file
-    new_functions: DiffSubsectionType = {
-        key: (saved, new) for key, (saved, new) in combined.items() if saved is None
-    }
-
-    # Any function now missing from the saved file
-    # or a non-stub -> stub conversion
-    dropped_functions: DiffSubsectionType = {
-        key: (saved, new)
-        for key, (saved, new) in combined.items()
-        if new is None
-        or (new is not None and saved is not None and new.is_stub and not saved.is_stub)
-    }
-
-    # TODO: move these two into functions if the assessment gets more complex
-    # Any function with increased match percentage
-    # or stub -> non-stub conversion
-    improved_functions: DiffSubsectionType = {
-        key: (saved, new)
-        for key, (saved, new) in combined.items()
-        if saved is not None
-        and new is not None
-        and (
-            new.effective_accuracy > saved.effective_accuracy
-            or (not new.is_stub and saved.is_stub)
-        )
-    }
-
-    # Any non-stub function with decreased match percentage
-    degraded_functions: DiffSubsectionType = {
-        key: (saved, new)
-        for key, (saved, new) in combined.items()
-        if saved is not None
-        and new is not None
-        and new.effective_accuracy < saved.effective_accuracy
-        and not saved.is_stub
-        and not new.is_stub
-    }
-
-    # Any function with former or current "effective" match
-    entropy_functions: DiffSubsectionType = {
-        key: (saved, new)
-        for key, (saved, new) in combined.items()
-        if saved is not None
-        and new is not None
-        and new.effective_accuracy == 1.0
-        and saved.effective_accuracy == 1.0
-        and new.is_effective_match != saved.is_effective_match
+    judgements = {
+        key: entity_diff_change(*diff_pair) for key, diff_pair in combined.items()
     }
 
     get_diff_str = diff_json_display(show_both_addrs, is_plain)
 
-    for diff_name, diff_dict in [
-        ("New", new_functions),
-        ("Increased", improved_functions),
-        ("Decreased", degraded_functions),
-        ("Dropped", dropped_functions),
-        ("Compiler entropy", entropy_functions),
+    for diff_name, diff_judgement in [
+        ("New", ReccmpDiffJudgement.NEW),
+        ("Increased", ReccmpDiffJudgement.INCREASE),
+        ("Decreased", ReccmpDiffJudgement.DECREASE),
+        ("Dropped", ReccmpDiffJudgement.DROPPED),
+        ("Compiler entropy", ReccmpDiffJudgement.ENTROPY),
     ]:
+        diff_dict = {
+            key: value
+            for key, value in combined.items()
+            if judgements.get(key) == diff_judgement
+        }
         if len(diff_dict) == 0:
             continue
 

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -311,41 +311,51 @@ class ReccmpDiffJudgement(enum.Enum):
 def entity_diff_change(
     saved: ReccmpComparedEntity | None, new: ReccmpComparedEntity | None
 ) -> ReccmpDiffJudgement:
-    if saved is None:
+    if saved is None and new is not None:
         return ReccmpDiffJudgement.NEW
 
-    if new is None or (
-        new is not None and saved is not None and new.is_stub and not saved.is_stub
-    ):
+    if saved is not None and new is None:
         return ReccmpDiffJudgement.DROPPED
 
-    if (
-        saved is not None
-        and new is not None
-        and (
-            new.effective_accuracy > saved.effective_accuracy
-            or (not new.is_stub and saved.is_stub)
-        )
-    ):
+    assert saved and new
+
+    # Do not report changes if the entity is a stub in both reports.
+    # (Regression in GH #405)
+    if saved.is_stub and new.is_stub:
+        return ReccmpDiffJudgement.NOTHING
+
+    if saved.is_stub and not new.is_stub:
         return ReccmpDiffJudgement.INCREASE
 
-    if (
-        saved is not None
-        and new is not None
-        and new.effective_accuracy < saved.effective_accuracy
-        and not saved.is_stub
-        and not new.is_stub
-    ):
+    if not saved.is_stub and new.is_stub:
         return ReccmpDiffJudgement.DECREASE
 
-    if (
-        saved is not None
-        and new is not None
-        and new.effective_accuracy == 1.0
-        and saved.effective_accuracy == 1.0
-        and new.is_effective_match != saved.is_effective_match
-    ):
+    # The entity is still functionally equivalent despite the degradation.
+    if saved.accuracy == 1.0 and new.is_effective_match:
         return ReccmpDiffJudgement.ENTROPY
+
+    # GH #431.
+    # Previously, we reported changes in either direction as ENTROPY.
+    if saved.is_effective_match and new.accuracy == 1.0:
+        return ReccmpDiffJudgement.INCREASE
+
+    # Don't report internal accuracy changes if it is still an effective match.
+    if saved.is_effective_match and new.is_effective_match:
+        return ReccmpDiffJudgement.NOTHING
+
+    # Don't consider accuracy if either report has an effective match.
+    if saved.is_effective_match and not new.is_effective_match:
+        return ReccmpDiffJudgement.DECREASE
+
+    if not saved.is_effective_match and new.is_effective_match:
+        return ReccmpDiffJudgement.INCREASE
+
+    # It is not a stub or effective match. Compare raw accuracy.
+    if saved.accuracy < new.accuracy:
+        return ReccmpDiffJudgement.INCREASE
+
+    if saved.accuracy > new.accuracy:
+        return ReccmpDiffJudgement.DECREASE
 
     return ReccmpDiffJudgement.NOTHING
 

--- a/tests/test_asmcmp_utils.py
+++ b/tests/test_asmcmp_utils.py
@@ -1,0 +1,126 @@
+import pytest
+from reccmp.utils import entity_diff_change, ReccmpDiffJudgement
+from reccmp.compare.report import ReccmpComparedEntity
+
+
+def entity(
+    *, accuracy: float, is_stub: bool = False, is_effective_match: bool = False
+) -> ReccmpComparedEntity:
+    """Helper to create entities with dummy values for required fields: address, name.
+    The only relevant fields are: accuracy, is_stub, is_effective_match"""
+    return ReccmpComparedEntity(
+        orig_addr="0x400000",
+        name="Test",
+        accuracy=accuracy,
+        is_stub=is_stub,
+        is_effective_match=is_effective_match,
+    )
+
+
+def test_diff_new_entity():
+    """If the entity did not exist in the saved report, it is flagged as NEW regardless of status."""
+    for new in [
+        entity(accuracy=1.0),
+        entity(accuracy=0.0),
+        entity(accuracy=0.5, is_stub=True),
+        entity(accuracy=0.5, is_effective_match=True),
+        entity(accuracy=0.5, is_stub=True, is_effective_match=True),
+    ]:
+        assert entity_diff_change(None, new) == ReccmpDiffJudgement.NEW
+
+
+def test_diff_dropped_entity():
+    """If the entity did exist in the saved report, but it does not exist now,
+    it is flagged as DROPPED regardless of status."""
+    for saved in [
+        entity(accuracy=1.0),
+        entity(accuracy=0.0),
+        entity(accuracy=0.5, is_stub=True),
+        entity(accuracy=0.5, is_effective_match=True),
+        entity(accuracy=0.5, is_stub=True, is_effective_match=True),
+    ]:
+        assert entity_diff_change(saved, None) == ReccmpDiffJudgement.DROPPED
+
+
+def test_diff_no_change():
+    """Do not report accuracy changes if nothing has changed."""
+    ent = entity(accuracy=0.5)
+    assert entity_diff_change(ent, ent) == ReccmpDiffJudgement.NOTHING
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_diff_stub_changes():
+    """Do not report accuracy changes if the entity is a stub in both reports."""
+    low_stub = entity(accuracy=0.5, is_stub=True)
+    high_stub = entity(accuracy=0.8, is_stub=True)
+    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NOTHING
+    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NOTHING
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_diff_stub_effective_changes():
+    """Do not report effective-match changes if the entity is a stub in both reports."""
+    low_stub = entity(accuracy=0.5, is_stub=True, is_effective_match=True)
+    high_stub = entity(accuracy=1.0, is_stub=True)
+    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NOTHING
+    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NOTHING
+
+
+def test_diff_stub_to_non_stub():
+    """Any move from a stub to a non-stub is an INCREASE, regardless of score."""
+    ent = entity(accuracy=0.6)
+
+    low_stub = entity(accuracy=0.5, is_stub=True)
+    high_stub = entity(accuracy=0.8, is_stub=True)
+    assert entity_diff_change(low_stub, ent) == ReccmpDiffJudgement.INCREASE
+    assert entity_diff_change(high_stub, ent) == ReccmpDiffJudgement.INCREASE
+
+    low_stub_effective = entity(accuracy=0.5, is_stub=True, is_effective_match=True)
+    high_stub_effective = entity(accuracy=0.8, is_stub=True, is_effective_match=True)
+    assert entity_diff_change(low_stub_effective, ent) == ReccmpDiffJudgement.INCREASE
+    assert entity_diff_change(high_stub_effective, ent) == ReccmpDiffJudgement.INCREASE
+
+
+def test_diff_accuracy_change():
+    """Report accuracy change for non-stub, non-effective."""
+    low_ent = entity(accuracy=0.5)
+    high_ent = entity(accuracy=0.8)
+    assert entity_diff_change(low_ent, high_ent) == ReccmpDiffJudgement.INCREASE
+    assert entity_diff_change(high_ent, low_ent) == ReccmpDiffJudgement.DECREASE
+
+
+def test_diff_upgrade_to_effective():
+    """Moving from any non-match to an effective match is an INCREASE."""
+    low_ent = entity(accuracy=0.5)
+    effective = entity(accuracy=0.8, is_effective_match=True)
+    assert entity_diff_change(low_ent, effective) == ReccmpDiffJudgement.INCREASE
+
+    # Report an improvement even though the raw score is lower for the effective match.
+    lower_effective = entity(accuracy=0.2, is_effective_match=True)
+    assert entity_diff_change(low_ent, lower_effective) == ReccmpDiffJudgement.INCREASE
+
+
+def test_diff_downgrade_from_effective():
+    """Moving from an effective match to any non-match is a DECREASE."""
+    low_ent = entity(accuracy=0.5)
+    effective = entity(accuracy=0.8, is_effective_match=True)
+    assert entity_diff_change(effective, low_ent) == ReccmpDiffJudgement.DECREASE
+
+    # Report a degradation even though the raw score is higher for the non-effective match.
+    higher_ent = entity(accuracy=0.9)
+    assert entity_diff_change(effective, higher_ent) == ReccmpDiffJudgement.DECREASE
+
+
+@pytest.mark.xfail(reason="TODO #431")
+def test_diff_effective_to_match():
+    """Moving from an effective-match to an exact match is an INCREASE. See GH #431."""
+    match = entity(accuracy=1.0)
+    effective = entity(accuracy=0.8, is_effective_match=True)
+    assert entity_diff_change(effective, match) == ReccmpDiffJudgement.INCREASE
+
+
+def test_diff_match_to_effective():
+    """Moving from an exact match to an effective match is judged to be ENTROPY."""
+    match = entity(accuracy=1.0)
+    effective = entity(accuracy=0.8, is_effective_match=True)
+    assert entity_diff_change(match, effective) == ReccmpDiffJudgement.ENTROPY

--- a/tests/test_asmcmp_utils.py
+++ b/tests/test_asmcmp_utils.py
@@ -44,23 +44,23 @@ def test_diff_dropped_entity():
 def test_diff_no_change():
     """Do not report accuracy changes if nothing has changed."""
     ent = entity(accuracy=0.5)
-    assert entity_diff_change(ent, ent) == ReccmpDiffJudgement.NOTHING
+    assert entity_diff_change(ent, ent) == ReccmpDiffJudgement.NO_CHANGE
 
 
 def test_diff_stub_changes():
     """Do not report accuracy changes if the entity is a stub in both reports."""
     low_stub = entity(accuracy=0.5, is_stub=True)
     high_stub = entity(accuracy=0.8, is_stub=True)
-    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NOTHING
-    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NOTHING
+    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NO_CHANGE
+    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NO_CHANGE
 
 
 def test_diff_stub_effective_changes():
     """Do not report effective-match changes if the entity is a stub in both reports."""
     low_stub = entity(accuracy=0.5, is_stub=True, is_effective_match=True)
     high_stub = entity(accuracy=1.0, is_stub=True)
-    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NOTHING
-    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NOTHING
+    assert entity_diff_change(low_stub, high_stub) == ReccmpDiffJudgement.NO_CHANGE
+    assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NO_CHANGE
 
 
 def test_diff_stub_to_non_stub():
@@ -131,8 +131,10 @@ def test_diff_effective_to_effective():
     low_effective = entity(accuracy=0.2, is_effective_match=True)
     high_effective = entity(accuracy=0.8, is_effective_match=True)
     assert (
-        entity_diff_change(low_effective, high_effective) == ReccmpDiffJudgement.NOTHING
+        entity_diff_change(low_effective, high_effective)
+        == ReccmpDiffJudgement.NO_CHANGE
     )
     assert (
-        entity_diff_change(high_effective, low_effective) == ReccmpDiffJudgement.NOTHING
+        entity_diff_change(high_effective, low_effective)
+        == ReccmpDiffJudgement.NO_CHANGE
     )

--- a/tests/test_asmcmp_utils.py
+++ b/tests/test_asmcmp_utils.py
@@ -1,4 +1,3 @@
-import pytest
 from reccmp.utils import entity_diff_change, ReccmpDiffJudgement
 from reccmp.compare.report import ReccmpComparedEntity
 
@@ -48,7 +47,6 @@ def test_diff_no_change():
     assert entity_diff_change(ent, ent) == ReccmpDiffJudgement.NOTHING
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_diff_stub_changes():
     """Do not report accuracy changes if the entity is a stub in both reports."""
     low_stub = entity(accuracy=0.5, is_stub=True)
@@ -57,7 +55,6 @@ def test_diff_stub_changes():
     assert entity_diff_change(high_stub, low_stub) == ReccmpDiffJudgement.NOTHING
 
 
-@pytest.mark.xfail(reason="TODO")
 def test_diff_stub_effective_changes():
     """Do not report effective-match changes if the entity is a stub in both reports."""
     low_stub = entity(accuracy=0.5, is_stub=True, is_effective_match=True)
@@ -74,11 +71,15 @@ def test_diff_stub_to_non_stub():
     high_stub = entity(accuracy=0.8, is_stub=True)
     assert entity_diff_change(low_stub, ent) == ReccmpDiffJudgement.INCREASE
     assert entity_diff_change(high_stub, ent) == ReccmpDiffJudgement.INCREASE
+    assert entity_diff_change(ent, low_stub) == ReccmpDiffJudgement.DECREASE
+    assert entity_diff_change(ent, high_stub) == ReccmpDiffJudgement.DECREASE
 
     low_stub_effective = entity(accuracy=0.5, is_stub=True, is_effective_match=True)
     high_stub_effective = entity(accuracy=0.8, is_stub=True, is_effective_match=True)
     assert entity_diff_change(low_stub_effective, ent) == ReccmpDiffJudgement.INCREASE
     assert entity_diff_change(high_stub_effective, ent) == ReccmpDiffJudgement.INCREASE
+    assert entity_diff_change(ent, low_stub_effective) == ReccmpDiffJudgement.DECREASE
+    assert entity_diff_change(ent, high_stub_effective) == ReccmpDiffJudgement.DECREASE
 
 
 def test_diff_accuracy_change():
@@ -111,7 +112,6 @@ def test_diff_downgrade_from_effective():
     assert entity_diff_change(effective, higher_ent) == ReccmpDiffJudgement.DECREASE
 
 
-@pytest.mark.xfail(reason="TODO #431")
 def test_diff_effective_to_match():
     """Moving from an effective-match to an exact match is an INCREASE. See GH #431."""
     match = entity(accuracy=1.0)
@@ -124,3 +124,15 @@ def test_diff_match_to_effective():
     match = entity(accuracy=1.0)
     effective = entity(accuracy=0.8, is_effective_match=True)
     assert entity_diff_change(match, effective) == ReccmpDiffJudgement.ENTROPY
+
+
+def test_diff_effective_to_effective():
+    """Do not report accuracy changes for effective matches."""
+    low_effective = entity(accuracy=0.2, is_effective_match=True)
+    high_effective = entity(accuracy=0.8, is_effective_match=True)
+    assert (
+        entity_diff_change(low_effective, high_effective) == ReccmpDiffJudgement.NOTHING
+    )
+    assert (
+        entity_diff_change(high_effective, low_effective) == ReccmpDiffJudgement.NOTHING
+    )


### PR DESCRIPTION
As a result of #405, stub entities now include an accuracy value in the JSON report. This resulted in a bug where changes to accuracy would cause the entity to appear in the "Increased" or "Decreased" section of the JSON diff report, reported as `stub -> stub`.

This closes that gap, addresses a `#TODO` comment to improve the readability of the code, and closes #431 while we're here.

The only potential improvement is to use a helper like this for `is_stub`, `is_effective_match`, and `accuracy` changes:
```python
def change(old_value: bool | float, new_value: bool | float) -> ReccmpDiffJudgement:
    if old_value < new_value:
        return ReccmpDiffJudgement.INCREASE

    if old_value > new_value:
        return ReccmpDiffJudgement.DECREASE

    return ReccmpDiffJudgement.NOTHING
```