### PR TITLE
Drop `DiffReport` struct

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -1,7 +1,7 @@
 import logging
 import difflib
 import struct
-from typing import Iterable, Iterator
+from typing import Callable, Iterator
 from typing_extensions import Self
 from reccmp.project.detect import RecCmpTarget
 from reccmp.compare.diff import EntityCompareResult, RawDiffOutput
@@ -32,8 +32,8 @@ from .match_msvc import (
     match_imports,
 )
 from .db import EntityDb, ReccmpEntity, ReccmpMatch
-from .diff import DiffReport
 from .lines import LinesDb
+from .report import ReccmpComparedEntity, ReccmpStatusReport
 from .analyze import (
     create_imports,
     create_import_thunks,
@@ -341,7 +341,7 @@ class Compare:
             match_ratio=ratio,
         )
 
-    def _compare_match(self, match: ReccmpMatch) -> DiffReport | None:
+    def _compare_match(self, match: ReccmpMatch) -> ReccmpComparedEntity | None:
         """Router for comparison type"""
 
         if match.size is None or match.any_size() == 0:
@@ -370,14 +370,15 @@ class Compare:
         best_name = match.best_name()
         assert best_name is not None
 
-        return DiffReport(
-            match_type=output_type,
+        return ReccmpComparedEntity(
             orig_addr=match.orig_addr,
-            recomp_addr=match.recomp_addr,
             name=best_name,
-            result=result,
-            is_library=match.get("library", False),
+            accuracy=result.match_ratio,
+            type=output_type,
+            recomp_addr=match.recomp_addr,
+            is_effective_match=result.is_effective_match,
             is_stub=match.get("stub", False),
+            rdiff=result.diff,
         )
 
     ## Public API
@@ -402,27 +403,49 @@ class Compare:
     def get_variables(self) -> Iterator[ReccmpMatch]:
         return self._db.get_matches_by_type(EntityType.DATA)
 
-    def compare_address(self, addr: int) -> DiffReport | None:
+    def compare_address(self, addr: int) -> ReccmpComparedEntity | None:
         match = self._db.get_one_match(addr)
         if match is None:
             return None
 
         return self._compare_match(match)
 
-    def compare_all(self) -> Iterable[DiffReport]:
-        for match in self._db.get_matches():
-            diff = self._compare_match(match)
-            if diff is not None:
-                yield diff
+    def compare_all(
+        self, filter_fn: Callable[[ReccmpEntity], bool] | None = None
+    ) -> Iterator[ReccmpComparedEntity]:
+        for ent in self._db.get_matches():
+            if ent.entity_type not in (
+                EntityType.FUNCTION,
+                EntityType.VTORDISP,
+                EntityType.VTABLE,
+            ):
+                continue
 
-    def compare_functions(self) -> Iterable[DiffReport]:
+            if filter_fn and not filter_fn(ent):
+                continue
+
+            match = self._compare_match(ent)
+            if match:
+                yield match
+
+    def compare_functions(self) -> Iterator[ReccmpComparedEntity]:
         for match in self.get_functions():
             diff = self._compare_match(match)
             if diff is not None:
                 yield diff
 
-    def compare_vtables(self) -> Iterable[DiffReport]:
+    def compare_vtables(self) -> Iterator[ReccmpComparedEntity]:
         for match in self.get_vtables():
             diff = self._compare_match(match)
             if diff is not None:
                 yield diff
+
+    def to_report(
+        self, filename: str, filter_fn: Callable[[ReccmpEntity], bool] | None = None
+    ) -> ReccmpStatusReport:
+        """Creates a ReccmpStatusReport using the current reccmp state."""
+        report = ReccmpStatusReport(filename=filename)
+        for match in self.compare_all(filter_fn):
+            report.add_match(match)
+
+        return report

--- a/reccmp/compare/diff.py
+++ b/reccmp/compare/diff.py
@@ -2,7 +2,6 @@ import dataclasses
 from typing import Iterable, Sequence
 from typing_extensions import NotRequired, TypedDict
 from reccmp.difflib import DiffOpcode, get_grouped_opcodes
-from reccmp.types import EntityType
 
 CombinedDiffInput = list[tuple[str, str]]
 
@@ -136,30 +135,3 @@ def raw_diff_to_udiff(
         opcode_groups = [diff.codes]
 
     return combined_diff(opcode_groups, diff.orig_inst, diff.recomp_inst)
-
-
-@dataclasses.dataclass
-class DiffReport:
-    match_type: EntityType
-    orig_addr: int
-    recomp_addr: int
-    name: str
-    result: EntityCompareResult = dataclasses.field(default_factory=EntityCompareResult)
-    is_stub: bool = False
-    is_library: bool = False
-
-    @property
-    def ratio(self) -> float:
-        return self.result.match_ratio
-
-    @property
-    def is_effective_match(self) -> bool:
-        return self.result.is_effective_match
-
-    @property
-    def effective_ratio(self) -> float:
-        return 1.0 if self.is_effective_match else self.ratio
-
-    def __str__(self) -> str:
-        """For debug purposes. Proper diff printing (with coloring) is in another module."""
-        return f"{self.name} (0x{self.orig_addr:x}) {self.ratio*100:.02f}%{'*' if self.is_effective_match else ''}"

--- a/reccmp/compare/report.py
+++ b/reccmp/compare/report.py
@@ -4,7 +4,7 @@ from typing import Literal, Iterable, Iterator
 from pydantic import BaseModel, ValidationError
 from pydantic_core import from_json
 from reccmp.types import EntityType
-from .diff import CombinedDiffOutput, DiffReport, RawDiffOutput, raw_diff_to_udiff
+from .diff import CombinedDiffOutput, RawDiffOutput, raw_diff_to_udiff
 
 
 def format_address(addr: int) -> str:
@@ -81,17 +81,8 @@ class ReccmpStatusReport:
 
         self.entities = {}
 
-    def add_match(self, match: DiffReport):
-        self.entities[match.orig_addr] = ReccmpComparedEntity(
-            orig_addr=match.orig_addr,
-            name=match.name,
-            type=match.match_type,
-            accuracy=match.ratio,
-            recomp_addr=match.recomp_addr,
-            is_effective_match=match.is_effective_match,
-            is_stub=match.is_stub,
-            rdiff=match.result.diff,
-        )
+    def add_match(self, match: ReccmpComparedEntity):
+        self.entities[match.orig_addr] = match
 
     def has_same_source(self, other: "ReccmpStatusReport") -> bool:
         """Were both reports derived from the same reccmp target?"""

--- a/reccmp/tools/asmcmp.py
+++ b/reccmp/tools/asmcmp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 import argparse
@@ -19,7 +18,8 @@ from reccmp.utils import (
 )
 
 from reccmp.compare import Compare
-from reccmp.compare.diff import DiffReport, raw_diff_to_udiff
+from reccmp.compare.db import ReccmpEntity
+from reccmp.compare.diff import raw_diff_to_udiff
 from reccmp.compare.report import (
     ReccmpStatusReport,
     ReccmpComparedEntity,
@@ -51,22 +51,23 @@ def gen_json(json_file: str, json_str: str):
         f.write(json_str)
 
 
-def print_match_verbose(match: DiffReport, show_both_addrs: bool = False):
-    percenttext = percent_string(match.effective_ratio, match.is_effective_match)
+def print_match_verbose(match: ReccmpComparedEntity, show_both_addrs: bool = False):
+    percenttext = percent_string(match.effective_accuracy, match.is_effective_match)
 
-    if show_both_addrs:
+    if show_both_addrs and match.recomp_addr is not None:
         addrs = (
             f"{format_address(match.orig_addr)} / {format_address(match.recomp_addr)}"
         )
     else:
         addrs = format_address(match.orig_addr)
 
-    grouped_diff = match.match_type != EntityType.VTABLE
-    udiff = raw_diff_to_udiff(match.result.diff, grouped=grouped_diff)
+    grouped_diff = match.type != EntityType.VTABLE
+    assert match.rdiff is not None
+    udiff = raw_diff_to_udiff(match.rdiff, grouped=grouped_diff)
 
-    if match.effective_ratio == 1.0:
+    if match.effective_accuracy == 1.0:
         ok_text = reccmp.color.Fore.GREEN + "✨ OK! ✨" + reccmp.color.Style.RESET_ALL
-        if match.ratio == 1.0:
+        if match.accuracy == 1.0:
             print(f"{addrs}: {match.name} 100% match.\n\n{ok_text}\n\n")
         else:
             print_combined_diff(udiff, show_both_addrs)
@@ -183,29 +184,43 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-def dump_all_matched_functions(matches: Sequence[DiffReport]):
+def dump_all_matched_functions(report: ReccmpStatusReport):
     logger.info("Creating assembly dump files.")
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    orig_order = sorted(matches, key=lambda m: m.orig_addr)
-    recomp_order = sorted(matches, key=lambda m: m.recomp_addr)
 
-    with open(f"reccmp-{timestamp}-orig.txt", "w+", encoding="utf-8") as f:
-        for match in orig_order:
-            f.write(f"; {match.name}\n")
-            for addr, line in match.result.diff.orig_inst:
-                if addr:
-                    f.write(f"{addr:10}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
+    # Extract instructions from each compared entity in both address spaces.
+    orig_items = [
+        (entity.orig_addr, entity.name, entity.rdiff.orig_inst)
+        for entity in report.entities.values()
+        if entity.recomp_addr is not None and entity.rdiff is not None
+    ]
 
-    with open(f"reccmp-{timestamp}-recomp.txt", "w+", encoding="utf-8") as f:
-        for match in recomp_order:
-            f.write(f"; {match.name}\n")
-            for addr, line in match.result.diff.recomp_inst:
-                if addr:
-                    f.write(f"{addr:10}: {line}\n")
-                else:
-                    f.write(f"        : {line}\n")
+    # mypy: recomp_addr can be None, but not for the matched entities we are reviewing.
+    recomp_items = [
+        (entity.recomp_addr, entity.name, entity.rdiff.recomp_inst)
+        for entity in report.entities.values()
+        if entity.recomp_addr is not None and entity.rdiff is not None
+    ]
+
+    # Sort by each binary's address order
+    orig_items.sort(key=lambda v: v[0])
+    recomp_items.sort(key=lambda v: v[0])
+
+    orig_filename = f"reccmp-{timestamp}-orig.txt"
+    recomp_filename = f"reccmp-{timestamp}-recomp.txt"
+
+    for filename, vitals in (
+        (orig_filename, orig_items),
+        (recomp_filename, recomp_items),
+    ):
+        with open(filename, "w+", encoding="utf-8") as f:
+            for _, name, instructions in vitals:
+                f.write(f"; {name}\n")
+                for addr, line in instructions:
+                    if addr:
+                        f.write(f"{addr:10}: {line}\n")
+                    else:
+                        f.write(f"        : {line}\n")
 
 
 def main() -> int:
@@ -236,26 +251,24 @@ def main() -> int:
 
     ### Compare everything.
 
-    compared = list(compare.compare_all())
+    def entity_filter(entity: ReccmpEntity) -> bool:
+        if (
+            entity.entity_type == EntityType.FUNCTION
+            and entity.name in target.report_config.ignore_functions
+        ):
+            return False
+
+        if args.nolib and entity.get("library"):
+            return False
+
+        return True
+
+    report = compare.to_report(
+        filename=target.original_path.name, filter_fn=entity_filter
+    )
 
     if args.dump:
-        dump_all_matched_functions(compared)
-
-    report = ReccmpStatusReport(filename=target.original_path.name)
-
-    # Build report:
-    for match in compared:
-        # if we are ignoring this function, skip to next one and don't add it to the entities list
-        if (
-            match.match_type == EntityType.FUNCTION
-            and match.name in target.report_config.ignore_functions
-        ):
-            continue
-
-        if args.nolib and match.is_library:
-            continue
-
-        report.add_match(match)
+        dump_all_matched_functions(report)
 
     # Count how many functions have the same virtual address in orig and recomp.
     functions_aligned_count = report_function_alignment(report)

--- a/reccmp/tools/stackcmp.py
+++ b/reccmp/tools/stackcmp.py
@@ -345,11 +345,11 @@ def main() -> int:
         print(f"Failed to find a match at address 0x{args.address:x}")
         return 1
 
-    assert match.result is not None
+    assert match.rdiff is not None
     # Analyze the entire function, including long sections that already match.
     # This comment explains why this is necessary:
     # https://github.com/isledecomp/reccmp/pull/307#issuecomment-3796146436
-    udiff = raw_diff_to_udiff(match.result.diff, grouped=False)
+    udiff = raw_diff_to_udiff(match.rdiff, grouped=False)
 
     function_data = next(
         (y for y in compare.cvdump_analysis.nodes if y.addr == match.recomp_addr),

--- a/reccmp/tools/vtable.py
+++ b/reccmp/tools/vtable.py
@@ -74,10 +74,14 @@ def main():
 
     for tbl_match in engine.compare_vtables():
         vtable_count += 1
-        if tbl_match.ratio < 1:
+        if tbl_match.accuracy < 1:
             problem_count += 1
 
-            udiff = raw_diff_to_udiff(tbl_match.result.diff)
+            assert tbl_match.rdiff is not None
+            udiff = raw_diff_to_udiff(tbl_match.rdiff)
+
+            if tbl_match.recomp_addr is None:
+                continue
 
             print(
                 tbl_match.name,
@@ -99,7 +103,7 @@ def main():
 
         diff = engine.compare_address(fun_match.orig_addr)
         assert diff is not None
-        if diff.ratio < 1.0:
+        if diff.accuracy < 1.0:
             problem_count += 1
             print(
                 f"Problem with adjuster thunk {fun_match.name} ({format_address(fun_match.orig_addr)} / {format_address(fun_match.recomp_addr)})"

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -33,10 +33,7 @@ def to_report(compare: Compare) -> ReccmpStatusReport:
     """Creates a ReccmpStatusReport using the current reccmp state,
     serializes to JSON text, then deserializes back to a new report object.
     The goal is to see the state of the data after serialization."""
-    report = ReccmpStatusReport(filename=compare.target_id)
-    for match in compare.compare_all():
-        report.add_match(match)
-
+    report = compare.to_report(filename=compare.target_id)
     json_text = serialize_reccmp_report(report, diff_included=True)
     return deserialize_reccmp_report(json_text)
 
@@ -101,9 +98,9 @@ def test_matched_entity_no_type():
         batch.set(ImageId.RECOMP, 0, name="test", size=1)
         batch.match(0, 0)
 
-    with pytest.raises(AssertionError):
-        # TODO: We could skip the entity instead of blowing up. GH #252
-        to_report(compare)
+    # Skip the entity instead of blowing up. (GH #252)
+    report = to_report(compare)
+    assert not report.entities
 
 
 def test_matched_function_missing_name():


### PR DESCRIPTION
Whittling down #486 to just the new changes.

This one drops the `DiffReport` struct, a stop on the way from a `ReccmpMatch` (metadata about the program) to a `ReccmpComparedEntity` (the finished product).

#493 introduced the possibility that `ReccmpComparedEntity` objects are unmatched. This is the "new" feature that we will explore in #486, so for now the plumbing only deals with `ReccmpMatch` objects. I added some code to check the `recomp_addr` where this is necessary.

`reccmp-reccmp` allows filtering the report entities in two ways:
- Exclude library functions via `--nolib`
- Exclude functions by name match in `reccmp-project.yml`

This PR moves the filtering inside of `core.py`. (I tried something similar in #447.) The question of whether to filter the finished `ReccmpComparedEntity` objects or the `ReccmpMatch` objects comes down to whether you want the ability to actually _skip_ the expensive comparison option. If we are filtering on `ReccmpComparedEntity`, the asm rendering and diffing has already occurred. This more closely matches the current behavior.