### PR TITLE
Bump `actions/cache` version to v6

### DIFF
--- a/.github/workflows/binfile-lego.yml
+++ b/.github/workflows/binfile-lego.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Restore original binaries
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: binfiles
         key: legobin

--- a/.github/workflows/binfile-ski.yml
+++ b/.github/workflows/binfile-ski.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Restore original binaries
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: binfiles
         key: skibin

--- a/.github/workflows/binfiles.yml
+++ b/.github/workflows/binfiles.yml
@@ -18,21 +18,21 @@ jobs:
     steps:
 
     - name: Restore LEGO
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v6
       with:
         path: binfiles
         key: legobin
         fail-on-cache-miss: true
 
     - name: Restore SKI
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v6
       with:
         path: binfiles
         key: skibin
         fail-on-cache-miss: true
 
     - name: Cache binfiles
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         enableCrossOsArchive: true
         path: binfiles

--- a/.github/workflows/unittest-ghidra.yml
+++ b/.github/workflows/unittest-ghidra.yml
@@ -21,7 +21,7 @@ jobs:
     # container images are used, see https://github.com/actions/cache/issues/1361#issuecomment-2611294058
     - name: Restore original binaries
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: binfiles
         key: legobin

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Restore sample binaries
       id: cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v6
       with:
         enableCrossOsArchive: true
         path: binfiles


### PR DESCRIPTION
I've been having sporadic failures on my fork caused by cache miss for the binfile dependencies. Not just to download them the first time, but also merging them together between steps. This appears to solve it.