### PR TITLE
Use `int` as address for in-memory report

### DIFF
--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -7,6 +7,13 @@ from reccmp.types import EntityType
 from .diff import CombinedDiffOutput, DiffReport, RawDiffOutput, raw_diff_to_udiff
 
 
+def format_address(addr: int) -> str:
+    """This is here just to document each spot where we
+    convert an int address into a string.
+    In the future, the format may be customizable. (GH #370)"""
+    return f"{addr:#x}"
+
+
 class ReccmpReportDeserializeError(Exception):
     """The given file is not a serialized reccmp report file"""
 
@@ -18,18 +25,22 @@ class ReccmpReportSameSourceError(Exception):
 @dataclass
 class ReccmpComparedEntity:
     # pylint:disable=too-many-instance-attributes
-    orig_addr: str
+    orig_addr: int
     name: str
     accuracy: float
     # Version 1 files have no type, so it is optional.
     type: EntityType | None = None
-    recomp_addr: str | None = None
+    recomp_addr: int | None = None
     is_effective_match: bool = False
     is_stub: bool = False
     rdiff: RawDiffOutput | None = None
 
     # Legacy field for importing version 1 files (aggregate).
     udiff: CombinedDiffOutput | None = None
+
+    recomp_addr_various: bool = False
+    """True if this entity had no fixed recomp address across the
+    samples combined by reccmp-aggregate."""
 
     @property
     def effective_accuracy(self) -> float:
@@ -46,7 +57,7 @@ class ReccmpStatusReport:
     timestamp: datetime
 
     # Using orig addr as the key.
-    entities: dict[str, ReccmpComparedEntity]
+    entities: dict[int, ReccmpComparedEntity]
 
     # Only set during deserialize.
     from_version: int | None
@@ -67,15 +78,12 @@ class ReccmpStatusReport:
         self.entities = {}
 
     def add_match(self, match: DiffReport):
-        orig_addr = f"0x{match.orig_addr:x}"
-        recomp_addr = f"0x{match.recomp_addr:x}"
-
-        self.entities[orig_addr] = ReccmpComparedEntity(
-            orig_addr=orig_addr,
+        self.entities[match.orig_addr] = ReccmpComparedEntity(
+            orig_addr=match.orig_addr,
             name=match.name,
             type=match.match_type,
             accuracy=match.ratio,
-            recomp_addr=recomp_addr,
+            recomp_addr=match.recomp_addr,
             is_effective_match=match.is_effective_match,
             is_stub=match.is_stub,
             rdiff=match.result.diff,
@@ -135,7 +143,7 @@ def report_progress_stats(report: ReccmpStatusReport) -> tuple[int, float]:
 
 
 def _get_entity_for_addr(
-    samples: Iterable[ReccmpStatusReport], addr: str
+    samples: Iterable[ReccmpStatusReport], addr: int
 ) -> Iterator[ReccmpComparedEntity]:
     """Helper to return entities from xreports that have the given address."""
     for sample in samples:
@@ -189,7 +197,8 @@ def combine_reports(samples: list[ReccmpStatusReport]) -> ReccmpStatusReport:
         # Keep the recomp_addr if it is the same across all samples.
         # i.e. to detect where function alignment ends
         if not all(e_list[0].recomp_addr == e.recomp_addr for e in e_list):
-            output.entities[addr].recomp_addr = "various"
+            output.entities[addr].recomp_addr = None
+            output.entities[addr].recomp_addr_various = True
 
     return output
 
@@ -249,16 +258,26 @@ class JSONReportVersion1(BaseModel):
     data: list[JSONEntityVersion1]
 
 
+MAGIC_STRING_VARIOUS = "various"
+"""reccmp-aggregate uses this to indicate an entity whose recomp addr varied between the sample reports."""
+
+
 def _serialize_version_1(
     report: ReccmpStatusReport, diff_included: bool = False
 ) -> JSONReportVersion1:
     """The JSON report can exclude the diff to make deserialization faster."""
     entities = [
         JSONEntityVersion1(
-            address=addr,  # prefer dict key over redundant value in entity
+            address=format_address(
+                addr
+            ),  # prefer dict key over redundant value in entity
             name=e.name,
             matching=e.accuracy,
-            recomp=e.recomp_addr,
+            recomp=(
+                format_address(e.recomp_addr)
+                if e.recomp_addr is not None
+                else (MAGIC_STRING_VARIOUS if e.recomp_addr_various else "")
+            ),
             stub=e.is_stub,
             effective=e.is_effective_match,
             diff=get_udiff_for_entity(e) if diff_included else None,
@@ -288,15 +307,25 @@ def _deserialize_version_1(obj: JSONReportVersion1) -> ReccmpStatusReport:
         except ValueError:
             entity_type = None
 
-        report.entities[e.address] = ReccmpComparedEntity(
-            orig_addr=e.address,
+        orig_addr = int(e.address, 16)
+
+        if e.recomp == MAGIC_STRING_VARIOUS:
+            recomp_addr = None
+            various = True
+        else:
+            recomp_addr = int(e.recomp, 16) if e.recomp is not None else None
+            various = False
+
+        report.entities[orig_addr] = ReccmpComparedEntity(
+            orig_addr=orig_addr,
             name=e.name,
             accuracy=e.matching,
             type=entity_type,
-            recomp_addr=e.recomp,
+            recomp_addr=recomp_addr,
             is_stub=e.stub,
             is_effective_match=e.effective,
             udiff=e.diff,
+            recomp_addr_various=various,
         )
 
     return report
@@ -306,7 +335,7 @@ def deserialize_reccmp_report(json_str: str) -> ReccmpStatusReport:
     try:
         obj = JSONReportVersion1.model_validate(from_json(json_str))
         return _deserialize_version_1(obj)
-    except ValidationError as ex:
+    except (ValidationError, ValueError) as ex:
         raise ReccmpReportDeserializeError from ex
 
 

--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -266,11 +266,14 @@ def _serialize_version_1(
     report: ReccmpStatusReport, diff_included: bool = False
 ) -> JSONReportVersion1:
     """The JSON report can exclude the diff to make deserialization faster."""
-    entities = [
-        JSONEntityVersion1(
-            address=format_address(
-                addr
-            ),  # prefer dict key over redundant value in entity
+    entities = []
+
+    for addr, e in report.entities.items():
+        # The dict key and the entity's `orig_addr` property should never differ.
+        assert addr == e.orig_addr
+
+        report_ent = JSONEntityVersion1(
+            address=format_address(addr),
             name=e.name,
             matching=e.accuracy,
             recomp=(
@@ -283,8 +286,8 @@ def _serialize_version_1(
             diff=get_udiff_for_entity(e) if diff_included else None,
             type=int(e.type) if e.type is not None else None,
         )
-        for addr, e in report.entities.items()
-    ]
+
+        entities.append(report_ent)
 
     return JSONReportVersion1(
         file=report.filename,

--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -31,6 +31,10 @@ class ReccmpComparedEntity:
     # Version 1 files have no type, so it is optional.
     type: EntityType | None = None
     recomp_addr: int | None = None
+    """The meaning of `None` depends on `recomp_addr_varies`:
+    recomp_addr_varies is False: This entity is unmatched.
+    recomp_addr_varies is True:  This entity has no fixed recomp addr."""
+
     is_effective_match: bool = False
     is_stub: bool = False
     rdiff: RawDiffOutput | None = None
@@ -38,7 +42,7 @@ class ReccmpComparedEntity:
     # Legacy field for importing version 1 files (aggregate).
     udiff: CombinedDiffOutput | None = None
 
-    recomp_addr_various: bool = False
+    recomp_addr_varies: bool = False
     """True if this entity had no fixed recomp address across the
     samples combined by reccmp-aggregate."""
 
@@ -198,7 +202,7 @@ def combine_reports(samples: list[ReccmpStatusReport]) -> ReccmpStatusReport:
         # i.e. to detect where function alignment ends
         if not all(e_list[0].recomp_addr == e.recomp_addr for e in e_list):
             output.entities[addr].recomp_addr = None
-            output.entities[addr].recomp_addr_various = True
+            output.entities[addr].recomp_addr_varies = True
 
     return output
 
@@ -279,7 +283,7 @@ def _serialize_version_1(
             recomp=(
                 format_address(e.recomp_addr)
                 if e.recomp_addr is not None
-                else (MAGIC_STRING_VARIOUS if e.recomp_addr_various else "")
+                else (MAGIC_STRING_VARIOUS if e.recomp_addr_varies else "")
             ),
             stub=e.is_stub,
             effective=e.is_effective_match,
@@ -328,7 +332,7 @@ def _deserialize_version_1(obj: JSONReportVersion1) -> ReccmpStatusReport:
             is_stub=e.stub,
             is_effective_match=e.effective,
             udiff=e.diff,
-            recomp_addr_various=various,
+            recomp_addr_varies=various,
         )
 
     return report

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -27,6 +27,7 @@ from reccmp.compare.report import (
     serialize_reccmp_report,
     report_function_alignment,
     report_function_accuracy,
+    format_address,
 )
 from reccmp.types import EntityType
 from reccmp.project.logging import (
@@ -54,9 +55,11 @@ def print_match_verbose(match: DiffReport, show_both_addrs: bool = False):
     percenttext = percent_string(match.effective_ratio, match.is_effective_match)
 
     if show_both_addrs:
-        addrs = f"0x{match.orig_addr:x} / 0x{match.recomp_addr:x}"
+        addrs = (
+            f"{format_address(match.orig_addr)} / {format_address(match.recomp_addr)}"
+        )
     else:
-        addrs = hex(match.orig_addr)
+        addrs = format_address(match.orig_addr)
 
     grouped_diff = match.match_type != EntityType.VTABLE
     udiff = raw_diff_to_udiff(match.result.diff, grouped=grouped_diff)
@@ -83,10 +86,12 @@ def print_match_verbose(match: DiffReport, show_both_addrs: bool = False):
 def print_match_oneline(match: ReccmpComparedEntity, show_both_addrs: bool = False):
     percenttext = percent_string(match.effective_accuracy, match.is_effective_match)
 
-    if show_both_addrs:
-        addrs = f"{match.orig_addr} / {match.recomp_addr}"
+    if show_both_addrs and match.recomp_addr is not None:
+        addrs = (
+            f"{format_address(match.orig_addr)} / {format_address(match.recomp_addr)}"
+        )
     else:
-        addrs = match.orig_addr
+        addrs = format_address(match.orig_addr)
 
     if match.is_stub:
         print(f"  {match.name} ({addrs}) is a stub.")

--- a/reccmp/tools/vtable.py
+++ b/reccmp/tools/vtable.py
@@ -16,6 +16,7 @@ from reccmp.project.detect import (
     RecCmpProjectException,
 )
 from reccmp.compare.diff import CombinedDiffOutput, raw_diff_to_udiff
+from reccmp.compare.report import format_address
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ def main():
 
             print(
                 tbl_match.name,
-                f": orig 0x{tbl_match.orig_addr:x}, recomp 0x{tbl_match.recomp_addr:x}",
+                f": orig {format_address(tbl_match.orig_addr)}, recomp {format_address(tbl_match.recomp_addr)}",
             )
             show_vtable_diff(udiff, args.verbose)
             print()
@@ -101,7 +102,7 @@ def main():
         if diff.ratio < 1.0:
             problem_count += 1
             print(
-                f"Problem with adjuster thunk {fun_match.name} (0x{fun_match.orig_addr:x} / 0x{fun_match.recomp_addr:x})"
+                f"Problem with adjuster thunk {fun_match.name} ({format_address(fun_match.orig_addr)} / {format_address(fun_match.recomp_addr)})"
             )
 
     return 1 if problem_count > 0 else 0

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -2,7 +2,7 @@ import base64
 import enum
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Callable, Iterable, Iterator
 import logging
 from pystache import Renderer  # type: ignore[import-untyped]
 from reccmp.assets import get_asset_file
@@ -11,6 +11,7 @@ from reccmp.compare.report import (
     ReccmpStatusReport,
     ReccmpComparedEntity,
     serialize_reccmp_report,
+    format_address,
 )
 
 
@@ -259,17 +260,21 @@ def percent_string(
     )
 
 
-def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
+def diff_json_display(
+    show_both_addrs: bool = False, is_plain: bool = False
+) -> Callable[[int, ReccmpComparedEntity | None, ReccmpComparedEntity | None], str]:
     """Generate a function that will display the diff according to
     the reccmp display preferences."""
 
     def formatter(
-        orig_addr, saved: ReccmpComparedEntity, new: ReccmpComparedEntity
+        orig_addr: int,
+        saved: ReccmpComparedEntity | None,
+        new: ReccmpComparedEntity | None,
     ) -> str:
         old_pct = "new"
         new_pct = "gone"
         name = ""
-        recomp_addr = "n/a"
+        recomp_addr_str = "n/a"
 
         if new is not None:
             new_pct = (
@@ -284,7 +289,10 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
             # We are using the original address as the key.
             # A function being renamed is not of interest here.
             name = new.name
-            recomp_addr = new.recomp_addr or "n/a"
+            if new.recomp_addr is None:
+                recomp_addr_str = "various" if new.recomp_addr_various else "n/a"
+            else:
+                recomp_addr_str = format_address(new.recomp_addr)
 
         if saved is not None:
             old_pct = (
@@ -298,10 +306,12 @@ def diff_json_display(show_both_addrs: bool = False, is_plain: bool = False):
             if name == "":
                 name = saved.name
 
+        orig_addr_str = format_address(orig_addr)
+
         if show_both_addrs:
-            addr_string = f"{orig_addr} / {recomp_addr:10}"
+            addr_string = f"{orig_addr_str} / {recomp_addr_str:10}"
         else:
-            addr_string = orig_addr
+            addr_string = orig_addr_str
 
         # The ANSI codes from colorama counted towards string length,
         # so displaying this as an ascii-like spreadsheet

--- a/reccmp/utils.py
+++ b/reccmp/utils.py
@@ -290,7 +290,7 @@ def diff_json_display(
             # A function being renamed is not of interest here.
             name = new.name
             if new.recomp_addr is None:
-                recomp_addr_str = "various" if new.recomp_addr_various else "n/a"
+                recomp_addr_str = "various" if new.recomp_addr_varies else "n/a"
             else:
                 recomp_addr_str = format_address(new.recomp_addr)
 

--- a/tests/test_asmcmp_utils.py
+++ b/tests/test_asmcmp_utils.py
@@ -8,7 +8,7 @@ def entity(
     """Helper to create entities with dummy values for required fields: address, name.
     The only relevant fields are: accuracy, is_stub, is_effective_match"""
     return ReccmpComparedEntity(
-        orig_addr="0x400000",
+        orig_addr=0x400000,
         name="Test",
         accuracy=accuracy,
         is_stub=is_stub,

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -153,17 +153,15 @@ def test_compare_function():
     report = to_report(compare)
     assert len(report.entities) == 1
 
-    e = report.entities["0x0"]
+    e = report.entities[0]
     assert e is not None
     assert e.accuracy == 1.0
     assert e.is_stub is False
 
     # The type round-trips through serialization as the EntityType enum.
     assert e.type == EntityType.FUNCTION
-
-    # String representation of address. No padding.
-    assert e.orig_addr == "0x0"
-    assert e.recomp_addr == "0x0"
+    assert e.orig_addr == 0
+    assert e.recomp_addr == 0
 
     # No diff generated for a match
     udiff = get_udiff(e)
@@ -188,7 +186,7 @@ def test_compare_function_stub():
     report = to_report(compare)
     assert len(report.entities) == 1
 
-    e = report.entities["0x0"]
+    e = report.entities[0]
     assert e is not None
     assert e.accuracy == 0.0
     assert e.is_stub is True
@@ -218,7 +216,7 @@ def test_compare_function_diff():
     report = to_report(compare)
     assert len(report.entities) == 1
 
-    e = report.entities["0x0"]
+    e = report.entities[0]
     assert e is not None
     assert e.accuracy == 0.0
     assert e.is_effective_match is False
@@ -248,7 +246,7 @@ def test_compare_function_effective_match():
     report = to_report(compare)
     assert len(report.entities) == 1
 
-    e = report.entities["0x0"]
+    e = report.entities[0]
     assert e is not None
     # Should retain non-effective accuracy.
     assert e.accuracy != 1.0
@@ -300,7 +298,7 @@ def test_compare_function_diff_context():
     report = to_report(compare)
     assert len(report.entities) == 1
 
-    e = report.entities["0x0"]
+    e = report.entities[0]
     assert e is not None
     assert e.accuracy != 1.0
     assert e.is_effective_match is False
@@ -351,7 +349,7 @@ def test_compare_vtable_match():
     report = to_report(compare)
     assert len(report.entities) == 2
 
-    e = report.entities["0x1"]
+    e = report.entities[1]
     assert e is not None
     assert e.accuracy == 1.0
 
@@ -408,7 +406,7 @@ def test_compare_vtable_diff():
     report = to_report(compare)
     assert len(report.entities) == 4
 
-    e = report.entities["0xc"]
+    e = report.entities[12]
     assert e is not None
     assert e.accuracy != 1.0
 
@@ -440,7 +438,7 @@ def test_aggregate_workflow():
 
     report = to_report(compare)
     assert len(report.entities) == 1
-    entity = report.entities["0x0"]
+    entity = report.entities[0]
 
     # The function matches, it has no diff data.
     assert entity.udiff is None
@@ -454,12 +452,12 @@ def test_aggregate_workflow():
 def test_report_function_alignment():
     def test_entity(
         orig_addr: int, recomp_addr: int, entity_type: EntityType
-    ) -> tuple[str, ReccmpComparedEntity]:
+    ) -> tuple[int, ReccmpComparedEntity]:
         return (
-            hex(orig_addr),
+            orig_addr,
             ReccmpComparedEntity(
-                orig_addr=hex(orig_addr),
-                recomp_addr=hex(recomp_addr),
+                orig_addr=orig_addr,
+                recomp_addr=recomp_addr,
                 name="hello",
                 accuracy=1.0,
                 type=entity_type,
@@ -502,12 +500,12 @@ def test_report_function_accuracy():
         *,
         effective: bool = False,
         stub: bool = False,
-    ) -> tuple[str, ReccmpComparedEntity]:
+    ) -> tuple[int, ReccmpComparedEntity]:
         return (
-            hex(addr),
+            addr,
             ReccmpComparedEntity(
-                orig_addr=hex(addr),
-                recomp_addr=hex(addr),
+                orig_addr=addr,
+                recomp_addr=addr,
                 name="hello",
                 accuracy=accuracy,
                 type=entity_type,

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -10,7 +10,7 @@ from reccmp.compare.report import (
 
 
 def create_report(
-    entities: list[tuple[str, float]] | None = None,
+    entities: list[tuple[int, float]] | None = None,
 ) -> ReccmpStatusReport:
     """Helper to quickly set up a report to be customized further for each test."""
     report = ReccmpStatusReport(filename="test.exe")
@@ -24,7 +24,7 @@ def create_report(
 def test_aggregate_identity():
     """Combine a list of one report. Should get the same report back,
     except for expected differences like the timestamp."""
-    report = create_report([("100", 1.0), ("200", 0.5)])
+    report = create_report([(100, 1.0), (200, 0.5)])
     combined = combine_reports([report])
 
     for (a_key, a_entity), (b_key, b_entity) in zip(
@@ -37,72 +37,72 @@ def test_aggregate_identity():
 
 def test_aggregate_simple():
     """Should choose the best score from the sample reports."""
-    x = create_report([("100", 0.8), ("200", 0.2)])
-    y = create_report([("100", 0.2), ("200", 0.8)])
+    x = create_report([(100, 0.8), (200, 0.2)])
+    y = create_report([(100, 0.2), (200, 0.8)])
 
     combined = combine_reports([x, y])
-    assert combined.entities["100"].accuracy == 0.8
-    assert combined.entities["200"].accuracy == 0.8
+    assert combined.entities[100].accuracy == 0.8
+    assert combined.entities[200].accuracy == 0.8
 
 
 def test_aggregate_union_all_addrs():
     """Should combine all addresses from any report."""
-    x = create_report([("100", 0.8)])
-    y = create_report([("200", 0.8)])
+    x = create_report([(100, 0.8)])
+    y = create_report([(200, 0.8)])
 
     combined = combine_reports([x, y])
-    assert "100" in combined.entities
-    assert "200" in combined.entities
+    assert 100 in combined.entities
+    assert 200 in combined.entities
 
 
 def test_aggregate_stubs():
     """Stub functions (i.e. do not compare asm) are considered to have 0 percent accuracy."""
-    x = create_report([("100", 0.9)])
-    y = create_report([("100", 0.5)])
+    x = create_report([(100, 0.9)])
+    y = create_report([(100, 0.5)])
 
     # In a real report, accuracy would be zero for a stub.
-    x.entities["100"].is_stub = True
-    y.entities["100"].is_stub = False
+    x.entities[100].is_stub = True
+    y.entities[100].is_stub = False
 
     combined = combine_reports([x, y])
-    assert combined.entities["100"].is_stub is False
+    assert combined.entities[100].is_stub is False
 
     # Choose the lower non-stub value
-    assert combined.entities["100"].accuracy == 0.5
+    assert combined.entities[100].accuracy == 0.5
 
 
 def test_aggregate_all_stubs():
     """If all samples are stubs, preserve that setting."""
-    x = create_report([("100", 1.0)])
+    x = create_report([(100, 1.0)])
 
-    x.entities["100"].is_stub = True
+    x.entities[100].is_stub = True
 
     combined = combine_reports([x, x])
-    assert combined.entities["100"].is_stub is True
+    assert combined.entities[100].is_stub is True
 
 
 def test_aggregate_100_over_effective():
     """Prefer 100% match over effective."""
-    x = create_report([("100", 0.9)])
-    y = create_report([("100", 1.0)])
-    x.entities["100"].is_effective_match = True
+    x = create_report([(100, 0.9)])
+    y = create_report([(100, 1.0)])
+    x.entities[100].is_effective_match = True
 
     combined = combine_reports([x, y])
-    assert combined.entities["100"].is_effective_match is False
+    assert combined.entities[100].is_effective_match is False
 
 
 def test_aggregate_effective_over_any():
     """Prefer effective match over any accuracy."""
-    x = create_report([("100", 0.5)])
-    y = create_report([("100", 0.6)])
-    x.entities["100"].is_effective_match = True
+    x = create_report([(100, 0.5)])
+    y = create_report([(100, 0.6)])
+    x.entities[100].is_effective_match = True
     # Y has higher accuracy score, but we could not confirm an effective match.
 
     combined = combine_reports([x, y])
-    assert combined.entities["100"].is_effective_match is True
+    assert combined.entities[100].is_effective_match is True
 
     # Should retain original accuracy for effective match.
-    assert combined.entities["100"].accuracy == 0.5
+    assert combined.entities[100].accuracy == 0.5
 
 
 def test_aggregate_different_files():
@@ -144,15 +144,16 @@ def test_aggregate_recomp_addr():
     """We combine the entity data based on the orig addr because this will not change.
     The recomp addr may vary a lot. If it is the same in all samples, use the value.
     Otherwise use a placeholder value."""
-    x = create_report([("100", 0.8), ("200", 0.2)])
-    y = create_report([("100", 0.2), ("200", 0.8)])
+    x = create_report([(100, 0.8), (200, 0.2)])
+    y = create_report([(100, 0.2), (200, 0.8)])
     # These recomp addrs match:
-    x.entities["100"].recomp_addr = "500"
-    y.entities["100"].recomp_addr = "500"
+    x.entities[100].recomp_addr = 500
+    y.entities[100].recomp_addr = 500
     # Y report has no addr for this
-    x.entities["200"].recomp_addr = "600"
+    x.entities[200].recomp_addr = 600
 
     combined = combine_reports([x, y])
-    assert combined.entities["100"].recomp_addr == "500"
-    assert combined.entities["200"].recomp_addr != "600"
-    assert combined.entities["200"].recomp_addr == "various"
+    assert combined.entities[100].recomp_addr == 500
+    assert combined.entities[200].recomp_addr != 600
+    assert combined.entities[200].recomp_addr is None
+    assert combined.entities[200].recomp_addr_various

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -156,4 +156,4 @@ def test_aggregate_recomp_addr():
     assert combined.entities[100].recomp_addr == 500
     assert combined.entities[200].recomp_addr != 600
     assert combined.entities[200].recomp_addr is None
-    assert combined.entities[200].recomp_addr_various
+    assert combined.entities[200].recomp_addr_varies

--- a/tests/test_report_version_1.py
+++ b/tests/test_report_version_1.py
@@ -1,0 +1,278 @@
+"""Tests for serializing and deserializing a version 1 report.
+We added some fields during the format's lifetime, but we expect any file
+to be compatible because missing fields get a default value."""
+
+import json
+from datetime import datetime
+import pytest
+from reccmp.compare.report import (
+    ReccmpStatusReport,
+    ReccmpComparedEntity,
+    ReccmpReportDeserializeError,
+    deserialize_reccmp_report,
+    serialize_reccmp_report,
+)
+from reccmp.compare.diff import CombinedDiffOutput, RawDiffOutput
+from reccmp.types import EntityType
+
+
+def create_json(entities: list[dict] | None = None, **kwargs) -> str:
+    """Helper to create a report in version 1 format serialied to JSON."""
+    obj = {
+        "file": "test.exe",
+        "format": 1,
+        "timestamp": 1234567890.0,
+        "data": entities if entities is not None else [],
+    }
+    obj.update(kwargs)
+    return json.dumps(obj)
+
+
+def create_entity(**kwargs) -> dict:
+    """Helper to set required fields for an entity. Add or overwrite fields using kwargs."""
+    entity = {"address": "0x100", "name": "test", "matching": 1.0}
+    entity.update(kwargs)
+    return entity
+
+
+def sample_rdiff() -> RawDiffOutput:
+    return RawDiffOutput(
+        codes=[("equal", 0, 1, 0, 1)],
+        orig_inst=[("0x0", "xor eax, eax")],
+        recomp_inst=[("0x0", "ret ")],
+    )
+
+
+def sample_udiff() -> CombinedDiffOutput:
+    """Returns unified diff with type for mypy coercion."""
+    return [
+        (
+            "@@ -0x0,1 +0x0,1 @@",
+            [{"orig": [("0x0", "nop ")], "recomp": [("0x0", "ret ")]}],
+        )
+    ]
+
+
+def test_deserialize_empty_report():
+    """Should deserialize a report with no entities."""
+    report = deserialize_reccmp_report(create_json())
+    assert report.filename == "test.exe"
+    assert report.from_version == 1
+    assert not report.entities
+
+
+def test_deserialize_one_entity():
+    """Should deserialize a report with one entity."""
+    report = deserialize_reccmp_report(create_json([create_entity()]))
+    assert 0x100 in report.entities
+
+    # Default values from create_entity()
+    e = report.entities[0x100]
+    assert e.orig_addr == 0x100
+    assert e.name == "test"
+    assert e.accuracy == 1.0
+
+
+def test_deserialize_if_missing_required_fields():
+    """Throw if any entity is missing these required fields: address, name, matching."""
+    for field in ("address", "name", "matching"):
+        entity = create_entity()
+        del entity[field]
+        with pytest.raises(ReccmpReportDeserializeError):
+            deserialize_reccmp_report(create_json([entity]))
+
+
+def test_deserialize_defaults_for_optional_fields():
+    """Set a default value if any of these "optional" fields are not set."""
+    report = deserialize_reccmp_report(create_json([create_entity()]))
+    e = report.entities[0x100]
+
+    assert e.type is None
+    assert e.recomp_addr is None
+    assert e.is_stub is False
+    assert e.is_effective_match is False
+    assert e.udiff is None
+    assert e.recomp_addr_various is False
+
+    # Cannot be set from a version 1 report.
+    assert e.rdiff is None
+
+
+@pytest.mark.xfail(reason="TODO")
+def test_deserialize_explicit_null_fields():
+    """Can use implicit or explicit null for optional fields."""
+    for field in ("recomp", "stub", "effective", "diff", "type"):
+        entity = create_entity()
+        entity[field] = None
+        report = deserialize_reccmp_report(create_json([entity]))
+        e = report.entities[0x100]
+
+        assert e.type is None
+        assert e.recomp_addr is None
+        assert e.is_stub is False
+        assert e.is_effective_match is False
+        assert e.udiff is None
+
+
+def test_deserialize_valid_type():
+    """Deserialize entity type using the integer value from the EntityType enum."""
+    entity = create_entity(type=int(EntityType.VTABLE))
+    report = deserialize_reccmp_report(create_json([entity]))
+    assert report.entities[0x100].type == EntityType.VTABLE
+
+
+def test_deserialize_invalid_type():
+    """If the type number for an entity is not part of the
+    EntityType enum, set the entity type to None."""
+    report = deserialize_reccmp_report(create_json([create_entity(type=999)]))
+    assert report.entities[0x100].type is None
+
+
+@pytest.mark.parametrize("address", ["", "0x", "hello", "1.5", "0x1zz", "-"])
+def test_deserialize_invalid_address_string(address: str):
+    """Fail the entire report if we cannot deserialize an address."""
+    with pytest.raises(ReccmpReportDeserializeError):
+        deserialize_reccmp_report(create_json([create_entity(address=address)]))
+
+    with pytest.raises(ReccmpReportDeserializeError):
+        deserialize_reccmp_report(create_json([create_entity(recomp=address)]))
+
+
+def test_deserialize_address_must_be_a_string():
+    """Version 1 addresses are hex strings, not numbers."""
+    with pytest.raises(ReccmpReportDeserializeError):
+        deserialize_reccmp_report(create_json([create_entity(address=0x100)]))
+
+    with pytest.raises(ReccmpReportDeserializeError):
+        deserialize_reccmp_report(create_json([create_entity(recomp=0x100)]))
+
+
+def test_deserialize_recomp_addr_various():
+    """For an entity with varying recomp addresses created by `reccmp-aggregate`
+    handle the magic string "various" and set the correct properties."""
+    entity = create_entity(recomp="various")
+    report = deserialize_reccmp_report(create_json([entity]))
+    e = report.entities[0x100]
+
+    assert e.recomp_addr is None
+    assert e.recomp_addr_various is True
+
+
+def test_deserialize_recomp_addr_various_exact():
+    """The magic string must be "various" exactly."""
+    for various_variant in ("various ", "Various", "VARIOUS"):
+        entity = create_entity(recomp=various_variant)
+        with pytest.raises(ReccmpReportDeserializeError):
+            deserialize_reccmp_report(create_json([entity]))
+
+
+def test_serialize_empty():
+    filename = "test.exe"
+    report = ReccmpStatusReport(filename=filename)
+    obj = json.loads(serialize_reccmp_report(report))
+
+    assert obj["file"] == filename
+    assert obj["format"] == 1
+
+    # No entities
+    assert not obj["data"]
+
+    # Just verify that we set some value for the timestamp.
+    assert isinstance(obj["timestamp"], float)
+
+
+def test_serialize_address():
+    """Serialized addresses are lowercase hex with the "0x" prefix and no padding digits."""
+    addr = 0x40A000
+    report = ReccmpStatusReport(filename="test.exe")
+    report.entities[addr] = ReccmpComparedEntity(
+        orig_addr=addr, name="test", accuracy=1.0, recomp_addr=addr
+    )
+
+    obj = json.loads(serialize_reccmp_report(report))
+    [entity] = obj["data"]
+
+    assert entity["address"] == "0x40a000"
+    assert entity["recomp"] == "0x40a000"
+
+
+def test_serialize_address_uses_dict_key():
+    """The dict key is the source of truth for the orig addr.
+    The value on the entity is redundant and is not serialized."""
+    report = ReccmpStatusReport(filename="test.exe")
+    report.entities[0x100] = ReccmpComparedEntity(
+        orig_addr=0x200, name="test", accuracy=1.0, recomp_addr=0x100
+    )
+
+    obj = json.loads(serialize_reccmp_report(report))
+    [entity] = obj["data"]
+    assert entity["address"] == "0x100"
+
+
+def test_serialize_prefer_existing_udiff():
+    """Do not recreate the unified diff if the entity already has one."""
+    report = ReccmpStatusReport(filename="test.exe")
+    report.entities[0x100] = ReccmpComparedEntity(
+        orig_addr=0x100,
+        name="test",
+        accuracy=1.0,
+        recomp_addr=0x100,
+        rdiff=sample_rdiff(),
+        udiff=sample_udiff(),
+    )
+
+    text = serialize_reccmp_report(report, diff_included=True)
+    obj = json.loads(text)
+    [entity] = obj["data"]
+
+    # Crude, but verifies that we are not using the data from sample_rdiff().
+    assert entity["diff"]
+    assert "nop" in str(entity["diff"])
+
+
+def test_serialize_excludes_defaults():
+    """Any fields set to a default value are omitted. This is to save space."""
+    report = ReccmpStatusReport(filename="test.exe")
+    report.entities[0x100] = ReccmpComparedEntity(
+        orig_addr=0x100, name="test", accuracy=1.0, recomp_addr=0x100
+    )
+
+    obj = json.loads(serialize_reccmp_report(report))
+    [entity] = obj["data"]
+
+    assert entity["address"] == "0x100"
+    assert entity["recomp"] == "0x100"
+
+    # The remaining optional fields are not in the JSON.
+    assert "stub" not in entity
+    assert "library" not in entity
+    assert "effective" not in entity
+    assert "diff" not in entity
+    assert "type" not in entity
+
+
+@pytest.mark.xfail(reason="TODO: Serialize changes report timestamp")
+def test_serialize_existing_timestamp():
+    """Serialize the timestamp captured when the report object was created.
+    Do not use a new timestamp when preparing the JSON string."""
+    then = datetime(2000, 1, 1)
+    report = ReccmpStatusReport(filename="test.exe", timestamp=then)
+
+    obj = json.loads(serialize_reccmp_report(report))
+    assert obj["timestamp"] == then.timestamp()
+
+    # Should not change the in-memory report
+    assert report.timestamp == then
+
+
+def test_serialize_recomp_addr_various():
+    """An entity created with `reccmp-aggregate` that does not have
+    a fixed recomp addr should use the magic string `various`."""
+    report = ReccmpStatusReport(filename="test.exe")
+    report.entities[0x100] = ReccmpComparedEntity(
+        orig_addr=0x100, name="test", accuracy=1.0, recomp_addr_various=True
+    )
+
+    obj = json.loads(serialize_reccmp_report(report))
+    [entity] = obj["data"]
+    assert entity["recomp"] == "various"

--- a/tests/test_report_version_1.py
+++ b/tests/test_report_version_1.py
@@ -92,7 +92,7 @@ def test_deserialize_defaults_for_optional_fields():
     assert e.is_stub is False
     assert e.is_effective_match is False
     assert e.udiff is None
-    assert e.recomp_addr_various is False
+    assert e.recomp_addr_varies is False
 
     # Cannot be set from a version 1 report.
     assert e.rdiff is None
@@ -147,7 +147,7 @@ def test_deserialize_address_must_be_a_string():
         deserialize_reccmp_report(create_json([create_entity(recomp=0x100)]))
 
 
-def test_deserialize_recomp_addr_various():
+def test_deserialize_recomp_addr_varies():
     """For an entity with varying recomp addresses created by `reccmp-aggregate`
     handle the magic string "various" and set the correct properties."""
     entity = create_entity(recomp="various")
@@ -155,7 +155,7 @@ def test_deserialize_recomp_addr_various():
     e = report.entities[0x100]
 
     assert e.recomp_addr is None
-    assert e.recomp_addr_various is True
+    assert e.recomp_addr_varies is True
 
 
 def test_deserialize_recomp_addr_various_exact():
@@ -265,12 +265,12 @@ def test_serialize_existing_timestamp():
     assert report.timestamp == then
 
 
-def test_serialize_recomp_addr_various():
+def test_serialize_recomp_addr_varies():
     """An entity created with `reccmp-aggregate` that does not have
     a fixed recomp addr should use the magic string `various`."""
     report = ReccmpStatusReport(filename="test.exe")
     report.entities[0x100] = ReccmpComparedEntity(
-        orig_addr=0x100, name="test", accuracy=1.0, recomp_addr_various=True
+        orig_addr=0x100, name="test", accuracy=1.0, recomp_addr_varies=True
     )
 
     obj = json.loads(serialize_reccmp_report(report))

--- a/tests/test_report_version_1.py
+++ b/tests/test_report_version_1.py
@@ -196,17 +196,17 @@ def test_serialize_address():
     assert entity["recomp"] == "0x40a000"
 
 
-def test_serialize_address_uses_dict_key():
-    """The dict key is the source of truth for the orig addr.
-    The value on the entity is redundant and is not serialized."""
+def test_serialize_address_and_dict_key_out_of_sync():
+    """Fail to serialize if the report's internal structures are out of sync.
+    By nature of using a `dict` for report.entities, the key and the entity's `orig_addr`
+    could disagree, but it should never happen in normal operation."""
     report = ReccmpStatusReport(filename="test.exe")
     report.entities[0x100] = ReccmpComparedEntity(
         orig_addr=0x200, name="test", accuracy=1.0, recomp_addr=0x100
     )
 
-    obj = json.loads(serialize_reccmp_report(report))
-    [entity] = obj["data"]
-    assert entity["address"] == "0x100"
+    with pytest.raises(AssertionError):
+        json.loads(serialize_reccmp_report(report))
 
 
 def test_serialize_prefer_existing_udiff():


### PR DESCRIPTION
JSON and HTML report files expect a hex string for each address. We also use this to print to the terminal.

Instead of converting the `int` address when the in-memory report is created, delay this until we need to write a file or display something. (In the spirit of #307.)

The sticking point is the magic string `"various"` that appears for the recomp addr when the entity is created by `reccmp-aggregate`. We have a new property for this to distinguish between the recomp addr being `None` because this is an unmatched entity or because it is matched but has no fixed recomp address. We don't currently use the report to hold unmatched entities, but I want to do this in a follow-up to fix some gaps with accuracy/progress calculation. (See: #444 and #447.)

We did not have any tests specific to the version 1 report format, so I added some.