### PR TITLE
More direct entity counting for decomp progress

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -1,7 +1,7 @@
 import logging
 import difflib
 import struct
-from typing import Iterable, Iterator
+from typing import Callable, Iterable, Iterator
 from typing_extensions import Self
 from reccmp.project.detect import RecCmpTarget
 from reccmp.compare.diff import EntityCompareResult, RawDiffOutput
@@ -343,7 +343,7 @@ class Compare:
             match_ratio=ratio,
         )
 
-    def _compare_match(self, match: ReccmpMatch) -> DiffReport | None:
+    def compare_match(self, match: ReccmpMatch) -> DiffReport | None:
         """Router for comparison type"""
 
         if match.size is None or match.any_size() == 0:
@@ -384,14 +384,6 @@ class Compare:
 
     ## Public API
 
-    def count_unmatched_functions(self) -> int:
-        """Count known but unmatched functions in orig."""
-        return sum(
-            1
-            for ent in self._db.unmatched(ImageId.ORIG)
-            if ent.get("type") == EntityType.FUNCTION
-        )
-
     def get_all(self) -> Iterator[ReccmpEntity]:
         return self._db.get_all()
 
@@ -409,22 +401,34 @@ class Compare:
         if match is None:
             return None
 
-        return self._compare_match(match)
+        return self.compare_match(match)
 
     def compare_all(self) -> Iterable[DiffReport]:
         for match in self._db.get_matches():
-            diff = self._compare_match(match)
+            diff = self.compare_match(match)
             if diff is not None:
                 yield diff
 
     def compare_functions(self) -> Iterable[DiffReport]:
         for match in self.get_functions():
-            diff = self._compare_match(match)
+            diff = self.compare_match(match)
             if diff is not None:
                 yield diff
 
     def compare_vtables(self) -> Iterable[DiffReport]:
         for match in self.get_vtables():
-            diff = self._compare_match(match)
+            diff = self.compare_match(match)
             if diff is not None:
                 yield diff
+
+    def get_all_compared(
+        self, func_filter: Callable[[ReccmpEntity], bool]
+    ) -> Iterator[ReccmpEntity]:
+        for ent in self._db.all(ImageId.ORIG):
+            entity_type = ent.get("type")
+            if entity_type in (EntityType.FUNCTION, EntityType.VTORDISP):
+                if func_filter(ent):
+                    yield ent
+
+            if entity_type == EntityType.VTABLE:
+                yield ent

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from collections.abc import Sequence
 from datetime import datetime
 import argparse
 import logging
@@ -18,6 +17,7 @@ from reccmp.utils import (
 )
 
 from reccmp.compare import Compare
+from reccmp.compare.db import ReccmpEntity, ReccmpMatch
 from reccmp.compare.diff import DiffReport, raw_diff_to_udiff
 from reccmp.compare.report import (
     ReccmpStatusReport,
@@ -175,29 +175,43 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def dump_all_matched_functions(matches: Sequence[DiffReport]):
+def dump_all_matched_functions(report: ReccmpStatusReport):
     logger.info("Creating assembly dump files.")
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    orig_order = sorted(matches, key=lambda m: m.orig_addr)
-    recomp_order = sorted(matches, key=lambda m: m.recomp_addr)
 
-    with open(f"reccmp-{timestamp}-orig.txt", "w+", encoding="utf-8") as f:
-        for match in orig_order:
-            f.write(f"; {match.name}\n")
-            for addr, line in match.result.diff.orig_inst:
-                if addr:
-                    f.write(f"{addr:10}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
+    # Extract instructions from each compared entity in both address spaces.
+    orig_items = [
+        (entity.orig_addr, entity.name, entity.rdiff.orig_inst)
+        for entity in report.entities.values()
+        if entity.rdiff
+    ]
 
-    with open(f"reccmp-{timestamp}-recomp.txt", "w+", encoding="utf-8") as f:
-        for match in recomp_order:
-            f.write(f"; {match.name}\n")
-            for addr, line in match.result.diff.recomp_inst:
-                if addr:
-                    f.write(f"{addr:10}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
+    # mypy: recomp_addr can be None, but not for the matched entities we are reviewing.
+    recomp_items = [
+        (entity.recomp_addr, entity.name, entity.rdiff.recomp_inst)
+        for entity in report.entities.values()
+        if entity.recomp_addr and entity.rdiff
+    ]
+
+    # Sort by each binary's address order
+    orig_items.sort(key=lambda v: v[0])
+    recomp_items.sort(key=lambda v: v[0])
+
+    orig_filename = f"reccmp-{timestamp}-orig.txt"
+    recomp_filename = f"reccmp-{timestamp}-recomp.txt"
+
+    for filename, vitals in (
+        (orig_filename, orig_items),
+        (recomp_filename, recomp_items),
+    ):
+        with open(filename, "w+", encoding="utf-8") as f:
+            for _, name, instructions in vitals:
+                f.write(f"; {name}\n")
+                for addr, line in instructions:
+                    if addr:
+                        f.write(f"{addr:10}: {line}\n")
+                    else:
+                        f.write(f"        : {line}\n")
 
 
 def main() -> int:
@@ -228,37 +242,43 @@ def main() -> int:
 
     ### Compare everything.
 
-    compared = list(compare.compare_all())
+    def should_consider_function(entity: ReccmpEntity) -> bool:
+        """if we are ignoring this function, skip to next one and don't add it to the entities list"""
+        if entity.name in target.report_config.ignore_functions:
+            return False
 
-    if args.dump:
-        dump_all_matched_functions(compared)
+        if args.nolib and entity.get("library"):
+            return False
+
+        return True
 
     report = ReccmpStatusReport(filename=target.original_path.name)
 
+    function_count = 0
+
     # Build report:
-    for match in compared:
-        # if we are ignoring this function, skip to next one and don't add it to the entities list
-        if (
-            match.match_type == EntityType.FUNCTION
-            and match.name in target.report_config.ignore_functions
-        ):
-            continue
+    for db_entity in compare.get_all_compared(should_consider_function):
+        if db_entity.get("type") in (EntityType.FUNCTION, EntityType.VTORDISP):
+            function_count += 1
 
-        if args.nolib and match.is_library:
-            continue
+        if isinstance(db_entity, ReccmpMatch):
+            match = compare.compare_match(db_entity)
+            if match:
+                report.add_match(match)
 
-        report.add_match(match)
+    if args.dump:
+        dump_all_matched_functions(report)
 
     # Count how many functions have the same virtual address in orig and recomp.
     functions_aligned_count = report_function_alignment(report)
 
     # Number of functions compared (i.e. excluding stubs)
-    function_count, _, total_effective_accuracy = report_function_accuracy(report)
+    implemented_funcs, _, total_effective_accuracy = report_function_accuracy(report)
 
     # Print diff summary to terminal
     if not args.silent and args.diff is None:
-        for entity in report.entities.values():
-            print_match_oneline(entity, show_both_addrs=args.print_rec_addr)
+        for report_entity in report.entities.values():
+            print_match_oneline(report_entity, show_both_addrs=args.print_rec_addr)
 
     # Compare with saved diff report.
     if args.diff is not None:
@@ -287,11 +307,6 @@ def main() -> int:
 
     if args.html is not None:
         write_html_report(args.html, report)
-
-    implemented_funcs = function_count
-
-    # Add known but unmatched functions to our count
-    function_count += compare.count_unmatched_functions()
 
     # If we know how many functions are in the file (via analysis with Ghidra or other tools)
     # we can substitute an alternate value to use when calculating the percentages below.


### PR DESCRIPTION
Improvement on #444.

The problem to solve is counting the number of functions in the decomp. You can directly set the value with `--total`. If it is not set, we need to count every annotated function from the orig address space, matched or not, stubbed or not. If `--nolib` is set, exclude library functions. We also exclude function names from the `report.exclude_functions` list.

Draft because I'm not sure where to draw the line between `asmcmp.py` and `core.py`. But this is the gist of what I think we need.