### PR TITLE
Use native replacement for `difflib.SequenceMatcher`

### DIFF
--- a/reccmp/compare/pinned_sequences.py
+++ b/reccmp/compare/pinned_sequences.py
@@ -1,8 +1,13 @@
-from difflib import SequenceMatcher
 from itertools import pairwise
 import itertools
-from typing import Iterable, Iterator, Sequence
+from typing import Iterable, Iterator, Sequence, TYPE_CHECKING
 from reccmp.difflib import DiffOpcode, get_grouped_opcodes
+
+# cydifflib has no type stubs, but we expect it to match the builtin difflib API exactly.
+if TYPE_CHECKING:
+    from difflib import SequenceMatcher
+else:
+    from cydifflib import SequenceMatcher
 
 
 class SequenceMatcherWithPins:

--- a/reccmp/compare/pinned_sequences.py
+++ b/reccmp/compare/pinned_sequences.py
@@ -7,6 +7,7 @@ from reccmp.difflib import DiffOpcode, get_grouped_opcodes
 if TYPE_CHECKING:
     from difflib import SequenceMatcher
 else:
+    # better performance than the stock `difflib`
     from cydifflib import SequenceMatcher
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-capstone
+capstone==5.0.9
 colorama>=0.4.6
-pystache
+pystache==0.6.8
 pydantic==2.13.4
-ruamel.yaml
+ruamel.yaml==0.19.1
 pydemumble==0.0.1
 pyghidra==3.1.0
+cydifflib==1.2.0


### PR DESCRIPTION
@madebr and I were looking into this last month. [`cydifflib`](https://github.com/rapidfuzz/CyDifflib) is another free performance boost, although the magnitude varies with the number of asm instructions in your decomp.

While we are here, pin all versions for our Python dependencies. Many of them are effectively finished projects and there would never be a reason to upgrade, so make sure this does not happen without our knowing.