### PR TITLE
Lazy parsing for cvdump type leaves

### DIFF
--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -28,7 +28,9 @@ logger = logging.getLogger(__name__)
 def load_cvdump_types(cvdump_analysis: CvdumpAnalysis, types: CvdumpTypesParser):
     # TODO: Populate the universal type database here when this exists. (#106)
     # For now, just copy the keys into another CvdumpTypesParser so we can use its API.
-    types.keys.update(cvdump_analysis.types.keys)
+    # pylint:disable=protected-access
+    types._raw.update(cvdump_analysis.types._raw)
+    types._keys.update(cvdump_analysis.types._keys)
     types.alerted_types = cvdump_analysis.types.alerted_types
 
 

--- a/reccmp/cvdump/parser.py
+++ b/reccmp/cvdump/parser.py
@@ -2,7 +2,7 @@ import re
 from pathlib import PureWindowsPath
 from typing import NamedTuple
 from .types import CvdumpTypesParser
-from .symbols import CvdumpSymbolsParser
+from .symbols import CvdumpSymbolsParser, SymbolsEntry
 from .cvinfo import CvdumpTypeKey
 
 # e.g. `     27 00034EC0     28 00034EE2     29 00034EE7     30 00034EF4`
@@ -118,7 +118,7 @@ class CvdumpParser:
         self.symbols_parser = CvdumpSymbolsParser()
 
     @property
-    def symbols(self):
+    def symbols(self) -> list[SymbolsEntry]:
         return self.symbols_parser.symbols
 
     def _lines_section(self, line: str):

--- a/reccmp/cvdump/types.py
+++ b/reccmp/cvdump/types.py
@@ -323,8 +323,17 @@ class CvdumpTypesParser:
     }
 
     def __init__(self) -> None:
-        self.keys: dict[CvdumpTypeKey, CvdumpParsedType] = {}
+        self._keys: dict[CvdumpTypeKey, CvdumpParsedType] = {}
+        self._raw: dict[CvdumpTypeKey, tuple[str, str]] = {}
         self.alerted_types: set[int] = set()
+
+    def from_key(self, type_key: CvdumpTypeKey) -> CvdumpParsedType:
+        try:
+            return self._keys[type_key]
+        except KeyError:
+            pass
+
+        return self._parse_raw(type_key)
 
     def _get_field_list(self, type_obj: CvdumpParsedType) -> list[FieldListItem]:
         """Return the field list for the given LF_CLASS/LF_STRUCTURE reference"""
@@ -333,7 +342,7 @@ class CvdumpTypesParser:
             field_obj = type_obj
         else:
             field_list_type = type_obj["field_list_type"]
-            field_obj = self.keys[field_list_type]
+            field_obj = self.from_key(field_list_type)
 
         members: list[FieldListItem] = []
 
@@ -375,10 +384,7 @@ class CvdumpTypesParser:
             )
 
         # Go to our dictionary to find it.
-        obj = self.keys.get(type_key)
-        if obj is None:
-            raise CvdumpKeyError(type_key)
-
+        obj = self.from_key(type_key)
         obj_type = obj.get("type")
 
         if obj_type == "LF_POINTER":
@@ -548,8 +554,8 @@ class CvdumpTypesParser:
 
     def get_name_for_offset(self, type_key: CvdumpTypeKey, offset: int) -> str:
         """Limited to arrays for now. Enable to close GH #462."""
-        if type_key in self.keys:
-            type_dict = self.keys[type_key]
+        if type_key in self._raw:
+            type_dict = self.from_key(type_key)
             if type_dict.get("type") != "LF_ARRAY":
                 return f"+{offset}" if offset > 0 else ""
 
@@ -594,6 +600,56 @@ class CvdumpTypesParser:
         members = self.get_scalars_gapless(type_key)
         return member_list_to_struct_string(members)
 
+    def _parse_raw(self, leaf_id: CvdumpTypeKey) -> CvdumpParsedType:
+        try:
+            leaf, leaf_type = self._raw[leaf_id]
+        except KeyError as ex:
+            raise CvdumpKeyError from ex
+
+        try:
+            match leaf_type:
+                case "LF_MODIFIER":
+                    self._keys[leaf_id] = self.read_modifier(leaf, leaf_type)
+
+                case "LF_ARRAY":
+                    self._keys[leaf_id] = self.read_array(leaf, leaf_type)
+
+                case "LF_FIELDLIST":
+                    self._keys[leaf_id] = self.read_fieldlist(leaf, leaf_type)
+
+                case "LF_ARGLIST":
+                    self._keys[leaf_id] = self.read_arglist(leaf, leaf_type)
+
+                case "LF_MFUNCTION":
+                    self._keys[leaf_id] = self.read_mfunction(leaf, leaf_type)
+
+                case "LF_PROCEDURE":
+                    self._keys[leaf_id] = self.read_procedure(leaf, leaf_type)
+
+                case "LF_CLASS" | "LF_STRUCTURE":
+                    self._keys[leaf_id] = self.read_class_or_struct(leaf, leaf_type)
+
+                case "LF_POINTER":
+                    self._keys[leaf_id] = self.read_pointer(leaf, leaf_type)
+
+                case "LF_ENUM":
+                    self._keys[leaf_id] = self.read_enum(leaf, leaf_type)
+
+                case "LF_UNION":
+                    self._keys[leaf_id] = self.read_union(leaf, leaf_type)
+
+                case "LF_BITFIELD":
+                    self._keys[leaf_id] = self.read_bitfield(leaf, leaf_type)
+
+                case _:
+                    # Check for exhaustiveness
+                    logger.error("Unhandled leaf type: %s", leaf_type)
+
+        except AssertionError:
+            logger.error("Failed to parse PDB types leaf:\n%s", leaf)
+
+        return self._keys[leaf_id]
+
     def read_all(self, section: str):
         r_leafsplit = re.compile(r"\n(?=0x\w{4,8} : )")
         for leaf in r_leafsplit.split(section):
@@ -601,51 +657,9 @@ class CvdumpTypesParser:
                 continue
 
             leaf_id_str, leaf_type = match.groups()
-            leaf_id = CvdumpTypeKey.from_str(leaf_id_str)
-            if leaf_type not in self.MODES_OF_INTEREST:
-                continue
-
-            try:
-                match leaf_type:
-                    case "LF_MODIFIER":
-                        self.keys[leaf_id] = self.read_modifier(leaf, leaf_type)
-
-                    case "LF_ARRAY":
-                        self.keys[leaf_id] = self.read_array(leaf, leaf_type)
-
-                    case "LF_FIELDLIST":
-                        self.keys[leaf_id] = self.read_fieldlist(leaf, leaf_type)
-
-                    case "LF_ARGLIST":
-                        self.keys[leaf_id] = self.read_arglist(leaf, leaf_type)
-
-                    case "LF_MFUNCTION":
-                        self.keys[leaf_id] = self.read_mfunction(leaf, leaf_type)
-
-                    case "LF_PROCEDURE":
-                        self.keys[leaf_id] = self.read_procedure(leaf, leaf_type)
-
-                    case "LF_CLASS" | "LF_STRUCTURE":
-                        self.keys[leaf_id] = self.read_class_or_struct(leaf, leaf_type)
-
-                    case "LF_POINTER":
-                        self.keys[leaf_id] = self.read_pointer(leaf, leaf_type)
-
-                    case "LF_ENUM":
-                        self.keys[leaf_id] = self.read_enum(leaf, leaf_type)
-
-                    case "LF_UNION":
-                        self.keys[leaf_id] = self.read_union(leaf, leaf_type)
-
-                    case "LF_BITFIELD":
-                        self.keys[leaf_id] = self.read_bitfield(leaf, leaf_type)
-
-                    case _:
-                        # Check for exhaustiveness
-                        logger.error("Unhandled data in mode: %s", leaf_type)
-
-            except AssertionError:
-                logger.error("Failed to parse PDB types leaf:\n%s", leaf)
+            if leaf_type in self.MODES_OF_INTEREST:
+                leaf_id = CvdumpTypeKey.from_str(leaf_id_str)
+                self._raw[leaf_id] = (leaf, leaf_type)
 
     def read_modifier(self, leaf: str, leaf_type: str) -> CvdumpParsedType:
         match = self.MODIFIES_RE.search(leaf)

--- a/reccmp/ghidra/importer/pdb_extraction.py
+++ b/reccmp/ghidra/importer/pdb_extraction.py
@@ -5,7 +5,7 @@ from reccmp.formats.exceptions import InvalidVirtualAddressError
 from reccmp.cvdump.symbols import SymbolsEntry
 from reccmp.compare import Compare
 from reccmp.compare.db import ReccmpMatch
-from reccmp.cvdump.types import CvdumpParsedType
+from reccmp.cvdump.types import CvdumpKeyError
 from reccmp.cvdump.cvinfo import CvdumpTypeKey, CVInfoTypeEnum
 
 logger = logging.getLogger(__file__)
@@ -63,11 +63,6 @@ class PdbFunctionExtractor:
         "Fast Near": "__fastcall",
     }
 
-    def _get_cvdump_type(
-        self, type_key: CvdumpTypeKey | None
-    ) -> CvdumpParsedType | None:
-        return None if type_key is None else self.compare.types.keys.get(type_key)
-
     def _get_func_signature(self, fn: SymbolsEntry) -> FunctionSignature | None:
         function_type_key = fn.func_type
         if function_type_key == CVInfoTypeEnum.T_NOTYPE:
@@ -76,8 +71,9 @@ class PdbFunctionExtractor:
 
         # get corresponding function type
 
-        function_type = self.compare.types.keys.get(function_type_key)
-        if function_type is None:
+        try:
+            function_type = self.compare.types.from_key(function_type_key)
+        except CvdumpKeyError:
             logger.error(
                 "Could not find function type %s for function %s", fn.func_type, fn.name
             )
@@ -85,8 +81,8 @@ class PdbFunctionExtractor:
 
         class_type = function_type.get("class_type")
 
-        arg_list_type = self._get_cvdump_type(function_type.get("arg_list_type"))
-        assert arg_list_type is not None
+        assert "arg_list_type" in function_type
+        arg_list_type = self.compare.types.from_key(function_type["arg_list_type"])
         arg_list_pdb_types = arg_list_type.get("args", [])
         assert arg_list_type["argcount"] == len(arg_list_pdb_types)
 

--- a/reccmp/ghidra/importer/type_importer.py
+++ b/reccmp/ghidra/importer/type_importer.py
@@ -22,6 +22,7 @@ from ghidra.program.model.data import (
 )
 
 from reccmp.cvdump.types import (
+    CvdumpKeyError,
     CvdumpParsedType,
     FieldListItem,
     VirtualBasePointer,
@@ -96,8 +97,8 @@ class PdbTypeImporter:
             return self._import_scalar_type(type_index)
 
         try:
-            type_pdb = self.extraction.compare.types.keys[type_index]
-        except KeyError as e:
+            type_pdb = self.extraction.compare.types.from_key(type_index)
+        except CvdumpKeyError as e:
             raise TypeNotFoundError(
                 f"Failed to find referenced type '{type_index:#x}'"
             ) from e
@@ -201,8 +202,13 @@ class PdbTypeImporter:
 
     def _import_enum(self, type_pdb: CvdumpParsedType) -> DataType:
         underlying_type = self.import_pdb_type_into_ghidra(type_pdb["underlying_type"])
-        field_list = self.extraction.compare.types.keys.get(type_pdb["field_list_type"])
-        assert field_list is not None, f"Failed to find field list for enum {type_pdb}"
+        try:
+            field_list = self.extraction.compare.types.from_key(
+                type_pdb["field_list_type"]
+            )
+        except CvdumpKeyError:
+            assert False, f"Failed to find field list for enum {type_pdb}"
+
         type_name: str = type_pdb["name"]
 
         result = self._get_or_create_enum_data_type(
@@ -223,7 +229,7 @@ class PdbTypeImporter:
         slim_for_vbase: bool = False,
     ) -> DataType:
         field_list_type = type_in_pdb["field_list_type"]
-        field_list = self.types.keys[field_list_type]
+        field_list = self.types.from_key(field_list_type)
 
         class_size: int = type_in_pdb["size"]
         raw_name: str = type_in_pdb["name"]

--- a/tests/test_compare_mutate_match_array.py
+++ b/tests/test_compare_mutate_match_array.py
@@ -8,6 +8,7 @@ from reccmp.cvdump.types import CvdumpTypesParser, FieldListItem, CVInfoTypeEnum
 from reccmp.cvdump.cvinfo import CvdumpTypeKey as TK
 
 # pylint:disable=protected-access
+# TODO: Remove after we no longer access `types_db._keys` directly. See #485.
 
 
 @pytest.fixture(name="db")

--- a/tests/test_compare_mutate_match_array.py
+++ b/tests/test_compare_mutate_match_array.py
@@ -7,6 +7,8 @@ from reccmp.compare.db import EntityDb
 from reccmp.cvdump.types import CvdumpTypesParser, FieldListItem, CVInfoTypeEnum
 from reccmp.cvdump.cvinfo import CvdumpTypeKey as TK
 
+# pylint:disable=protected-access
+
 
 @pytest.fixture(name="db")
 def fixture_db() -> EntityDb:
@@ -42,7 +44,7 @@ def name_for_address(
 
 def test_match_array(db: EntityDb, types_db: CvdumpTypesParser):
     """Should rename the entity for the array and create a new entity for the second member."""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": CVInfoTypeEnum.T_REAL32,
         "size": 8,
@@ -117,12 +119,12 @@ def test_match_array_type_is_scalar(db: EntityDb):
 def test_match_array_type_is_struct(db: EntityDb, types_db: CvdumpTypesParser):
     """Should have no effect if the data_type key is not an array.
     We do not currently populate entities for struct members."""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1001),
         "size": 8,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="hello", type=CVInfoTypeEnum.T_REAL32),
@@ -153,7 +155,7 @@ def test_match_array_type_is_struct(db: EntityDb, types_db: CvdumpTypesParser):
 def test_match_array_type_orig_smaller(db: EntityDb, types_db: CvdumpTypesParser):
     """Should not create entities on the orig side if the array is known to be smaller.
     (i.e. if another DATA entity is in the way.)"""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": CVInfoTypeEnum.T_REAL32,
         "size": 8,
@@ -184,17 +186,17 @@ def test_match_array_type_orig_smaller(db: EntityDb, types_db: CvdumpTypesParser
 
 def test_match_array_array_of_structs(db: EntityDb, types_db: CvdumpTypesParser):
     """If the type is an array of structs, create entities for one level of struct members."""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": TK(0x1001),
         "size": 16,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1002),
         "size": 8,
     }
-    types_db.keys[TK(0x1002)] = {
+    types_db._keys[TK(0x1002)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="hello", type=CVInfoTypeEnum.T_REAL32),
@@ -227,12 +229,12 @@ def test_match_array_array_of_structs(db: EntityDb, types_db: CvdumpTypesParser)
 
 def test_match_array_array_of_arrays(db: EntityDb, types_db: CvdumpTypesParser):
     """For a multi-dimensional array, create entities for one level."""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": TK(0x1001),
         "size": 16,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_ARRAY",
         "array_type": CVInfoTypeEnum.T_REAL32,
         "size": 8,
@@ -263,29 +265,29 @@ def test_match_array_array_of_arrays(db: EntityDb, types_db: CvdumpTypesParser):
 
 def test_match_array_array_of_structs_limit(db: EntityDb, types_db: CvdumpTypesParser):
     """Does not create entities for offsets more than one level beyond the main entity."""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": TK(0x1001),
         "size": 16,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1002),
         "size": 8,
     }
-    types_db.keys[TK(0x1002)] = {
+    types_db._keys[TK(0x1002)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="hello", type=TK(0x1003)),
             FieldListItem(offset=4, name="world", type=TK(0x1003)),
         ],
     }
-    types_db.keys[TK(0x1003)] = {
+    types_db._keys[TK(0x1003)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1004),
         "size": 4,
     }
-    types_db.keys[TK(0x1004)] = {
+    types_db._keys[TK(0x1004)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="x", type=CVInfoTypeEnum.T_SHORT),
@@ -322,17 +324,17 @@ def test_match_array_array_of_union_structs(db: EntityDb, types_db: CvdumpTypesP
     - We create offset entities for unions, as with a struct or multidimensional array
     - We will not create entities deeper than the second level (in this case, array -> union)
     """
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": TK(0x1001),
         "size": 8,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_UNION",
         "field_list_type": TK(0x1002),
         "size": 4,
     }
-    types_db.keys[TK(0x1002)] = {
+    types_db._keys[TK(0x1002)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="hello", type=TK(0x1003)),
@@ -341,12 +343,12 @@ def test_match_array_array_of_union_structs(db: EntityDb, types_db: CvdumpTypesP
     }
     # These values will not be accessed because we do not completely flatten the structure.
     # But they are here to provide a complete example of type data.
-    types_db.keys[TK(0x1003)] = {
+    types_db._keys[TK(0x1003)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1004),
         "size": 4,
     }
-    types_db.keys[TK(0x1004)] = {
+    types_db._keys[TK(0x1004)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="a", type=CVInfoTypeEnum.T_CHAR),
@@ -377,17 +379,17 @@ def test_match_array_array_of_union_structs(db: EntityDb, types_db: CvdumpTypesP
 
 def test_match_array_of_struct_bitfield(db: EntityDb, types_db: CvdumpTypesParser):
     """Verify comparing an array of struct bitfields uses the underlying type of the bitfield"""
-    types_db.keys[TK(0x1000)] = {
+    types_db._keys[TK(0x1000)] = {
         "type": "LF_ARRAY",
         "array_type": TK(0x1001),
         "size": 4 * 8,
     }
-    types_db.keys[TK(0x1001)] = {
+    types_db._keys[TK(0x1001)] = {
         "type": "LF_STRUCTURE",
         "field_list_type": TK(0x1002),
         "size": 8,
     }
-    types_db.keys[TK(0x1002)] = {
+    types_db._keys[TK(0x1002)] = {
         "type": "LF_FIELDLIST",
         "members": [
             FieldListItem(offset=0, name="v0", type=CVInfoTypeEnum.T_UINT4),
@@ -395,13 +397,13 @@ def test_match_array_of_struct_bitfield(db: EntityDb, types_db: CvdumpTypesParse
             FieldListItem(offset=4, name="bit1", type=TK(0x1004)),
         ],
     }
-    types_db.keys[TK(0x1003)] = {
+    types_db._keys[TK(0x1003)] = {
         "type": "LF_BITFIELD",
         "bit_start": 0,
         "bit_count": 1,
         "bit_type": CVInfoTypeEnum.T_UCHAR,
     }
-    types_db.keys[TK(0x1004)] = {
+    types_db._keys[TK(0x1004)] = {
         "type": "LF_BITFIELD",
         "bit_start": 1,
         "bit_count": 1,

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -3,6 +3,7 @@ and type dependency tree walker."""
 
 # pylint:disable=too-many-lines
 # pylint:disable=protected-access
+# TODO: Remove after we no longer access `types_db._keys` directly. See #485.
 
 from struct import calcsize
 from typing import Iterable

--- a/tests/test_cvdump_types.py
+++ b/tests/test_cvdump_types.py
@@ -2,6 +2,7 @@
 and type dependency tree walker."""
 
 # pylint:disable=too-many-lines
+# pylint:disable=protected-access
 
 from struct import calcsize
 from typing import Iterable
@@ -418,12 +419,12 @@ def types_empty_parser_fixture():
 
 
 def test_basic_parsing(parser: CvdumpTypesParser):
-    obj = parser.keys[TK(0x4DB6)]
+    obj = parser.from_key(TK(0x4DB6))
     assert obj["type"] == "LF_CLASS"
     assert obj["name"] == "MxString"
     assert obj["udt"] == TK(0x4DB6)
 
-    assert len(parser.keys[TK(0x4DB5)]["members"]) == 2
+    assert len(parser.from_key(TK(0x4DB5))["members"]) == 2
 
 
 def test_scalar_types(parser: CvdumpTypesParser):
@@ -485,8 +486,7 @@ def test_members(parser: CvdumpTypesParser):
 def test_virtual_base_classes(parser: CvdumpTypesParser):
     """Make sure that virtual base classes are parsed correctly."""
 
-    lego_car_race_actor = parser.keys.get(TK(0x5591))
-    assert lego_car_race_actor is not None
+    lego_car_race_actor = parser.from_key(TK(0x5591))
     assert lego_car_race_actor["vbase"] == VirtualBasePointer(
         vboffset=4,
         bases=[
@@ -687,7 +687,7 @@ def test_lf_pointer(parser: CvdumpTypesParser):
 
 def test_lf_pointer_type(parser: CvdumpTypesParser):
     """Save pointer type from leaf."""
-    leaf = parser.keys[TK(0x3FAB)]
+    leaf = parser.from_key(TK(0x3FAB))
     assert leaf["pointer_type"] == "Pointer"
 
 
@@ -706,7 +706,8 @@ def test_broken_forward_ref(parser: CvdumpTypesParser):
     parser.get(TK(0x1220))
 
     # Delete the MxCore LF_CLASS
-    del parser.keys[TK(0x4060)]
+    del parser._raw[TK(0x4060)]
+    del parser._keys[TK(0x4060)]
 
     # Forward ref via 0x1220 will fail
     with pytest.raises(CvdumpKeyError):
@@ -720,7 +721,7 @@ def test_null_forward_ref(parser: CvdumpTypesParser):
     parser.get(TK(0x14DB))
 
     # Delete the UDT for MxString
-    del parser.keys[TK(0x14DB)]["udt"]
+    del parser._keys[TK(0x14DB)]["udt"]
 
     # Cannot complete the forward reference lookup
     with pytest.raises(CvdumpIntegrityError):
@@ -732,7 +733,8 @@ def test_broken_array_element_ref(parser: CvdumpTypesParser):
     parser.get(TK(0x19B1))
 
     # Delete ROIColorAlias
-    del parser.keys[TK(0x19B0)]
+    del parser._raw[TK(0x19B0)]
+    del parser._keys[TK(0x19B0)]
 
     # Type reference lookup will fail
     with pytest.raises(CvdumpKeyError):
@@ -754,7 +756,7 @@ def test_lf_modifier(parser: CvdumpTypesParser):
 
 def test_lf_modifier_modified_how(parser: CvdumpTypesParser):
     """Store the modification type (e.g. const, volatile) from the leaf."""
-    leaf = parser.keys[TK(0x1028)]
+    leaf = parser.from_key(TK(0x1028))
     assert leaf["modification"] == "const"
 
 
@@ -771,7 +773,7 @@ CONST_VOLATILE_MODIFIED_EXAMPLE = """
 def test_lf_modifier_const_and_volatile(empty_parser: CvdumpTypesParser):
     """Store the complete modifier text from the leaf."""
     empty_parser.read_all(CONST_VOLATILE_MODIFIED_EXAMPLE)
-    leaf = empty_parser.keys[TK(0x40A5)]
+    leaf = empty_parser.from_key(TK(0x40A5))
     assert "const" in leaf["modification"]
     assert "volatile" in leaf["modification"]
 
@@ -794,13 +796,13 @@ def test_union_members(parser: CvdumpTypesParser):
 
 
 def test_arglist(parser: CvdumpTypesParser):
-    arglist = parser.keys[TK(0x1018)]
+    arglist = parser.from_key(TK(0x1018))
     assert arglist["argcount"] == 3
     assert arglist["args"] == [TK(0x100D), 0x1016, 0x1017]
 
 
 def test_procedure(parser: CvdumpTypesParser):
-    procedure = parser.keys[TK(0x1019)]
+    procedure = parser.from_key(TK(0x1019))
     assert procedure == {
         "type": "LF_PROCEDURE",
         "return_type": CVInfoTypeEnum.T_LONG,
@@ -812,7 +814,7 @@ def test_procedure(parser: CvdumpTypesParser):
 
 
 def test_mfunction(parser: CvdumpTypesParser):
-    mfunction = parser.keys[TK(0x101E)]
+    mfunction = parser.from_key(TK(0x101E))
     assert mfunction == {
         "type": "LF_MFUNCTION",
         "return_type": CVInfoTypeEnum.T_CHAR,
@@ -827,14 +829,14 @@ def test_mfunction(parser: CvdumpTypesParser):
 
 
 def test_union_forward_ref(parser: CvdumpTypesParser):
-    union = parser.keys[TK(0x2339)]
+    union = parser.from_key(TK(0x2339))
     assert union["is_forward_ref"] is True
     assert "field_list_type" not in union
     assert union["udt"] == TK(0x2E85)
 
 
 def test_union(parser: CvdumpTypesParser):
-    union = parser.keys[TK(0x2E85)]
+    union = parser.from_key(TK(0x2E85))
     assert union == {
         "type": "LF_UNION",
         "name": "FlagBitfield",
@@ -845,7 +847,7 @@ def test_union(parser: CvdumpTypesParser):
 
 
 def test_fieldlist_enumerate(parser: CvdumpTypesParser):
-    fieldlist_enum = parser.keys[TK(0x3C45)]
+    fieldlist_enum = parser.from_key(TK(0x3C45))
     assert fieldlist_enum == {
         "type": "LF_FIELDLIST",
         "variants": [
@@ -873,7 +875,7 @@ def test_unnamed_union(empty_parser: CvdumpTypesParser):
     empty_parser.read_all(UNNAMED_UNION_DATA)
 
     # Make sure we can parse the members line
-    union = empty_parser.keys[TK(0x369E)]
+    union = empty_parser.from_key(TK(0x369E))
     assert union["name"] == "__unnamed"
     assert union["size"] == 4
     assert union["field_list_type"] == TK(0x369D)
@@ -895,7 +897,7 @@ def test_arglist_unknown_type(empty_parser: CvdumpTypesParser):
     """Should parse the ??? types and not fail with an assert."""
     empty_parser.read_all(ARGLIST_UNKNOWN_TYPE)
 
-    t = empty_parser.keys[TK(0x11F3)]
+    t = empty_parser.from_key(TK(0x11F3))
     assert len(t["args"]) == t["argcount"]
 
     # Make sure we correctly identify the type key.
@@ -927,10 +929,10 @@ def test_mfunction_func_attr(empty_parser: CvdumpTypesParser):
     """Should parse "Func attr" values other than 'none'"""
     empty_parser.read_all(FUNC_ATTR_EXAMPLES)
 
-    assert empty_parser.keys[TK(0x1216)]["func_attr"] == "return UDT (C++ style)"
-    assert empty_parser.keys[TK(0x122B)]["func_attr"] == "instance constructor"
+    assert empty_parser.from_key(TK(0x1216))["func_attr"] == "return UDT (C++ style)"
+    assert empty_parser.from_key(TK(0x122B))["func_attr"] == "instance constructor"
     assert (
-        empty_parser.keys[TK(0x1232)]["func_attr"]
+        empty_parser.from_key(TK(0x1232))["func_attr"]
         == "****Warning**** unused field non-zero!"
     )
 
@@ -945,8 +947,8 @@ def test_union_without_udt(empty_parser: CvdumpTypesParser):
     """Should parse union that is missing the UDT attribute"""
     empty_parser.read_all(UNION_UNNAMED_TAG)
 
-    assert "udt" not in empty_parser.keys[TK(0x3352)]
-    assert empty_parser.keys[TK(0x3352)]["name"] == "<unnamed-tag>"
+    assert "udt" not in empty_parser.from_key(TK(0x3352))
+    assert empty_parser.from_key(TK(0x3352))["name"] == "<unnamed-tag>"
 
 
 # codespell:ignore-begin
@@ -963,7 +965,7 @@ def test_mfunction_unk_return_type(empty_parser: CvdumpTypesParser):
     """Should parse unknown return type as-is"""
     empty_parser.read_all(MFUNCTION_UNK_RETURN_TYPE)
 
-    assert empty_parser.keys[TK(0x11D8)]["return_type"] == TK(0x47C)
+    assert empty_parser.from_key(TK(0x11D8))["return_type"] == TK(0x47C)
 
 
 CLASS_WITH_UNIQUE_NAME = """
@@ -979,7 +981,7 @@ def test_class_unique_name(empty_parser: CvdumpTypesParser):
     """Make sure we can parse the UDT when the 'unique name' attribute is present"""
     empty_parser.read_all(CLASS_WITH_UNIQUE_NAME)
 
-    assert empty_parser.keys[TK(0x1CF0)]["udt"] == TK(0x1CF0)
+    assert empty_parser.from_key(TK(0x1CF0))["udt"] == TK(0x1CF0)
 
 
 TWO_FORMATS_FOR_ARRAY_LENGTH = """
@@ -1001,8 +1003,8 @@ def test_two_formats_for_array_length(empty_parser: CvdumpTypesParser):
     """Make sure we can parse the UDT when the 'unique name' attribute is present"""
     empty_parser.read_all(TWO_FORMATS_FOR_ARRAY_LENGTH)
 
-    assert empty_parser.keys[TK(0x62C1)]["size"] == 50
-    assert empty_parser.keys[TK(0x62C5)]["size"] == 131328
+    assert empty_parser.from_key(TK(0x62C1))["size"] == 50
+    assert empty_parser.from_key(TK(0x62C5))["size"] == 131328
 
 
 LF_POINTER_TO_MEMBER = """
@@ -1016,7 +1018,7 @@ LF_POINTER_TO_MEMBER = """
 def test_pointer_to_member(empty_parser: CvdumpTypesParser):
     """LF_POINTER with optional 'Containing class' attribute."""
     empty_parser.read_all(LF_POINTER_TO_MEMBER)
-    assert empty_parser.keys[TK(0x1646)]["element_type"] == TK(0x1645)
+    assert empty_parser.from_key(TK(0x1646))["element_type"] == TK(0x1645)
 
 
 MSVC700_ENUM_WITH_LOCAL_FLAG = """
@@ -1030,7 +1032,7 @@ def test_enum_with_local_flag(empty_parser: CvdumpTypesParser):
     """Make sure we can parse an enum with the LOCAL flag set. At the moment, the flag is ignored."""
     empty_parser.read_all(MSVC700_ENUM_WITH_LOCAL_FLAG)
 
-    assert empty_parser.keys[TK(0x26BA)] == {
+    assert empty_parser.from_key(TK(0x26BA)) == {
         "field_list_type": 0x26B9,
         "name": "SomeEnumType::SomeEnumInternalName::__l2::__unnamed",
         "num_members": 3,
@@ -1074,7 +1076,7 @@ def test_enum_with_containing_class_and_type_of_pointed_to(
     """Make sure that a pointer with these attributes is parsed correctly. 'Type of pointed to' is currently ignored."""
     empty_parser.read_all(MSVC700_POINTER_CONTAINING_CLASS_TYPE_OF_POINTED_TO)
 
-    assert empty_parser.keys[TK(0x64CA)] == {
+    assert empty_parser.from_key(TK(0x64CA)) == {
         "element_type": 0x2FD1,
         "type": "LF_POINTER",
         "containing_class": 0x1165,
@@ -1094,7 +1096,7 @@ def test_pointer_without_containing_class(
 ):
     empty_parser.read_all(POINTER_WITHOUT_CONTAINING_CLASS)
 
-    assert empty_parser.keys[TK(0x534E)] == {
+    assert empty_parser.from_key(TK(0x534E)) == {
         "element_type": 0x2505,
         "type": "LF_POINTER",
         "pointer_type": "Pointer",
@@ -1113,7 +1115,7 @@ def test_enum_with_whitespace_and_comma(
 ):
     empty_parser.read_all(ENUM_WITH_WHITESPACE_AND_COMMA)
 
-    assert empty_parser.keys[TK(0x4DC2)] == {
+    assert empty_parser.from_key(TK(0x4DC2)) == {
         "field_list_type": 0x2588,
         "is_nested": True,
         "name": "CPool<CTask,signed char [128]>::__unnamed",
@@ -1134,7 +1136,7 @@ def test_this_adjust_hex(empty_parser: CvdumpTypesParser):
     Parms = 3, Arg list type = 0x6579, This adjust = 24""")
     # codespell:ignore-end
 
-    assert empty_parser.keys[TK(0x657A)]["this_adjust"] == TK(0x24)
+    assert empty_parser.from_key(TK(0x657A))["this_adjust"] == TK(0x24)
 
 
 BIG_TYPE_KEY_SAMPLE = """
@@ -1164,10 +1166,10 @@ def test_type_keys_over_ffff(empty_parser: CvdumpTypesParser):
     """Make sure we can read type keys larger than 0xffff.
     This checks various leaves where it could appear."""
     empty_parser.read_all(BIG_TYPE_KEY_SAMPLE)
-    assert empty_parser.keys[TK(0x1023)]["udt"] == TK(0x11738)
-    assert empty_parser.keys[TK(0x11736)]["array_type"] == TK(0x11735)
-    assert empty_parser.keys[TK(0x11737)]["members"][0].type == TK(0x11736)
-    assert empty_parser.keys[TK(0x11738)]["field_list_type"] == TK(0x11737)
+    assert empty_parser.from_key(TK(0x1023))["udt"] == TK(0x11738)
+    assert empty_parser.from_key(TK(0x11736))["array_type"] == TK(0x11735)
+    assert empty_parser.from_key(TK(0x11737))["members"][0].type == TK(0x11736)
+    assert empty_parser.from_key(TK(0x11738))["field_list_type"] == TK(0x11737)
 
 
 BIG_ENUM_KEY_SAMPLE = """
@@ -1180,9 +1182,11 @@ BIG_ENUM_KEY_SAMPLE = """
 def test_enum_keys_over_ffff(empty_parser: CvdumpTypesParser):
     """Make sure we can read an LF_ENUM if its field list type key is over 0xffff. (GH #318)"""
     empty_parser.read_all(BIG_ENUM_KEY_SAMPLE)
-    assert empty_parser.keys[TK(0x105DA)]["field_list_type"] == TK(0x105D9)
-    assert empty_parser.keys[TK(0x105DA)]["underlying_type"] == CVInfoTypeEnum.T_INT4
-    assert empty_parser.keys[TK(0x105DA)]["name"] == "e_STATE_t"
+    assert empty_parser.from_key(TK(0x105DA))["field_list_type"] == TK(0x105D9)
+    assert (
+        empty_parser.from_key(TK(0x105DA))["underlying_type"] == CVInfoTypeEnum.T_INT4
+    )
+    assert empty_parser.from_key(TK(0x105DA))["name"] == "e_STATE_t"
 
 
 ENUM_WITH_DATA_TYPES_SAMPLES = """
@@ -1203,7 +1207,7 @@ ENUM_WITH_DATA_TYPES_SAMPLES = """
 def test_enum_with_data_types(empty_parser: CvdumpTypesParser):
     """Make sure we can read an LF_FIELDLIST of an enum with a negative value (GH #380)"""
     empty_parser.read_all(ENUM_WITH_DATA_TYPES_SAMPLES)
-    assert empty_parser.keys[TK(0x4E63)]["variants"] == [
+    assert empty_parser.from_key(TK(0x4E63))["variants"] == [
         EnumItem(name="c_act1", value=1),
         EnumItem(name="c_imain", value=2),
         EnumItem(name="c_ielev", value=16),
@@ -1212,7 +1216,7 @@ def test_enum_with_data_types(empty_parser: CvdumpTypesParser):
         EnumItem(name="c_act3", value=65536),
     ]
 
-    assert empty_parser.keys[TK(0x5695)]["variants"] == [
+    assert empty_parser.from_key(TK(0x5695))["variants"] == [
         EnumItem(name="c_unknownminusone", value=-1),
         EnumItem(name="c_unknown8", value=8),
     ]
@@ -1255,9 +1259,9 @@ ARRAY_OF_STRUCT_BITFIELDS = """
 def test_bitfields(empty_parser: CvdumpTypesParser):
     """Make sure we can read a LF_BITFIELD present in LF_FIELDLIST"""
     empty_parser.read_all(ARRAY_OF_STRUCT_BITFIELDS)
-    assert empty_parser.keys[TK(0x1002)]["bit_start"] == 0
-    assert empty_parser.keys[TK(0x1002)]["bit_count"] == 1
-    assert empty_parser.keys[TK(0x1002)]["bit_type"] == CVInfoTypeEnum.T_UCHAR
-    assert empty_parser.keys[TK(0x1003)]["bit_start"] == 6
-    assert empty_parser.keys[TK(0x1003)]["bit_count"] == 3
-    assert empty_parser.keys[TK(0x1003)]["bit_type"] == CVInfoTypeEnum.T_UINT4
+    assert empty_parser.from_key(TK(0x1002))["bit_start"] == 0
+    assert empty_parser.from_key(TK(0x1002))["bit_count"] == 1
+    assert empty_parser.from_key(TK(0x1002))["bit_type"] == CVInfoTypeEnum.T_UCHAR
+    assert empty_parser.from_key(TK(0x1003))["bit_start"] == 6
+    assert empty_parser.from_key(TK(0x1003))["bit_count"] == 3
+    assert empty_parser.from_key(TK(0x1003))["bit_type"] == CVInfoTypeEnum.T_UINT4


### PR DESCRIPTION
Defer regex parsing of each leaf in the `TYPES` section until we need it. If you're not using `datacmp` or importing to Ghidra, it turns out you can skip almost everything.

This hides the raw data in `types._keys` behind the `from_key()` function. Many of the tests need to set `_keys` values directly, so we'll have to live with the `pylint:disable=protected-access` escape hatch for now.

This squeezed out another 400-500ms for `LEGO1` on my Windows box, although this is surely less pronounced on a machine from this decade.

The `SYMBOLS` and `LINES` sections are now the slowest in the profiler. We could apply the same principle to `SYMBOLS` and see what happens. For `LINES`, we actually do need everything up front, so this is where we'll benefit most from parsing the PDB directly, either with Python or a native module.