### PR TITLE
Don't create entities for substrings

### DIFF
--- a/reccmp/compare/analyze.py
+++ b/reccmp/compare/analyze.py
@@ -46,9 +46,15 @@ def create_analysis_strings(
     an existing entity. It's possible that some variables or pointers
     will be mistakenly identified as short strings."""
     with db.batch() as batch:
+        last_range = range(0)
         for addr, string in binfile.iter_string(encoding):
             # If the address is the site of a relocation, this is a pointer, not a string.
             if addr in binfile.relocations:
+                continue
+
+            # Don't create an entity for a substring of
+            # the most recently created string.
+            if addr in last_range:
                 continue
 
             if is_likely_latin1(string) and not db.intersects(img_id, addr):
@@ -59,6 +65,7 @@ def create_analysis_strings(
                     name=entity_name_from_string(string),
                     size=len(string) + 1,  # including null-terminator
                 )
+                last_range = range(addr, addr + len(string) + 1)
 
 
 def create_analysis_floats(db: EntityDb, img_id: ImageId, binfile: PEImage):

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -116,6 +116,30 @@ def test_create_analysis_strings_do_not_create_substrings(db: EntityDb):
     assert db.get(ImageId.ORIG, 102) is None
 
 
+def test_create_analysis_strings_abutting_strings(db: EntityDb):
+    """Demonstrating that our check for substrings allows strings that are
+    next to each other, separated by the null-terminator."""
+    binfile = Mock(spec=[])
+    # iter_string() hides the null-terminator but it is assumed to be there.
+    binfile.iter_string = Mock(
+        return_value=[(100, "Test"), (105, "Test"), (109, "Test")]
+    )
+    binfile.relocations = set()
+
+    create_analysis_strings(db, ImageId.ORIG, binfile)
+
+    ent = db.get(ImageId.ORIG, 100)
+    assert ent is not None
+    assert ent.get("type") == EntityType.STRING
+
+    ent = db.get(ImageId.ORIG, 105)
+    assert ent is not None
+    assert ent.get("type") == EntityType.STRING
+
+    # Would overlap the null-terminator of the string at address 105.
+    assert db.get(ImageId.ORIG, 109) is None
+
+
 def test_create_analysis_strings_not_relocated(db: EntityDb):
     """Should not add the string if its address is the site of a relocation.
     i.e. We know this is a pointer, despite how it appears."""

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -97,6 +97,25 @@ def test_create_analysis_strings_do_not_replace_overlap(db: EntityDb):
     assert e is None
 
 
+def test_create_analysis_strings_do_not_create_substrings(db: EntityDb):
+    """iter_string() uses the relocation table to search for strings.
+    Bounds checking in a loop may point to an offset of the string,
+    and so those address will end up in the relocation table too.
+    We don't want to create redundant substring entities."""
+    binfile = Mock(spec=[])
+    binfile.iter_string = Mock(return_value=[(100, "Test"), (101, "est"), (102, "st")])
+    binfile.relocations = set()
+
+    create_analysis_strings(db, ImageId.ORIG, binfile)
+
+    ent = db.get(ImageId.ORIG, 100)
+    assert ent is not None
+    assert ent.get("type") == EntityType.STRING
+
+    assert db.get(ImageId.ORIG, 101) is None
+    assert db.get(ImageId.ORIG, 102) is None
+
+
 def test_create_analysis_strings_not_relocated(db: EntityDb):
     """Should not add the string if its address is the site of a relocation.
     i.e. We know this is a pointer, despite how it appears."""


### PR DESCRIPTION
Fixing a regression I noticed after merging #459. You can see this in `LEGO1` with the strings `"eatdn"` and `"A_Bitmap"`.

```
Decreased (3):
0x10040060 - Act3Cop::ParseAction (100.00% -> 99.25%)
0x10077cc0 - RegistrationBook::ReadyWorld (100.00% -> 98.54%)
0x100826f0 - HistoryBook::ReadyWorld (76.33% -> 75.91%)
```

`Act3Cop::ParseAction` is still reduced, but this is "correct" because we don't replace addresses for `cmp reg, value` instructions unless the value is a known entity.