### PR TITLE
Remove duplicate call to `match_array_elements`

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -167,7 +167,6 @@ class Compare:
 
         match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
 
-        match_array_elements(self._db, self.types)
         # Detect floats first to eliminate potential overlap with string data
         for img_id, binfile in (
             (ImageId.ORIG, self.orig_bin),


### PR DESCRIPTION
Missed this while merging #432. When #406 added `set_max_size`, my intent was to call `match_array_elements` _after_ `set_max_size`. There isn't any need to measure the size of array offset entities, and it's faster to run `set_max_size `with fewer entities in the database.