### PR TITLE
Use raw tuple from `capstone` instead of wrapping

### DIFF
--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -90,12 +90,8 @@ class UsedAddressCollector:
 
         for section in ig.sections:
             if section.type == SectionType.CODE:
-                for (
-                    _,
-                    __,
-                    inst_mnemonic,
-                    inst_op_str,
-                ) in section.contents:
+                for inst in section.contents:
+                    inst_mnemonic, inst_op_str = inst[2:]
                     if inst_mnemonic == "ret":
                         break
 

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -6,7 +6,6 @@ from typing import Callable, Iterator
 from typing_extensions import Buffer
 from reccmp.compare.asm.const import JUMP_MNEMONICS
 from reccmp.compare.asm.instgen import (
-    DisasmLiteInst,
     InstructGen,
     SectionType,
 )
@@ -89,27 +88,26 @@ class UsedAddressCollector:
     def analyze(self, data: Buffer, start_addr: int):
         ig = InstructGen(bytes(data), start_addr, True)
 
-        instructions = (
-            inst
-            for section in ig.sections
-            for inst in section.contents
-            if section.type == SectionType.CODE
-        )
+        for section in ig.sections:
+            if section.type == SectionType.CODE:
+                for (
+                    _,
+                    __,
+                    inst_mnemonic,
+                    inst_op_str,
+                ) in section.contents:
+                    if inst_mnemonic == "ret":
+                        break
 
-        for inst in instructions:
-            assert isinstance(inst, DisasmLiteInst)
-            if inst.mnemonic == "ret":
-                break
+                    if inst_mnemonic in JUMP_MNEMONICS:
+                        continue
 
-            if inst.mnemonic in JUMP_MNEMONICS:
-                continue
-
-            if inst.mnemonic in ("mov", "fstp"):
-                dst_operand, _, src_operand = inst.op_str.partition(", ")
-                self._append_addrs(dst_operand, True)
-                self._append_addrs(src_operand, False)
-            else:
-                self._append_addrs(inst.op_str, False)
+                    if inst_mnemonic in ("mov", "fstp"):
+                        dst_operand, _, src_operand = inst_op_str.partition(", ")
+                        self._append_addrs(dst_operand, True)
+                        self._append_addrs(src_operand, False)
+                    else:
+                        self._append_addrs(inst_op_str, False)
 
 
 def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:

--- a/reccmp/compare/asm/instgen.py
+++ b/reccmp/compare/asm/instgen.py
@@ -9,7 +9,6 @@ from enum import Enum, auto
 from typing import Iterable, Literal, NamedTuple
 from capstone import Cs, CS_ARCH_X86, CS_MODE_16, CS_MODE_32  # type: ignore
 from .const import JUMP_MNEMONICS
-from .types import DisasmLiteInst
 
 
 @cache
@@ -30,7 +29,7 @@ class SectionType(Enum):
 
 class CodeSection(NamedTuple):
     type: Literal[SectionType.CODE]
-    contents: list[DisasmLiteInst]
+    contents: list[DisasmLiteTuple]
 
 
 TabSectionType = Literal[SectionType.DATA_TAB] | Literal[SectionType.ADDR_TAB]
@@ -65,7 +64,7 @@ class InstructGen:
         self.start = start
         self.end = len(blob) + start
         self.section_end: int = self.end
-        self.code_tracks: list[list[DisasmLiteInst]] = []
+        self.code_tracks: list[list[DisasmLiteTuple]] = []
 
         # Todo: Could be refactored later
         self.cur_addr: int = 0
@@ -77,7 +76,7 @@ class InstructGen:
         self.confirmed_addrs: dict[int, SectionType] = {}
         self.analysis()
 
-    def _finish_code_section(self, contents: list[DisasmLiteInst]):
+    def _finish_code_section(self, contents: list[DisasmLiteTuple]):
         self.sections.append(CodeSection(SectionType.CODE, contents))
 
     def _finish_tab_section(self, type_: TabSectionType, stuff: list[tuple[int, int]]):
@@ -140,7 +139,7 @@ class InstructGen:
 
         return new_type
 
-    def _get_code_for(self, addr: int) -> list[DisasmLiteInst]:
+    def _get_code_for(self, addr: int) -> list[DisasmLiteTuple]:
         """Start disassembling at the given address."""
         # If we are reading a code block beyond the first, see if we already
         # have disassembled instructions beginning at the specified address.
@@ -148,7 +147,7 @@ class InstructGen:
         # correct instruction after the jump table's junk instructions.
         for track in self.code_tracks:
             for i, inst in enumerate(track):
-                if inst.address == addr:
+                if inst[0] == addr:
                     return track[i:]
 
         # If we are here, we don't have the instructions.
@@ -160,23 +159,21 @@ class InstructGen:
 
         disassembler = get_disassembler(self.is_32bit)
         blob_cropped = self.blob[addr - self.start :]
-        instructions = [
-            DisasmLiteInst(*inst)
-            for inst in stop_at_int3(disassembler.disasm_lite(blob_cropped, addr))
-        ]
+        instructions = list(stop_at_int3(disassembler.disasm_lite(blob_cropped, addr)))
         self.code_tracks.append(instructions)
         return instructions
 
-    def _handle_jump(self, inst: DisasmLiteInst):
+    def _handle_jump(self, inst: DisasmLiteTuple):
         # If this is a regular jump and its destination is within the
         # bounds of the binary data (i.e. presumed function size)
         # add it to our list of confirmed addresses.
-        if inst.op_str[0] == "0":
-            value = int(inst.op_str, 16)
+        inst_address, inst_size, inst_mnemonic, inst_op_str = inst
+        if inst_op_str[0] == "0":
+            value = int(inst_op_str, 16)
             self._insert_confirmed_addr(value, SectionType.CODE)
 
         # If this is jumping into a table of addresses, save the destination
-        elif (match := displacement_regex.match(inst.op_str)) is not None:
+        elif (match := displacement_regex.match(inst_op_str)) is not None:
             value = int(match.group(1), 16)
             self._insert_confirmed_addr(value, SectionType.ADDR_TAB)
 
@@ -199,6 +196,7 @@ class InstructGen:
                     break
 
                 for inst in instructions:
+                    inst_address, inst_size, inst_mnemonic, inst_op_str = inst
                     # section_end is updated as we read instructions.
                     # If we are into a jump/data table and would read
                     # a junk instruction, stop here.
@@ -207,18 +205,18 @@ class InstructGen:
 
                     # print(f"{inst.address:x} : {inst.mnemonic} {inst.op_str}")
 
-                    if inst.mnemonic in JUMP_MNEMONICS:
+                    if inst_mnemonic in JUMP_MNEMONICS:
                         self._handle_jump(inst)
                         # Todo: log calls too (unwind section)
-                    elif inst.mnemonic in ("mov", "movzx"):
+                    elif inst_mnemonic in ("mov", "movzx"):
                         # Todo: maintain pairing of data/jump tables
-                        if (match := displacement_regex.match(inst.op_str)) is not None:
+                        if (match := displacement_regex.match(inst_op_str)) is not None:
                             value = int(match.group(1), 16)
                             self._insert_confirmed_addr(value, SectionType.DATA_TAB)
 
                     # Do this instead of copying instruction address.
                     # If there is only one instruction, we would get stuck here.
-                    self.cur_addr += inst.size
+                    self.cur_addr += inst_size
 
                 # End of for loop on instructions.
                 # We are at the end of the section or the entire function.
@@ -228,7 +226,7 @@ class InstructGen:
                 # Todo: don't need to iter on every instruction here.
                 # They are already in order.
                 instruction_slice = [
-                    inst for inst in instructions if inst.address < self.section_end
+                    inst for inst in instructions if inst[0] < self.section_end
                 ]
                 self._finish_code_section(instruction_slice)
 

--- a/reccmp/compare/asm/instgen.py
+++ b/reccmp/compare/asm/instgen.py
@@ -17,6 +17,13 @@ def get_disassembler(is_32: bool = True) -> Cs:
 
 
 DisasmLiteTuple = tuple[int, int, str, str]
+"""Raw tuple returned by capstone's disasm_lite() function.
+The fields are:
+    - address
+    - size (of instruction, in bytes)
+    - mnemonic
+    - op_str (all operands, comma-delimited)
+"""
 
 displacement_regex = re.compile(r".*\+ (0x[0-9a-f]+)\]")
 

--- a/reccmp/compare/asm/instgen.py
+++ b/reccmp/compare/asm/instgen.py
@@ -163,17 +163,16 @@ class InstructGen:
         self.code_tracks.append(instructions)
         return instructions
 
-    def _handle_jump(self, inst: DisasmLiteTuple):
+    def _handle_jump(self, op_str: str):
         # If this is a regular jump and its destination is within the
         # bounds of the binary data (i.e. presumed function size)
         # add it to our list of confirmed addresses.
-        inst_address, inst_size, inst_mnemonic, inst_op_str = inst
-        if inst_op_str[0] == "0":
-            value = int(inst_op_str, 16)
+        if op_str[0] == "0":
+            value = int(op_str, 16)
             self._insert_confirmed_addr(value, SectionType.CODE)
 
         # If this is jumping into a table of addresses, save the destination
-        elif (match := displacement_regex.match(inst_op_str)) is not None:
+        elif (match := displacement_regex.match(op_str)) is not None:
             value = int(match.group(1), 16)
             self._insert_confirmed_addr(value, SectionType.ADDR_TAB)
 
@@ -195,8 +194,7 @@ class InstructGen:
                     self.cur_addr += 1
                     break
 
-                for inst in instructions:
-                    inst_address, inst_size, inst_mnemonic, inst_op_str = inst
+                for _, inst_size, inst_mnemonic, inst_op_str in instructions:
                     # section_end is updated as we read instructions.
                     # If we are into a jump/data table and would read
                     # a junk instruction, stop here.
@@ -206,7 +204,7 @@ class InstructGen:
                     # print(f"{inst.address:x} : {inst.mnemonic} {inst.op_str}")
 
                     if inst_mnemonic in JUMP_MNEMONICS:
-                        self._handle_jump(inst)
+                        self._handle_jump(inst_op_str)
                         # Todo: log calls too (unwind section)
                     elif inst_mnemonic in ("mov", "movzx"):
                         # Todo: maintain pairing of data/jump tables

--- a/reccmp/compare/asm/parse.py
+++ b/reccmp/compare/asm/parse.py
@@ -10,9 +10,8 @@ import re
 from functools import cache
 from typing_extensions import Buffer
 from .const import JUMP_MNEMONICS, SINGLE_OPERAND_INSTS
-from .instgen import InstructGen, SectionType
+from .instgen import DisasmLiteTuple, InstructGen, SectionType
 from .replacement import AddrTestProtocol, NameReplacementProtocol
-from .types import DisasmLiteInst
 
 AsmExcerpt = list[tuple[int | None, str]]
 
@@ -135,7 +134,7 @@ class ParseAsm:
         value = int(match.group(1), 16)
         return self.indirect_replace(value)
 
-    def sanitize(self, inst: DisasmLiteInst) -> tuple[str, str]:
+    def sanitize(self, inst: DisasmLiteTuple) -> tuple[str, str]:
         # For jumps or calls, if the entire op_str is a hex number, the value
         # is a relative offset.
         # Otherwise (i.e. it looks like `dword ptr [address]`) it is an
@@ -143,40 +142,41 @@ class ParseAsm:
         # Providing the starting address of the function to capstone.disasm has
         # automatically resolved relative offsets to an absolute address.
         # We will have to undo this for some of the jumps or they will not match.
+        inst_address, inst_size, inst_mnemonic, inst_op_str = inst
 
         if (
-            inst.mnemonic in SINGLE_OPERAND_INSTS
-            and (op_str_address := from_hex(inst.op_str)) is not None
+            inst_mnemonic in SINGLE_OPERAND_INSTS
+            and (op_str_address := from_hex(inst_op_str)) is not None
         ):
-            if inst.mnemonic == "call":
-                return (inst.mnemonic, self.replace(op_str_address, exact=True))
+            if inst_mnemonic == "call":
+                return (inst_mnemonic, self.replace(op_str_address, exact=True))
 
-            if inst.mnemonic == "push":
+            if inst_mnemonic == "push":
                 if self.is_addr(op_str_address):
-                    return (inst.mnemonic, self.replace(op_str_address))
+                    return (inst_mnemonic, self.replace(op_str_address))
 
                 # To avoid falling into jump handling
-                return (inst.mnemonic, inst.op_str)
+                return (inst_mnemonic, inst_op_str)
 
-            if inst.mnemonic == "jmp":
+            if inst_mnemonic == "jmp":
                 # The unwind section contains JMPs to other functions.
                 # If we have a name for this address, use it. If not,
                 # do not create a new placeholder. We will instead
                 # fall through to generic jump handling below.
                 potential_name = self.lookup(op_str_address, exact=True)
                 if potential_name is not None:
-                    return (inst.mnemonic, potential_name)
+                    return (inst_mnemonic, potential_name)
 
             # Else: this is any jump
             # Show the jump offset rather than the absolute address
-            jump_displacement = op_str_address - (inst.address + inst.size)
-            return (inst.mnemonic, hex(jump_displacement))
+            jump_displacement = op_str_address - (inst_address + inst_size)
+            return (inst_mnemonic, hex(jump_displacement))
 
-        if inst.mnemonic == "call":
+        if inst_mnemonic == "call":
             # Special handling for absolute indirect CALL.
-            op_str = ptr_replace_regex.sub(self.hex_replace_indirect, inst.op_str)
+            op_str = ptr_replace_regex.sub(self.hex_replace_indirect, inst_op_str)
         else:
-            op_str = ptr_replace_regex.sub(self.hex_replace_always, inst.op_str)
+            op_str = ptr_replace_regex.sub(self.hex_replace_always, inst_op_str)
 
             # We only want relocated addresses for pointer displacement.
             # i.e. ptr [register + something]
@@ -186,12 +186,12 @@ class ParseAsm:
 
         # In the event of pointer comparison, only replace the immediate value
         # if it is a known address.
-        if inst.mnemonic == "cmp":
+        if inst_mnemonic == "cmp":
             op_str = immediate_replace_regex.sub(self.hex_replace_annotated, op_str)
         else:
             op_str = immediate_replace_regex.sub(self.hex_replace_relocated, op_str)
 
-        return (inst.mnemonic, op_str)
+        return (inst_mnemonic, op_str)
 
     def parse_asm(self, data: Buffer, start_addr: int) -> AsmExcerpt:
         self.reset()
@@ -202,9 +202,7 @@ class ParseAsm:
         for section in ig.sections:
             if section.type == SectionType.CODE:
                 for inst in section.contents:
-                    # Use heuristics to disregard some differences that aren't representative
-                    # of the accuracy of a function (e.g. global offsets)
-
+                    inst_address, inst_size, inst_mnemonic, inst_op_str = inst
                     # If there is no pointer or immediate value in the op_str,
                     # there is nothing to sanitize.
                     # This leaves us with cases where a small immediate value or
@@ -214,17 +212,17 @@ class ParseAsm:
                     # where the hex value could not be an address.
                     # The exception is jumps which are as small as 2 bytes
                     # but are still useful to sanitize.
-                    if "0x" in inst.op_str and (
-                        inst.mnemonic in JUMP_MNEMONICS
-                        or inst.size > 4
+                    if "0x" in inst_op_str and (
+                        inst_mnemonic in JUMP_MNEMONICS
+                        or inst_size > 4
                         or not self.is_32bit
                     ):
                         result = self.sanitize(inst)
                     else:
-                        result = (inst.mnemonic, inst.op_str)
+                        result = (inst_mnemonic, inst_op_str)
 
                     # mnemonic + " " + op_str
-                    asm.append((inst.address, " ".join(result)))
+                    asm.append((inst_address, " ".join(result)))
             elif section.type == SectionType.ADDR_TAB:
                 asm.append((None, "Jump table:"))
                 for ofs, target in section.contents:

--- a/reccmp/compare/asm/types.py
+++ b/reccmp/compare/asm/types.py
@@ -1,8 +1,0 @@
-from typing import NamedTuple
-
-
-class DisasmLiteInst(NamedTuple):
-    address: int
-    size: int
-    mnemonic: str
-    op_str: str

--- a/tests/test_instgen.py
+++ b/tests/test_instgen.py
@@ -1,5 +1,4 @@
 from reccmp.compare.asm.instgen import InstructGen, SectionType
-from reccmp.compare.asm.types import DisasmLiteInst
 
 
 def test_ret():
@@ -42,9 +41,9 @@ def test_score_notify():
     # CODE section stopped at correct place?
     section = ig.sections[0]
     assert section.type == SectionType.CODE
-    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
+    last_inst_address = section.contents[-1][0]
 
-    assert instructions[-1].address == 0x100014D2
+    assert last_inst_address == 0x100014D2
     # n.b. 0x100014d2 is the dummy instruction `mov edi, edi`
     # Ghidra does more thorough analysis and ignores this.
     # The last real instruction should be at 0x100014cf. Not a big deal
@@ -77,8 +76,8 @@ def test_smack_case():
     # Make sure we captured the instruction immediately after
     section = ig.sections[2]
     assert section.type == SectionType.CODE
-    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
-    assert instructions[0].mnemonic == "mov"
+    first_inst_mnemonic = section.contents[0][2]
+    assert first_inst_mnemonic == "mov"
 
 
 # BETA10 0x1004c9cc
@@ -106,8 +105,8 @@ def test_beta_case():
     # Make sure we captured the instruction immediately after
     section = ig.sections[2]
     assert section.type == SectionType.CODE
-    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
-    assert instructions[0].mnemonic == "mov"
+    first_inst_mnemonic = section.contents[0][2]
+    assert first_inst_mnemonic == "mov"
 
 
 # LEGO1 0x1000fb50

--- a/tests/test_instgen.py
+++ b/tests/test_instgen.py
@@ -40,8 +40,10 @@ def test_score_notify():
     assert types_only == (SectionType.CODE, SectionType.ADDR_TAB, SectionType.DATA_TAB)
 
     # CODE section stopped at correct place?
-    instructions = ig.sections[0].contents
-    assert isinstance(instructions[-1], DisasmLiteInst)
+    section = ig.sections[0]
+    assert section.type == SectionType.CODE
+    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
+
     assert instructions[-1].address == 0x100014D2
     # n.b. 0x100014d2 is the dummy instruction `mov edi, edi`
     # Ghidra does more thorough analysis and ignores this.
@@ -73,8 +75,10 @@ def test_smack_case():
     assert ig.sections[0].type == ig.sections[2].type == SectionType.CODE
 
     # Make sure we captured the instruction immediately after
-    assert isinstance(ig.sections[2].contents[0], DisasmLiteInst)
-    assert ig.sections[2].contents[0].mnemonic == "mov"
+    section = ig.sections[2]
+    assert section.type == SectionType.CODE
+    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
+    assert instructions[0].mnemonic == "mov"
 
 
 # BETA10 0x1004c9cc
@@ -100,8 +104,10 @@ def test_beta_case():
     assert ig.sections[0].type == ig.sections[2].type == SectionType.CODE
 
     # Make sure we captured the instruction immediately after
-    assert isinstance(ig.sections[2].contents[0], DisasmLiteInst)
-    assert ig.sections[2].contents[0].mnemonic == "mov"
+    section = ig.sections[2]
+    assert section.type == SectionType.CODE
+    instructions = [DisasmLiteInst(*inst) for inst in section.contents]
+    assert instructions[0].mnemonic == "mov"
 
 
 # LEGO1 0x1000fb50

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -7,44 +7,44 @@ from reccmp.compare.asm.replacement import (
     AddrTestProtocol,
     NameReplacementProtocol,
 )
-from reccmp.compare.asm.types import DisasmLiteInst
+from reccmp.compare.asm.instgen import DisasmLiteTuple
 
 REGISTER_ONLY_INSTRUCTIONS = (
     # No operands
-    DisasmLiteInst(0x1000, 1, "sti", ""),
-    DisasmLiteInst(0x1000, 1, "ret", ""),
+    (0x1000, 1, "sti", ""),
+    (0x1000, 1, "ret", ""),
     # One operand
-    DisasmLiteInst(0x1000, 1, "push", "eax"),
-    DisasmLiteInst(0x1000, 2, "call", "eax"),
+    (0x1000, 1, "push", "eax"),
+    (0x1000, 2, "call", "eax"),
     # Two operands
-    DisasmLiteInst(0x1000, 2, "cmp", "eax, edx"),
+    (0x1000, 2, "cmp", "eax, edx"),
 )
 
 
 @pytest.mark.parametrize("inst", REGISTER_ONLY_INSTRUCTIONS)
-def test_nothing_to_replace(inst: DisasmLiteInst):
+def test_nothing_to_replace(inst: DisasmLiteTuple):
     """There's no pointer or address value in these instructions,
     so your operand string should not be manipulated."""
     p = ParseAsm()
     _, op_str = p.sanitize(inst)
-    assert op_str == inst.op_str
+    assert op_str == inst[3]
 
 
 # There is one pointer in these instructions and we always replace it.
 POINTER_INSTRUCTIONS = (
     # One operand
-    DisasmLiteInst(0x1000, 6, "inc", "byte ptr [0x1234]"),
-    DisasmLiteInst(0x1000, 6, "inc", "word ptr [0x1234]"),
-    DisasmLiteInst(0x1000, 6, "inc", "dword ptr [0x1234]"),
-    DisasmLiteInst(0x1000, 6, "inc", "qword ptr [0x1234]"),
+    (0x1000, 6, "inc", "byte ptr [0x1234]"),
+    (0x1000, 6, "inc", "word ptr [0x1234]"),
+    (0x1000, 6, "inc", "dword ptr [0x1234]"),
+    (0x1000, 6, "inc", "qword ptr [0x1234]"),
     # Two operands
-    DisasmLiteInst(0x1000, 5, "mov", "eax, dword ptr [0x1234]"),
-    DisasmLiteInst(0x1000, 5, "mov", "dword ptr [0x1234], eax"),
+    (0x1000, 5, "mov", "eax, dword ptr [0x1234]"),
+    (0x1000, 5, "mov", "dword ptr [0x1234], eax"),
 )
 
 
 @pytest.mark.parametrize("inst", POINTER_INSTRUCTIONS)
-def test_pointer_instructions(inst: DisasmLiteInst):
+def test_pointer_instructions(inst: DisasmLiteTuple):
     """Can identify the pointer and insert a placeholder, regardless of the size
     of the pointed-at-item or the operand position."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=False)
@@ -58,7 +58,7 @@ def test_pointer_instructions(inst: DisasmLiteInst):
 
 
 @pytest.mark.parametrize("inst", POINTER_INSTRUCTIONS)
-def test_pointer_instructions_deterministic(inst: DisasmLiteInst):
+def test_pointer_instructions_deterministic(inst: DisasmLiteTuple):
     """Calling sanitize() twice on the same instruction should give the same result.
     i.e. we use the same placeholder for the same address."""
     p = ParseAsm()
@@ -68,7 +68,7 @@ def test_pointer_instructions_deterministic(inst: DisasmLiteInst):
 
 
 @pytest.mark.parametrize("inst", POINTER_INSTRUCTIONS)
-def test_pointer_instructions_with_name(inst: DisasmLiteInst):
+def test_pointer_instructions_with_name(inst: DisasmLiteTuple):
     """Same as above, but using name lookup and substitution."""
     name_lookup = Mock(spec=NameReplacementProtocol, return_value="Hello")
     p = ParseAsm(name_lookup=name_lookup)
@@ -82,29 +82,29 @@ def test_pointer_instructions_with_name(inst: DisasmLiteInst):
 
 DISPLACE_INSTRUCTIONS = (
     # One operand
-    DisasmLiteInst(0x1000, 6, "inc", "byte ptr [eax + 0x1234]"),
+    (0x1000, 6, "inc", "byte ptr [eax + 0x1234]"),
     # Two operands
-    DisasmLiteInst(0x1000, 6, "mov", "eax, dword ptr [ecx + 0x1234]"),
-    DisasmLiteInst(0x1000, 6, "mov", "dword ptr [ecx + 0x1234], eax"),
-    DisasmLiteInst(0x1000, 7, "mov", "dword ptr [eax*4 + 0x1234], esi"),
-    DisasmLiteInst(0x1000, 7, "mov", "esi, dword ptr [eax*4 + 0x1234]"),
+    (0x1000, 6, "mov", "eax, dword ptr [ecx + 0x1234]"),
+    (0x1000, 6, "mov", "dword ptr [ecx + 0x1234], eax"),
+    (0x1000, 7, "mov", "dword ptr [eax*4 + 0x1234], esi"),
+    (0x1000, 7, "mov", "esi, dword ptr [eax*4 + 0x1234]"),
     # Jump table
-    DisasmLiteInst(0x1000, 7, "jmp", "dword ptr [eax*4 + 0x1234]"),
+    (0x1000, 7, "jmp", "dword ptr [eax*4 + 0x1234]"),
 )
 
 
 @pytest.mark.parametrize("inst", DISPLACE_INSTRUCTIONS)
-def test_displacement_without_addr_verify(inst: DisasmLiteInst):
+def test_displacement_without_addr_verify(inst: DisasmLiteTuple):
     """Can identify displacement operand (i.e. register plus address)
     but we only replace the value if it passes the address test."""
     p = ParseAsm()
     _, op_str = p.sanitize(inst)
     # No address test function provided, should not replace.
-    assert op_str == inst.op_str
+    assert op_str == inst[3]
 
 
 @pytest.mark.parametrize("inst", DISPLACE_INSTRUCTIONS)
-def test_displacement_with_addr_verify(inst: DisasmLiteInst):
+def test_displacement_with_addr_verify(inst: DisasmLiteTuple):
     """Same test as above, but with the address test function provided."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=True)
     p = ParseAsm(addr_test=addr_test)
@@ -117,24 +117,24 @@ def test_displacement_with_addr_verify(inst: DisasmLiteInst):
 
 IMMEDIATE_VALUE_INSTRUCTIONS = (
     # One operand
-    DisasmLiteInst(0x1000, 5, "push", "0x1234"),
+    (0x1000, 5, "push", "0x1234"),
     # Two operands
-    DisasmLiteInst(0x1000, 5, "mov", "eax, 0x1234"),
+    (0x1000, 5, "mov", "eax, 0x1234"),
 )
 
 
 @pytest.mark.parametrize("inst", IMMEDIATE_VALUE_INSTRUCTIONS)
-def test_immediate_without_addr_verify(inst: DisasmLiteInst):
+def test_immediate_without_addr_verify(inst: DisasmLiteTuple):
     """If an operand is just a number, we will substitute the name
     or placeholder if it passes the address test."""
     p = ParseAsm()
     _, op_str = p.sanitize(inst)
     # No address test function provided, should not replace.
-    assert op_str == inst.op_str
+    assert op_str == inst[3]
 
 
 @pytest.mark.parametrize("inst", IMMEDIATE_VALUE_INSTRUCTIONS)
-def test_immediate_with_addr_verify(inst: DisasmLiteInst):
+def test_immediate_with_addr_verify(inst: DisasmLiteTuple):
     """Same test as above, but with the address test function provided."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=True)
     p = ParseAsm(addr_test=addr_test)
@@ -150,7 +150,7 @@ def test_pointer_and_immediate_is_not_addr():
     In this case, we assume 0x5555 is not an address"""
     addr_test = Mock(spec=AddrTestProtocol, return_value=False)
     p = ParseAsm(addr_test=addr_test)
-    inst = DisasmLiteInst(0x1000, 10, "mov", "dword ptr [0x1234], 0x5555")
+    inst = (0x1000, 10, "mov", "dword ptr [0x1234], 0x5555")
 
     _, op_str = p.sanitize(inst)
 
@@ -166,25 +166,25 @@ def test_pointer_and_immediate_is_addr():
     """Same test as above, assumes 0x5555 is a valid address."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=True)
     p = ParseAsm(addr_test=addr_test)
-    inst = DisasmLiteInst(0x1000, 10, "mov", "dword ptr [0x1234], 0x5555")
+    inst = (0x1000, 10, "mov", "dword ptr [0x1234], 0x5555")
 
     _, op_str = p.sanitize(inst)
     assert op_str == "dword ptr [<OFFSET1>], <OFFSET2>"
 
 
 JUMP_SAMPLES = (
-    (DisasmLiteInst(0x1000, 5, "jmp", "0x10ac"), "0xa7"),
-    (DisasmLiteInst(0x1000, 5, "jmp", "0x805"), "-0x800"),
-    (DisasmLiteInst(0x1000, 2, "je", "0x1006"), "0x4"),
-    (DisasmLiteInst(0x1000, 2, "je", "0x1000"), "-0x2"),
-    (DisasmLiteInst(0x1000, 5, "loop", "0x10ac"), "0xa7"),
-    (DisasmLiteInst(0x1000, 2, "loope", "0x1006"), "0x4"),
-    (DisasmLiteInst(0x1000, 2, "loopne", "0x1000"), "-0x2"),
+    ((0x1000, 5, "jmp", "0x10ac"), "0xa7"),
+    ((0x1000, 5, "jmp", "0x805"), "-0x800"),
+    ((0x1000, 2, "je", "0x1006"), "0x4"),
+    ((0x1000, 2, "je", "0x1000"), "-0x2"),
+    ((0x1000, 5, "loop", "0x10ac"), "0xa7"),
+    ((0x1000, 2, "loope", "0x1006"), "0x4"),
+    ((0x1000, 2, "loopne", "0x1000"), "-0x2"),
 )
 
 
 @pytest.mark.parametrize("inst, expected", JUMP_SAMPLES)
-def test_jump_displacement(inst: DisasmLiteInst, expected: str):
+def test_jump_displacement(inst: DisasmLiteTuple, expected: str):
     """Jump instructions use a displacement value as their operand.
     Meaning: the jump destination is the jump instruction's address
     plus the instruction size plus the operand value.
@@ -237,7 +237,7 @@ def test_no_placeholder_for_jumps():
     placeholder OR bump the placeholder number."""
     # codespell:ignore-end
     p = ParseAsm()
-    _, op_str = p.sanitize(DisasmLiteInst(0x1000, 5, "jmp", "0x2000"))
+    _, op_str = p.sanitize((0x1000, 5, "jmp", "0x2000"))
 
     # We don't have the name, so don't use a placeholder.
     assert op_str != "<OFFSET1>"
@@ -248,10 +248,10 @@ def test_jmp_ignore_placeholder():
     p = ParseAsm()
 
     # Establish placeholder for 0x2000
-    p.sanitize(DisasmLiteInst(0x1000, 5, "call", "0x2000"))
+    p.sanitize((0x1000, 5, "call", "0x2000"))
     assert 0x2000 in p.replacements
 
-    _, op_str = p.sanitize(DisasmLiteInst(0x1000, 5, "jmp", "0x2000"))
+    _, op_str = p.sanitize((0x1000, 5, "jmp", "0x2000"))
 
     # Do not use the existing placeholder
     assert op_str != "<OFFSET1>"
@@ -263,7 +263,7 @@ def test_jmp_with_name_lookup():
     name_lookup = Mock(spec=NameReplacementProtocol, return_value="Hello")
     p = ParseAsm(name_lookup=name_lookup)
 
-    _, op_str = p.sanitize(DisasmLiteInst(0x1000, 5, "jmp", "0x2000"))
+    _, op_str = p.sanitize((0x1000, 5, "jmp", "0x2000"))
 
     name_lookup.assert_called_with(0x2000, exact=True, indirect=False)
     assert op_str == "Hello"
@@ -276,12 +276,12 @@ def test_cmp_without_name_lookup():
     because it suggests that some variables are out of order."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=False)
     p = ParseAsm(addr_test=addr_test)
-    inst = DisasmLiteInst(0x1000, 5, "cmp", "eax, 0x2000")
+    inst = (0x1000, 5, "cmp", "eax, 0x2000")
 
     _, op_str = p.sanitize(inst)
 
     addr_test.assert_not_called()
-    assert op_str == inst.op_str
+    assert op_str == inst[3]
 
 
 def test_cmp_ignore_placeholder():
@@ -290,22 +290,22 @@ def test_cmp_ignore_placeholder():
     p = ParseAsm()
 
     # Establish placeholder for 0x2000
-    p.sanitize(DisasmLiteInst(0x1000, 5, "call", "0x2000"))
+    p.sanitize((0x1000, 5, "call", "0x2000"))
     assert 0x2000 in p.replacements
 
-    inst = DisasmLiteInst(0x1000, 5, "cmp", "eax, 0x2000")
+    inst = (0x1000, 5, "cmp", "eax, 0x2000")
 
     _, op_str = p.sanitize(inst)
 
     # Do not use the existing placeholder
-    assert op_str == inst.op_str
+    assert op_str == inst[3]
 
 
 def test_cmp_with_name_lookup():
     """We will replace the value in a CMP instruction if we have a name for the address."""
     name_lookup = Mock(spec=NameReplacementProtocol, return_value="Hello")
     p = ParseAsm(name_lookup=name_lookup)
-    inst = DisasmLiteInst(0x1000, 5, "cmp", "eax, 0x2000")
+    inst = (0x1000, 5, "cmp", "eax, 0x2000")
 
     _, op_str = p.sanitize(inst)
 
@@ -317,7 +317,7 @@ def test_call_without_name_lookup():
     """CALL 0x____ instructions always use a placeholder."""
     addr_test = Mock(spec=AddrTestProtocol, return_value=False)
     p = ParseAsm(addr_test=addr_test)
-    inst = DisasmLiteInst(0x1000, 5, "call", "0x1234")
+    inst = (0x1000, 5, "call", "0x1234")
 
     _, op_str = p.sanitize(inst)
 
@@ -330,7 +330,7 @@ def test_call_with_name_lookup():
     """CALL instructions require exact addr match"""
     name_lookup = Mock(spec=NameReplacementProtocol, return_value="Hello")
     p = ParseAsm(name_lookup=name_lookup)
-    inst = DisasmLiteInst(0x1000, 5, "call", "0x1234")
+    inst = (0x1000, 5, "call", "0x1234")
 
     _, op_str = p.sanitize(inst)
 
@@ -349,10 +349,10 @@ def test_replacement_numbering():
 
     p = ParseAsm(name_lookup=substitute_1234_mock)
 
-    _, op_str = p.sanitize(DisasmLiteInst(0x1000, 6, "inc", "dword ptr [0x1234]"))
+    _, op_str = p.sanitize((0x1000, 6, "inc", "dword ptr [0x1234]"))
     assert op_str == "dword ptr [Hello]"
 
-    _, op_str = p.sanitize(DisasmLiteInst(0x1000, 6, "inc", "dword ptr [0x5555]"))
+    _, op_str = p.sanitize((0x1000, 6, "inc", "dword ptr [0x5555]"))
     assert op_str == "dword ptr [<OFFSET2>]"
 
 
@@ -363,7 +363,7 @@ def test_absolute_indirect():
     that it was called with the indirect parameter set."""
     name_lookup = Mock(spec=NameReplacementProtocol, return_value=None)
     p = ParseAsm(name_lookup=name_lookup)
-    inst = DisasmLiteInst(0x1000, 5, "call", "dword ptr [0x1234]")
+    inst = (0x1000, 5, "call", "dword ptr [0x1234]")
 
     _, op_str = p.sanitize(inst)
 
@@ -381,8 +381,8 @@ def test_direct_and_indirect_different_names():
 
     lookup_mock = Mock(side_effect=lookup)
 
-    indirect_inst = DisasmLiteInst(0x1000, 5, "call", "dword ptr [0x1234]")
-    direct_inst = DisasmLiteInst(0x1000, 5, "mov", "eax, dword ptr [0x1234]")
+    indirect_inst = (0x1000, 5, "call", "dword ptr [0x1234]")
+    direct_inst = (0x1000, 5, "mov", "eax, dword ptr [0x1234]")
 
     # Indirect first
     p = ParseAsm(name_lookup=lookup_mock)
@@ -414,8 +414,8 @@ def test_direct_and_indirect_different_names():
 
 def test_direct_and_indirect_placeholders():
     """If no addresses are known, placeholders for direct and indirect lookup must be distinct"""
-    indirect_inst = DisasmLiteInst(0x1000, 5, "call", "dword ptr [0x1234]")
-    direct_inst = DisasmLiteInst(0x1000, 5, "mov", "eax, dword ptr [0x1234]")
+    indirect_inst = (0x1000, 5, "call", "dword ptr [0x1234]")
+    direct_inst = (0x1000, 5, "mov", "eax, dword ptr [0x1234]")
 
     name_lookup = Mock(spec=NameReplacementProtocol, return_value=None)
     p = ParseAsm(name_lookup=name_lookup)

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -2,11 +2,12 @@
 
 from unittest.mock import Mock, patch
 import pytest
-from reccmp.compare.asm.parse import DisasmLiteInst, ParseAsm
+from reccmp.compare.asm.parse import ParseAsm
 from reccmp.compare.asm.replacement import (
     AddrTestProtocol,
     NameReplacementProtocol,
 )
+from reccmp.compare.asm.types import DisasmLiteInst
 
 REGISTER_ONLY_INSTRUCTIONS = (
     # No operands


### PR DESCRIPTION
Capstone's `disasm_lite()` function returns a tuple with the instruction details. We wrap it in a `namedtuple` to be self-documenting. It's faster to not do that. `LEGO1` is 500-700ms faster on my Windows box.

I've been looking at `iced_x86` again (#175) as a potential replacement for `capstone`. This will be helpful to establish the best performance with the current setup.

Except for some unit tests that still use the `DisasmLiteInst` wrapper, the instruction tuple is only passed around internally between the users of `instgen.py`: asm rendition in `asm/parse.py` and CRT function analysis.