### PR TITLE
Fix param test using generator

### DIFF
--- a/tests/test_ghidra_integration_type_imports.py
+++ b/tests/test_ghidra_integration_type_imports.py
@@ -141,7 +141,7 @@ def _assert_legoanimactorentry(imported_structure: "DataType"):
     assert id_component.getDataType().name == "ulong"
 
 
-verified_types = (
+verified_types = tuple(
     t
     for t in CVInfoTypeEnum
     if CvdumpTypeMap[t].verified and t != CVInfoTypeEnum.T_NOTYPE


### PR DESCRIPTION
Fix warning for parametrized test iterating on a generator. [Deprecated in pytest 9.1](https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators) (#465)

The generator was only used once, so no test code was ever skipped.