### PR TITLE
Support target icons for SVG and HTML reports

### DIFF
--- a/reccmp/assets/template.html
+++ b/reccmp/assets/template.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="icon" type="image/png" href="data:image/png;base64,{{favicon}}">
     <title>Decompilation Status</title>
     <style>
       body {

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -63,6 +63,7 @@ class YmlReportConfig(BaseModel):
         default_factory=list,
         validation_alias=AliasChoices("ignore-variables", "ignore_variables"),
     )
+    icon: Path | None = Field(default=None)
 
     @classmethod
     def default(cls) -> "YmlReportConfig":
@@ -94,7 +95,6 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("marker-aliases", "marker_aliases"),
         default_factory=dict,
     )
-    icon: Path | None = Field(default=None)
 
 
 class ProjectFile(YmlFileModel):

--- a/reccmp/project/config.py
+++ b/reccmp/project/config.py
@@ -94,6 +94,7 @@ class ProjectFileTarget(BaseModel):
         validation_alias=AliasChoices("marker-aliases", "marker_aliases"),
         default_factory=dict,
     )
+    icon: Path | None = Field(default=None)
 
 
 class ProjectFile(YmlFileModel):

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -125,6 +125,9 @@ class ReportConfig:
     ignore_variables: list[str] = field(default_factory=list)
     """Variables matching these names will be omitted from the reccmp-datacmp report."""
 
+    icon: Path | None = None
+    """Path to icon (PNG image) to use in SVG and HTML reports."""
+
 
 @dataclass
 class RecCmpPartialTarget:
@@ -171,8 +174,6 @@ class RecCmpPartialTarget:
 
     marker_aliases: dict[str, str] | None = None
 
-    icon: Path | None = None
-
 
 @dataclass
 class RecCmpTarget:
@@ -213,8 +214,6 @@ class RecCmpTarget:
     data_sources: list[Path] = field(default_factory=list)
 
     marker_aliases: dict[str, str] = field(default_factory=dict)
-
-    icon: Path | None = None
 
 
 class RecCmpProject:
@@ -292,7 +291,6 @@ class RecCmpProject:
             data_sources=data_sources,
             marker_aliases=marker_aliases,
             report_config=report,
-            icon=target.icon,
         )
 
     def find_build_config(self, search_path: Path) -> BuildFile | None:
@@ -381,9 +379,15 @@ class RecCmpProject:
             else:
                 ghidra = None
             if target.report is not None:
+                target_icon = (
+                    project_directory / target.report.icon
+                    if target.report.icon
+                    else None
+                )
                 report = ReportConfig(
                     ignore_functions=target.report.ignore_functions,
                     ignore_variables=target.report.ignore_variables,
+                    icon=target_icon,
                 )
             else:
                 report = None
@@ -396,7 +400,6 @@ class RecCmpProject:
             data_sources = [
                 project_directory / ds_path for ds_path in target.data_sources
             ]
-            target_icon = project_directory / target.icon if target.icon else None
 
             project.targets[target_id] = RecCmpPartialTarget(
                 target_id=target_id,
@@ -408,7 +411,6 @@ class RecCmpProject:
                 data_sources=data_sources,
                 marker_aliases=target.marker_aliases,
                 report_config=report,
-                icon=target_icon,
             )
 
         # Apply reccmp-user.yml

--- a/reccmp/project/detect.py
+++ b/reccmp/project/detect.py
@@ -171,6 +171,8 @@ class RecCmpPartialTarget:
 
     marker_aliases: dict[str, str] | None = None
 
+    icon: Path | None = None
+
 
 @dataclass
 class RecCmpTarget:
@@ -211,6 +213,8 @@ class RecCmpTarget:
     data_sources: list[Path] = field(default_factory=list)
 
     marker_aliases: dict[str, str] = field(default_factory=dict)
+
+    icon: Path | None = None
 
 
 class RecCmpProject:
@@ -288,6 +292,7 @@ class RecCmpProject:
             data_sources=data_sources,
             marker_aliases=marker_aliases,
             report_config=report,
+            icon=target.icon,
         )
 
     def find_build_config(self, search_path: Path) -> BuildFile | None:
@@ -391,6 +396,7 @@ class RecCmpProject:
             data_sources = [
                 project_directory / ds_path for ds_path in target.data_sources
             ]
+            target_icon = project_directory / target.icon if target.icon else None
 
             project.targets[target_id] = RecCmpPartialTarget(
                 target_id=target_id,
@@ -402,6 +408,7 @@ class RecCmpProject:
                 data_sources=data_sources,
                 marker_aliases=target.marker_aliases,
                 report_config=report,
+                icon=target_icon,
             )
 
         # Apply reccmp-user.yml

--- a/reccmp/tools/aggregate.py
+++ b/reccmp/tools/aggregate.py
@@ -129,6 +129,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--svg-icon",
         metavar="icon",
+        type=Path,
         help="Icon to use in SVG (PNG)",
     )
     parser.add_argument(

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -288,7 +288,7 @@ def main() -> int:
             args.json, serialize_reccmp_report(report, diff_included=diff_included)
         )
 
-    target_icon = args.svg_icon or target.icon
+    target_icon = args.svg_icon or target.report_config.icon
 
     if args.html is not None:
         write_html_report(args.html, report, target_icon)

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from datetime import datetime
+from pathlib import Path
 import argparse
 import logging
 import os
@@ -151,7 +152,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--svg", "-S", metavar="<file>", help="Generate SVG graphic of progress"
     )
-    parser.add_argument("--svg-icon", metavar="icon", help="Icon to use in SVG (PNG)")
+    parser.add_argument(
+        "--svg-icon", metavar="icon", type=Path, help="Icon to use in SVG (PNG)"
+    )
     parser.add_argument(
         "--print-rec-addr",
         action="store_true",
@@ -285,8 +288,10 @@ def main() -> int:
             args.json, serialize_reccmp_report(report, diff_included=diff_included)
         )
 
+    target_icon = args.svg_icon or target.icon
+
     if args.html is not None:
-        write_html_report(args.html, report)
+        write_html_report(args.html, report, target_icon)
 
     implemented_funcs = function_count
 
@@ -324,7 +329,7 @@ def main() -> int:
         gen_svg(
             args.svg,
             os.path.basename(target.original_path),
-            args.svg_icon,
+            target_icon,
             implemented_funcs,
             function_count,
             total_effective_accuracy,

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -52,11 +52,16 @@ def read_js_file(filename: str) -> str:
     return file_header + "".join(lines)
 
 
-def base64_blob(path: Path) -> str:
+def get_base64_icon(path: Path) -> str:
+    if path.suffix.lower() != ".png":
+        logging.getLogger().error("Icon must be PNG image: %s", path)
+        return ""
+
     try:
         with path.open("rb") as f:
             return base64.b64encode(f.read()).decode("utf-8")
     except FileNotFoundError:
+        logging.getLogger().error("Could not open icon: %s", path)
         return ""
 
 
@@ -72,7 +77,7 @@ def gen_svg(
     """Render the progress SVG badge from the bundled template."""
     icon_data = None
     if icon:
-        icon_data = base64_blob(icon)
+        icon_data = get_base64_icon(icon)
 
     total_statistic = raw_accuracy / total_funcs
     full_percentbar_width = 127.18422
@@ -125,8 +130,8 @@ def write_html_report(
     report_str = serialize_reccmp_report(report, diff_included=True)
 
     favicon = ""
-    if icon and icon.suffix == ".png":
-        favicon = base64_blob(icon)
+    if icon:
+        favicon = get_base64_icon(icon)
 
     output_data = Renderer().render_path(
         get_asset_file("template.html"),

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -1,6 +1,7 @@
 import base64
 import enum
 from datetime import datetime
+from pathlib import Path
 from typing import Iterable, Iterator
 import logging
 from pystache import Renderer  # type: ignore[import-untyped]
@@ -51,11 +52,19 @@ def read_js_file(filename: str) -> str:
     return file_header + "".join(lines)
 
 
+def base64_blob(path: Path) -> str:
+    try:
+        with path.open("rb") as f:
+            return base64.b64encode(f.read()).decode("utf-8")
+    except FileNotFoundError:
+        return ""
+
+
 # pylint: disable=too-many-positional-arguments
 def gen_svg(
     svg_file: str,
     name_svg: str,
-    icon: str | None,
+    icon: Path | None,
     svg_implemented_funcs: int,
     total_funcs: int,
     raw_accuracy: float,
@@ -63,8 +72,7 @@ def gen_svg(
     """Render the progress SVG badge from the bundled template."""
     icon_data = None
     if icon:
-        with open(icon, "rb") as iconfile:
-            icon_data = base64.b64encode(iconfile.read()).decode("utf-8")
+        icon_data = base64_blob(icon)
 
     total_statistic = raw_accuracy / total_funcs
     full_percentbar_width = 127.18422
@@ -83,7 +91,9 @@ def gen_svg(
         svgfile.write(output_data)
 
 
-def write_html_report(html_file: str, report: ReccmpStatusReport):
+def write_html_report(
+    html_file: str, report: ReccmpStatusReport, icon: Path | None = None
+):
     """Create the interactive HTML diff viewer with the given report."""
     # For the flat-file report, the component JS files must be added in a particular order
     # so that any dependencies required by a particular file have already been resolved.
@@ -114,9 +124,13 @@ def write_html_report(html_file: str, report: ReccmpStatusReport):
     # Convert the report to a JSON string to insert in the HTML template.
     report_str = serialize_reccmp_report(report, diff_included=True)
 
+    favicon = ""
+    if icon and icon.suffix == ".png":
+        favicon = base64_blob(icon)
+
     output_data = Renderer().render_path(
         get_asset_file("template.html"),
-        {"report": report_str, "reccmp_js": reccmp_js},
+        {"report": report_str, "reccmp_js": reccmp_js, "favicon": favicon},
     )
 
     with open(html_file, "w", encoding="utf-8") as htmlfile:


### PR DESCRIPTION
This adds an `icon` parameter to the project YML file so you can provide a path (relative to project root) of an image to use in the SVG progress display.

e.g.
```yml
targets:
  ISLE:
    filename: ISLE.EXE
    source-root: .
    hash:
      sha256: 5cf57c284973fce9d14f5677a2e4435fd989c5e938970764d00c8932ed5128ca
    report:
      icon: assets/isle.png
  LEGO1:
    filename: LEGO1.DLL
    source-root: LEGO1
    hash:
      sha256: 14645225bbe81212e9bc1919cd8a692b81b8622abb6561280d99b0fc4151ce17
    report:
      icon: assets/lego1.png
```

While we're here, we now use that image as the favicon for the HTML report.

The `--svg-icon` argument will override the project setting.

`reccmp-aggregate` does not load the project file, so you need to keep using `--svg-icon` to get the image to appear.