### PR TITLE
Create and match CRT functions in two steps

### DIFF
--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -2,6 +2,7 @@ import enum
 import re
 import struct
 from dataclasses import dataclass
+from functools import partial
 from typing import Callable, Iterator
 from typing_extensions import Buffer
 from reccmp.compare.asm.const import JUMP_MNEMONICS
@@ -140,10 +141,7 @@ def get_function_fingerprint(
     size = get_function_sample_size(db, image_id, addr)
     raw = binfile.read(addr, size)
 
-    def entity_exists(test_addr: int) -> bool:
-        return db.get(image_id, test_addr, exact=True) is not None
-
-    collector = UsedAddressCollector(entity_exists)
+    collector = UsedAddressCollector(partial(db.used, image_id))
     collector.analyze(raw, addr)
 
     normalized_addrs = []
@@ -246,6 +244,25 @@ def detect_crt_startup_arrays(
             )
         else:
             yield (array_type, None)
+
+
+def read_crt_arrays(
+    db: EntityDb, image_id: ImageId, binfile: PEImage
+) -> Iterator[tuple[str, list[int]]]:
+    labels = find_crt_startup_labels(db, image_id)
+    for array_type, (label_start, label_end) in _CRT_STARTUP_ARRAY_BOUNDARIES.items():
+        if label_start in labels and label_end in labels:
+            array_range = range(labels[label_start], labels[label_end])
+            base_name = get_crt_function_name(array_type)
+            addrs = []
+
+            for addr in read_crt_array(binfile, array_range):
+                addrs.append(addr)
+                was_thunk, real_addr = unwrap_jump(binfile, addr)
+                if was_thunk:
+                    addrs.append(real_addr)
+
+            yield (base_name, addrs)
 
 
 def create_crt_matches(

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -141,7 +141,7 @@ def get_function_fingerprint(
     size = get_function_sample_size(db, image_id, addr)
     raw = binfile.read(addr, size)
 
-    collector = UsedAddressCollector(partial(db.used, image_id))
+    collector = UsedAddressCollector(partial(db.exists, image_id))
     collector.analyze(raw, addr)
 
     normalized_addrs = []

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -179,84 +179,76 @@ def find_crt_startup_labels(db: EntityDb, image_id: ImageId) -> dict[str, int]:
     return found
 
 
-INITIALIZER_THUNK_MAX_JUMP_OFFSET = 16
-"""Some MSVC dynamic initializers are thunked. By observation, the thunked function is
-usually at the next 16-byte-aligned address. Tweak this value if necessary."""
+JMP_THUNK = b"\xe9\x0b\x00\x00\x00"
+"""Observed thunk pattern for CRT init:
+jump to the function at start + 16 to set the variable."""
+
+CALL_JMP_THUNK = b"\xe8\x0b\x00\x00\x00\xe9\x16\x00\x00\x00"
+"""Observed thunk pattern for CRT init:
+call the function at start + 16 to set the variable,
+then jump to the function at start + 32 to set the atexit handler."""
 
 
 def unwrap_jump(binfile: Image, addr: int) -> tuple[bool, int]:
-    """If there is a 5-byte JMP or CALL instruction at the given address,
-    follow it by calculating the destination address.
+    """The address in the CRT array may not be the function that sets the variable
+    or calls the constructor. Detect thunk patterns we have observed in MSVC binaries.
+    The first thunked function (by either a CALL or JMP) is the "main" function
+    that we will use to identify (fingerprint) the variable.
     Returns either (True, jmp_destination) or (False, starting_addr)."""
-    jmp = binfile.read(addr, 5)
-    # Check for CALL (0xE8) or JMP (0xE9) opcodes.
-    if jmp[0] in (0xE8, 0xE9):
-        (offset,) = struct.unpack("<i", jmp[1:])
-        # Add 5 because the offset is based on the address of
-        # the *next* instruction after the JMP.
-        destination = addr + 5 + offset
-        # Follow the jump only if it is small.
-        if abs(destination - addr) <= INITIALIZER_THUNK_MAX_JUMP_OFFSET:
-            return (True, destination)
+    data = binfile.read(addr, len(CALL_JMP_THUNK))
+
+    if data[:5] == JMP_THUNK or data == CALL_JMP_THUNK:
+        return (True, addr + 16)
 
     return (False, addr)
 
 
-def analyze_crt_startup_functions(
-    db: EntityDb, image_id: ImageId, binfile: PEImage, span: range
-) -> CrtStartupArray:
-    """Read the functions for a single CRT startup array and find the identifying "fingerprint"
-    of which variables are referenced."""
-    funcs = tuple(read_crt_array(binfile, span))
+def read_crt_functions(binfile: PEImage, span: range) -> CrtStartupArray:
+    """Create the CRT array structure using the given range of addresses.
+    For each function in the array that matches a known thunk pattern,
+    "unwrap" the indirection so we can search the most likely place for
+    the instruction that sets the variable."""
+    functions: dict[int, tuple[UsedAddress, ...]] = {}
+    thunks: dict[int, int] = {}
 
-    fingerprints = {}
-    thunks = {}
-
-    for xc_addr in funcs:
+    for array_addr in read_crt_array(binfile, span):
         # n.b. The first value in the array is zero. It was excluded by read_crt_array.
-        was_thunk, real_addr = unwrap_jump(binfile, xc_addr)
-        fp = get_function_fingerprint(db, image_id, binfile, real_addr)
-        fingerprints[real_addr] = fp
+        was_thunk, real_addr = unwrap_jump(binfile, array_addr)
+        functions[real_addr] = ()
         if was_thunk:
-            thunks[real_addr] = xc_addr
+            thunks[real_addr] = array_addr
 
-    return CrtStartupArray(fingerprints, thunks)
+    return CrtStartupArray(functions, thunks)
+
+
+def fingerprint_crt_functions(
+    db: EntityDb, image_id: ImageId, binfile: PEImage, array: CrtStartupArray
+):
+    """Update the CRT array structure so that the detected functions have a characteristic
+    set of addresses (the "fingerprint") read or written to by their instructions."""
+    for addr in array.functions.keys():
+        array.functions[addr] = get_function_fingerprint(db, image_id, binfile, addr)
+
+
+def iter_crt_array_ranges(
+    db: EntityDb, image_id: ImageId
+) -> Iterator[tuple[CrtStartupArrayType, range]]:
+    """For each CRT array whose start and end labels are known, return the array type and address range."""
+    labels = find_crt_startup_labels(db, image_id)
+    for array_type, (label_start, label_end) in _CRT_STARTUP_ARRAY_BOUNDARIES.items():
+        if label_start in labels and label_end in labels:
+            array_range = range(labels[label_start], labels[label_end])
+            yield (array_type, array_range)
 
 
 def detect_crt_startup_arrays(
     db: EntityDb, image_id: ImageId, binfile: PEImage
-) -> Iterator[tuple[CrtStartupArrayType, CrtStartupArray | None]]:
-    """For the CRT startup arrays in the given binary, if the start and end labels are known,
-    analyze the functions in each array."""
-    labels = find_crt_startup_labels(db, image_id)
-    for array_type, (label_start, label_end) in _CRT_STARTUP_ARRAY_BOUNDARIES.items():
-        if label_start in labels and label_end in labels:
-            array_range = range(labels[label_start], labels[label_end])
-            yield (
-                array_type,
-                analyze_crt_startup_functions(db, image_id, binfile, array_range),
-            )
-        else:
-            yield (array_type, None)
-
-
-def read_crt_arrays(
-    db: EntityDb, image_id: ImageId, binfile: PEImage
-) -> Iterator[tuple[str, list[int]]]:
-    labels = find_crt_startup_labels(db, image_id)
-    for array_type, (label_start, label_end) in _CRT_STARTUP_ARRAY_BOUNDARIES.items():
-        if label_start in labels and label_end in labels:
-            array_range = range(labels[label_start], labels[label_end])
-            base_name = get_crt_function_name(array_type)
-            addrs = []
-
-            for addr in read_crt_array(binfile, array_range):
-                addrs.append(addr)
-                was_thunk, real_addr = unwrap_jump(binfile, addr)
-                if was_thunk:
-                    addrs.append(real_addr)
-
-            yield (base_name, addrs)
+) -> dict[CrtStartupArrayType, CrtStartupArray]:
+    """Return a map of CRT startup array types to each list of functions."""
+    return {
+        array_type: read_crt_functions(binfile, array_range)
+        for array_type, array_range in iter_crt_array_ranges(db, image_id)
+    }
 
 
 def create_crt_matches(

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -183,10 +183,12 @@ JMP_THUNK = b"\xe9\x0b\x00\x00\x00"
 """Observed thunk pattern for CRT init:
 jump to the function at start + 16 to set the variable."""
 
-CALL_JMP_THUNK = b"\xe8\x0b\x00\x00\x00\xe9\x16\x00\x00\x00"
+CALL_JMP_THUNK = b"\xe8\x0b\x00\x00\x00\xe9"
 """Observed thunk pattern for CRT init:
 call the function at start + 16 to set the variable,
-then jump to the function at start + 32 to set the atexit handler."""
+then jump to the function that sets the atexit handler.
+The position of the atexit setter depends on the size of the called function.
+(It is probably at +32, but not guaranteed to be there.)"""
 
 
 def unwrap_jump(binfile: Image, addr: int) -> tuple[bool, int]:

--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -18,6 +18,9 @@ from reccmp.analysis import (
     find_eh_handlers,
     is_likely_latin1,
 )
+from reccmp.analysis.crt_startup import (
+    read_crt_arrays,
+)
 from .db import EntityDb, entity_name_from_string
 from .queries import get_floats_without_data, get_strings_without_data
 
@@ -36,6 +39,23 @@ def match_entry(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
     with db.batch() as batch:
         batch.set(ImageId.RECOMP, recomp_bin.entry, type=EntityType.FUNCTION)
         batch.match(orig_bin.entry, recomp_bin.entry)
+
+
+def create_crt_functions(db: EntityDb, image_id: ImageId, binfile: PEImage):
+    crt_arrays = tuple(read_crt_arrays(db, image_id, binfile))
+
+    with db.batch() as batch:
+        for base_name, array in crt_arrays:
+            if array is None:
+                continue
+
+            for addr in array:
+                batch.set(
+                    image_id,
+                    addr,
+                    type=EntityType.FUNCTION,
+                    name=base_name,
+                )
 
 
 def create_analysis_strings(

--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -19,7 +19,8 @@ from reccmp.analysis import (
     is_likely_latin1,
 )
 from reccmp.analysis.crt_startup import (
-    read_crt_arrays,
+    detect_crt_startup_arrays,
+    get_crt_function_name,
 )
 from .db import EntityDb, entity_name_from_string
 from .queries import get_floats_without_data, get_strings_without_data
@@ -42,14 +43,17 @@ def match_entry(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
 
 
 def create_crt_functions(db: EntityDb, image_id: ImageId, binfile: PEImage):
-    crt_arrays = tuple(read_crt_arrays(db, image_id, binfile))
+    """Create entities for all functions found to be part of the CRT array.
+    This includes any functions (thunks) called indirectly."""
+    crt_arrays = detect_crt_startup_arrays(db, image_id, binfile)
 
     with db.batch() as batch:
-        for base_name, array in crt_arrays:
-            if array is None:
-                continue
-
-            for addr in array:
+        for array_type, array in crt_arrays.items():
+            # All entities get the same base name.
+            # We could use more specific names when we have more confidence in the format.
+            # e.g. "atexit_setter"
+            base_name = get_crt_function_name(array_type)
+            for addr in [*array.functions, *array.thunks.values()]:
                 batch.set(
                     image_id,
                     addr,

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -41,6 +41,7 @@ from .analyze import (
     create_analysis_floats,
     create_analysis_strings,
     create_analysis_vtordisps,
+    create_crt_functions,
     create_seh_entities,
     complete_partial_floats,
     complete_partial_strings,
@@ -165,8 +166,6 @@ class Compare:
         match_variables(self._db, self.report)
         match_lines(self._db, self._lines_db, self.report)
 
-        match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
-
         # Detect floats first to eliminate potential overlap with string data
         for img_id, binfile in (
             (ImageId.ORIG, self.orig_bin),
@@ -177,6 +176,7 @@ class Compare:
             create_seh_entities(self._db, img_id, binfile)
             create_thunks(self._db, img_id, binfile)
             create_analysis_vtordisps(self._db, img_id, binfile)
+            create_crt_functions(self._db, img_id, binfile)
             import_sections(self._db, img_id, binfile)
 
         match_imports(self._db)
@@ -185,6 +185,7 @@ class Compare:
         for img_id in (ImageId.ORIG, ImageId.RECOMP):
             set_max_size(self._db, img_id)
 
+        match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
         # Creates new offset entities within the footprint of each matched
         # array variable. If the array is larger (bytes) in recomp than in orig,
         # stop short before overwriting any existing orig entities.

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -7,7 +7,6 @@ from functools import cache
 from reccmp.analysis.crt_startup import (
     detect_crt_startup_arrays,
     create_crt_matches,
-    get_crt_function_name,
 )
 from reccmp.cvdump.demangler import (
     get_function_arg_string,
@@ -225,32 +224,5 @@ def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
             matches.extend(create_crt_matches(orig_array, recomp_array))
 
     with db.batch() as batch:
-        for image_id, crt_arrays in (
-            (ImageId.ORIG, crt_orig),
-            (ImageId.RECOMP, crt_recomp),
-        ):
-            for array_type, array in crt_arrays:
-                if array is None:
-                    continue
-
-                name = get_crt_function_name(array_type)
-
-                for addr in array.functions.keys():
-                    batch.set(
-                        image_id,
-                        addr,
-                        type=EntityType.FUNCTION,
-                        name=name,
-                    )
-
-                    if addr in array.thunks:
-                        thunk_addr = array.thunks[addr]
-                        batch.set(
-                            image_id,
-                            thunk_addr,
-                            type=EntityType.FUNCTION,
-                            name=name,
-                        )
-
         for orig_addr, recomp_addr in matches:
             batch.match(orig_addr, recomp_addr)

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -5,6 +5,7 @@ These functions create or update entities using the current information in the d
 import logging
 from reccmp.analysis.crt_startup import (
     detect_crt_startup_arrays,
+    fingerprint_crt_functions,
     create_crt_matches,
 )
 from reccmp.cvdump.demangler import (
@@ -90,17 +91,19 @@ def unique_names_for_overloaded_functions(db: EntityDb):
 
 
 def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
-    crt_orig = tuple(detect_crt_startup_arrays(db, ImageId.ORIG, orig_bin))
-    crt_recomp = tuple(detect_crt_startup_arrays(db, ImageId.RECOMP, recomp_bin))
+    crt_orig = detect_crt_startup_arrays(db, ImageId.ORIG, orig_bin)
+    crt_recomp = detect_crt_startup_arrays(db, ImageId.RECOMP, recomp_bin)
 
     matches = []
 
-    for (orig_type, orig_array), (recomp_type, recomp_array) in zip(
-        crt_orig, crt_recomp
-    ):
-        # Safety
-        assert orig_type == recomp_type
-        if orig_array and recomp_array:
+    for array_type, orig_array in crt_orig.items():
+        recomp_array = crt_recomp.get(array_type)
+        if recomp_array is None:
+            continue
+
+        if orig_array.functions and recomp_array.functions:
+            fingerprint_crt_functions(db, ImageId.ORIG, orig_bin, orig_array)
+            fingerprint_crt_functions(db, ImageId.RECOMP, recomp_bin, recomp_array)
             matches.extend(create_crt_matches(orig_array, recomp_array))
 
     with db.batch() as batch:

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -91,6 +91,10 @@ def unique_names_for_overloaded_functions(db: EntityDb):
 
 
 def match_crt_startup(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
+    """Match CRT function entities established in create_crt_functions().
+    For best performance, call after set_max_size() has provided a limit for
+    CRT function size. Otherwise, the fingerprint sampler will read more
+    bytes than necessary for each function."""
     crt_orig = detect_crt_startup_arrays(db, ImageId.ORIG, orig_bin)
     crt_recomp = detect_crt_startup_arrays(db, ImageId.RECOMP, recomp_bin)
 

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -295,13 +295,18 @@ def test_collector_calls_and_jumps():
     ]
 
 
-def test_unwrap_jump_call_and_jmp():
-    """Follows the two-instruction thunk to the function at the next 16-byte boundary."""
+CRT_CALL_JMP_PATTERNS = (
+    b"\xe8\x0b\x00\x00\x00\xe9\x16\x00\x00\x00",  # call 0x10, jmp 0x20
+    b"\xe8\x0b\x00\x00\x00\xe9\x36\x00\x00\x00",  # call 0x10, jmp 0x40
+)
+
+
+@pytest.mark.parametrize("code", CRT_CALL_JMP_PATTERNS)
+def test_unwrap_jump_call_and_jmp(code: bytes):
+    """Follows the two-instruction thunk to the function at the next 16-byte boundary.
+    The called function can be larger than 16 bytes, so the jmp displacement varies."""
     memory = bytearray(128)
-    memory[0:10] = (
-        b"\xe8\x0b\x00\x00\x00"  # call 0x10
-        b"\xe9\x16\x00\x00\x00"  # jmp 0x20
-    )
+    memory[0 : len(code)] = code
     memory[0x10] = 0xC3  # RET
 
     binfile = RawImage.from_memory(bytes(memory))
@@ -321,7 +326,8 @@ def test_unwrap_jump_jmp_only():
 
 
 CRT_NOT_THUNK_PATTERNS = (
-    b"\xe8\x3b\x00\x00\x00",  # call +0x40
+    b"\xe8\x0b\x00\x00\x00\xc3",  # call +0x10 with no jmp to follow it
+    b"\xe8\x3b\x00\x00\x00\xc3",  # call +0x40
     b"\xe9\x3b\x00\x00\x00",  # jmp +0x40
     b"\xe9\xdb\xff\xff\xff",  # jmp -0x20
 )

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -3,7 +3,8 @@ import pytest
 from reccmp.analysis.crt_startup import (
     get_function_fingerprint,
     find_crt_startup_labels,
-    analyze_crt_startup_functions,
+    read_crt_functions,
+    fingerprint_crt_functions,
     CrtStartupArray,
     create_crt_matches,
     UsedAddressCollector,
@@ -83,12 +84,13 @@ def test_xca_fingerprints_empty(binfile: PEImage):
     db = EntityDb()
 
     # Baseline: no entities so all fingerprints are empty
-    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
+    array = read_crt_functions(binfile, XCA_XCZ_RANGE)
+    fingerprint_crt_functions(db, ImageId.ORIG, binfile, array)
 
-    assert set(result.functions.keys()) == {addr for addr, _ in XCA_THUNK_MAPPING}
-    assert all(not v for v in result.functions.values())
+    assert set(array.functions.keys()) == {addr for addr, _ in XCA_THUNK_MAPPING}
+    assert all(not v for v in array.functions.values())
 
-    assert tuple(result.thunks.items()) == XCA_THUNK_MAPPING
+    assert tuple(array.thunks.items()) == XCA_THUNK_MAPPING
 
 
 def test_xca_fingerprints_not_variable(binfile: PEImage):
@@ -99,8 +101,9 @@ def test_xca_fingerprints_not_variable(binfile: PEImage):
         batch.set(ImageId.ORIG, 0x10102B28, name="g_spawnLocations")
         batch.match(0x10102B28, 0x10102B28)
 
-    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
-    assert not result.functions[0x1001A6D0]
+    array = read_crt_functions(binfile, XCA_XCZ_RANGE)
+    fingerprint_crt_functions(db, ImageId.ORIG, binfile, array)
+    assert not array.functions[0x1001A6D0]
 
 
 def test_xca_fingerprints_matched_variable(binfile: PEImage):
@@ -113,17 +116,17 @@ def test_xca_fingerprints_matched_variable(binfile: PEImage):
         )
         batch.match(0x10102B28, 0x10102B28)
 
-    result = analyze_crt_startup_functions(db, ImageId.ORIG, binfile, XCA_XCZ_RANGE)
-    assert result.functions[0x1001A6D0] == ((0x10102B28, False),)
+    array = read_crt_functions(binfile, XCA_XCZ_RANGE)
+    fingerprint_crt_functions(db, ImageId.ORIG, binfile, array)
+    assert array.functions[0x1001A6D0] == ((0x10102B28, False),)
 
 
 def test_xca_fingerprints_avoid_crash(binfile: PEImage):
-    db = EntityDb()
     # Misaligned end address will cause struct.iter_unpack to raise struct.error.
     modified_range = range(XCA_XCZ_RANGE.start, XCA_XCZ_RANGE.stop - 1)
 
     try:
-        analyze_crt_startup_functions(db, ImageId.ORIG, binfile, modified_range)
+        read_crt_functions(binfile, modified_range)
     except struct.error:
         assert False, "Should not throw"
 
@@ -292,52 +295,44 @@ def test_collector_calls_and_jumps():
     ]
 
 
-def jump_instruction(start: int, end: int, opcode: int = 0xE9) -> bytes:
-    """Create an instruction with the correct jump displacement."""
-    return struct.pack("<Bi", opcode, end - start - 5)
+def test_unwrap_jump_call_and_jmp():
+    """Follows the two-instruction thunk to the function at the next 16-byte boundary."""
+    memory = bytearray(128)
+    memory[0:10] = (
+        b"\xe8\x0b\x00\x00\x00"  # call 0x10
+        b"\xe9\x16\x00\x00\x00"  # jmp 0x20
+    )
+    memory[0x10] = 0xC3  # RET
+
+    binfile = RawImage.from_memory(bytes(memory))
+    assert unwrap_jump(binfile, 0) == (True, 0x10)
+    assert unwrap_jump(binfile, 0x10) == (False, 0x10)
 
 
-CRT_THUNK_ORIENTATIONS = (
-    (0, 5),  # Thunk first, no gap
-    (0, 16),  # Thunk first, 16-byte-aligned
-    (5, 0),  # Function first, no gap
-    (16, 0),  # Function first, 16-byte-aligned
+def test_unwrap_jump_jmp_only():
+    """Follows the single-instruction thunk to the function at the next 16-byte boundary."""
+    memory = bytearray(128)
+    memory[0:5] = b"\xe9\x0b\x00\x00\x00"  # jmp 0x10
+    memory[0x10] = 0xC3  # RET
+
+    binfile = RawImage.from_memory(bytes(memory))
+    assert unwrap_jump(binfile, 0) == (True, 0x10)
+    assert unwrap_jump(binfile, 0x10) == (False, 0x10)
+
+
+CRT_NOT_THUNK_PATTERNS = (
+    b"\xe8\x3b\x00\x00\x00",  # call +0x40
+    b"\xe9\x3b\x00\x00\x00",  # jmp +0x40
+    b"\xe9\xdb\xff\xff\xff",  # jmp -0x20
 )
 
 
-@pytest.mark.parametrize("opcode", (0xE8, 0xE9))  # CALL, JMP
-@pytest.mark.parametrize("thunk_addr, func_addr", CRT_THUNK_ORIENTATIONS)
-def test_unwrap_jump(thunk_addr: int, func_addr: int, opcode: int):
-    """Testing situations where we assume a jump or call is a thunk."""
-    thunk = jump_instruction(start=thunk_addr, end=func_addr, opcode=opcode)
-
-    # Prepare the instructions
+@pytest.mark.parametrize("code", CRT_NOT_THUNK_PATTERNS)
+def test_unwrap_jump_not_a_thunk(code: bytes):
+    """The function may begin with a call or jmp. It is not a thunk
+    unless the displacements match a thunk pattern exactly."""
     memory = bytearray(128)
-    memory[thunk_addr : thunk_addr + 5] = thunk
-    memory[func_addr] = 0xC3  # RET
+    memory[0x40 : 0x40 + len(code)] = code
 
     binfile = RawImage.from_memory(bytes(memory))
-    assert unwrap_jump(binfile, thunk_addr) == (True, func_addr)
-    assert unwrap_jump(binfile, func_addr) == (False, func_addr)
-
-
-CRT_NOT_A_THUNK_ORIENTATIONS = (
-    (0, 0x40),  # Thunk first
-    (0x60, 0),  # Function first
-)
-
-
-@pytest.mark.parametrize("opcode", (0xE8, 0xE9))  # CALL, JMP
-@pytest.mark.parametrize("thunk_addr, func_addr", CRT_NOT_A_THUNK_ORIENTATIONS)
-def test_unwrap_jump_outside_thresh(thunk_addr: int, func_addr: int, opcode: int):
-    """Testing where we do NOT assume a jump or call is a thunk."""
-    thunk = jump_instruction(start=thunk_addr, end=func_addr, opcode=opcode)
-
-    # Prepare the instructions
-    memory = bytearray(128)
-    memory[thunk_addr : thunk_addr + 5] = thunk
-    memory[func_addr] = 0xC3  # RET
-
-    binfile = RawImage.from_memory(bytes(memory))
-    assert unwrap_jump(binfile, thunk_addr) == (False, thunk_addr)
-    assert unwrap_jump(binfile, func_addr) == (False, func_addr)
+    assert unwrap_jump(binfile, 0x40) == (False, 0x40)


### PR DESCRIPTION
We want to do this so we can call `set_max_size` in between the two actions and establish the upper bound for how many bytes to read when disassembling.

[`105`](https://github.com/CriminalRETeam/gta2_re) has thousands of CRT functions and performance is not great since merging #432 😬

This was thrown together quickly while working on #459 and I'm sure there are more things we could improve (items from #440 perhaps)