### PR TITLE
Handle `loop` instructions as jumps

### DIFF
--- a/reccmp/compare/asm/const.py
+++ b/reccmp/compare/asm/const.py
@@ -21,6 +21,10 @@ JUMP_MNEMONICS = {
     "jo",
     "jp",
     "js",
+    # Capstone uses loope/loopne, not loopz/loopnz.
+    "loop",
+    "loope",
+    "loopne",
 }
 
 # Guaranteed to be a single operand.

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -176,6 +176,9 @@ JUMP_SAMPLES = (
     (DisasmLiteInst(0x1000, 5, "jmp", "0x805"), "-0x800"),
     (DisasmLiteInst(0x1000, 2, "je", "0x1006"), "0x4"),
     (DisasmLiteInst(0x1000, 2, "je", "0x1000"), "-0x2"),
+    (DisasmLiteInst(0x1000, 5, "loop", "0x10ac"), "0xa7"),
+    (DisasmLiteInst(0x1000, 2, "loope", "0x1006"), "0x4"),
+    (DisasmLiteInst(0x1000, 2, "loopne", "0x1000"), "-0x2"),
 )
 
 


### PR DESCRIPTION
We expect to see the jump displacement shown as the operand, not the raw address.