### PR TITLE
Prepare analysis loop for NE

### DIFF
--- a/reccmp/compare/asm/instgen.py
+++ b/reccmp/compare/asm/instgen.py
@@ -25,6 +25,8 @@ The fields are:
     - op_str (all operands, comma-delimited)
 """
 
+switch_displacement_regex = re.compile(r"\w+ ptr (?:cs\:)?\[.+\+ (0x[0-9a-f]+)\]")
+
 displacement_regex = re.compile(r".*\+ (0x[0-9a-f]+)\]")
 
 
@@ -179,8 +181,13 @@ class InstructGen:
             self._insert_confirmed_addr(value, SectionType.CODE)
 
         # If this is jumping into a table of addresses, save the destination
-        elif (match := displacement_regex.match(op_str)) is not None:
+        elif (match := switch_displacement_regex.match(op_str)) is not None:
             value = int(match.group(1), 16)
+
+            if not self.is_32bit:
+                code_seg_mask = self.start & 0xFFFF0000
+                value += code_seg_mask
+
             self._insert_confirmed_addr(value, SectionType.ADDR_TAB)
 
     def analysis(self):
@@ -236,19 +243,36 @@ class InstructGen:
                 self._finish_code_section(instruction_slice)
 
             elif sect_type == SectionType.ADDR_TAB:
-                # Clamp to multiple of 4 (dwords)
-                read_size = ((self.section_end - self.cur_addr) // 4) * 4
-                offsets = range(self.section_start, self.section_start + read_size, 4)
-                dwords = self.blob[
+                pointer_size = 4 if self.is_32bit else 2
+                # Clamp to pointer size to allow for imprecise section cut.
+                read_size = (
+                    (self.section_end - self.cur_addr) // pointer_size
+                ) * pointer_size
+                # 32-bit addresses of each destination in the jump table.
+                table_offsets = range(
+                    self.section_start, self.section_start + read_size, pointer_size
+                )
+                # 16 or 32-bit destinations in the table.
+                code_offsets = self.blob[
                     self.cur_addr - self.start : self.cur_addr - self.start + read_size
                 ]
-                addrs: list[int] = [addr for addr, in struct.iter_unpack("<L", dwords)]
+                addrs: list[int]
+
+                if self.is_32bit:
+                    addrs = [addr for addr, in struct.iter_unpack("<L", code_offsets)]
+                else:
+                    code_seg_mask = self.start & 0xFFFF0000
+                    addrs = [
+                        code_seg_mask + addr
+                        for addr, in struct.iter_unpack("<H", code_offsets)
+                    ]
+
                 for addr in addrs:
                     # Todo: the fact that these are jump table destinations
                     # should factor into the label name.
                     self._insert_confirmed_addr(addr, SectionType.CODE)
 
-                jump_table = list(zip(offsets, addrs))
+                jump_table = list(zip(table_offsets, addrs))
                 # for (t0,t1) in jump_table:
                 #     print(f"{t0:x} : --> {t1:x}")
 

--- a/reccmp/compare/asm/parse.py
+++ b/reccmp/compare/asm/parse.py
@@ -19,6 +19,8 @@ ptr_replace_regex = re.compile(r"(?<=\[)(0x[0-9a-f]+)(?=\])")
 
 displace_replace_regex = re.compile(r"(?<= )(0x[0-9a-f]+)(?=\])")
 
+lcall_replace_regex = re.compile(r"((?:0x)?[0-9a-f]{1,4}, (?:0x)?[0-9a-f]{1,4})")
+
 # For matching an immediate value operand
 immediate_replace_regex = re.compile(r"(?<=, )(0x[0-9a-f]+)")
 
@@ -100,6 +102,11 @@ class ParseAsm:
         self.indirect_replacements[addr] = placeholder
         return placeholder
 
+    def lcall_replace(self, match: re.Match) -> str:
+        seg_str, _, ofs_str = match.group(1).partition(", ")
+        value = (int(seg_str, 16) << 16) + int(ofs_str, 16)
+        return self.replace(value, exact=True)
+
     def hex_replace_always(self, match: re.Match) -> str:
         """If a pointer value was matched, always insert a placeholder"""
         value = int(match.group(1), 16)
@@ -135,6 +142,7 @@ class ParseAsm:
         return self.indirect_replace(value)
 
     def sanitize(self, inst: DisasmLiteTuple) -> tuple[str, str]:
+        # pylint: disable=too-many-return-statements
         # For jumps or calls, if the entire op_str is a hex number, the value
         # is a relative offset.
         # Otherwise (i.e. it looks like `dword ptr [address]`) it is an
@@ -143,6 +151,12 @@ class ParseAsm:
         # automatically resolved relative offsets to an absolute address.
         # We will have to undo this for some of the jumps or they will not match.
         inst_address, inst_size, inst_mnemonic, inst_op_str = inst
+
+        if inst_mnemonic == "lcall" and "," in inst_op_str:
+            return (
+                inst_mnemonic,
+                lcall_replace_regex.sub(self.lcall_replace, inst_op_str),
+            )
 
         if (
             inst_mnemonic in SINGLE_OPERAND_INSTS

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -10,6 +10,7 @@ from reccmp.dir import source_code_search
 from reccmp.compare.functions import FunctionComparator
 from reccmp.formats import (
     Image,
+    NEImage,
     PEImage,
     TextFile,
     detect_image,
@@ -131,9 +132,55 @@ class Compare:
             self.recomp_bin,
             self.report,
             self.types,
+            is_32bit=not isinstance(self.orig_bin, NEImage),
         )
 
+    def run_ne(self):
+        load_markers(
+            self.code_files,
+            self._lines_db,
+            self.orig_bin,
+            self.target_id,
+            self._db,
+            self.bin_encoding,
+            self.project_aliases,
+            self.report,
+        )
+
+        load_data_sources(self._db, self.data_sources)
+
+        # Match using PDB and annotation data
+        match_symbols(self._db, self.report, truncate=True)
+        match_functions(self._db, self.report, truncate=True)
+        match_vtables(self._db, self.report)
+        match_static_variables(self._db, self.report)
+        match_variables(self._db, self.report)
+        match_lines(self._db, self._lines_db, self.report)
+
+        # Detect floats first to eliminate potential overlap with string data
+        for img_id, binfile in (
+            (ImageId.ORIG, self.orig_bin),
+            (ImageId.RECOMP, self.recomp_bin),
+        ):
+            create_imports(self._db, img_id, binfile)
+            create_import_thunks(self._db, img_id, binfile)
+            import_sections(self._db, img_id, binfile)
+
+        match_imports(self._db)
+
+        for img_id in (ImageId.ORIG, ImageId.RECOMP):
+            set_max_size(self._db, img_id)
+
+        match_ref(self._db, self.report)
+        unique_names_for_overloaded_functions(self._db)
+
+        match_strings(self._db, self.report)
+
     def run(self):
+        if isinstance(self.orig_bin, NEImage):
+            self.run_ne()
+            return
+
         if not isinstance(self.orig_bin, PEImage) or not isinstance(
             self.recomp_bin, PEImage
         ):

--- a/reccmp/compare/functions.py
+++ b/reccmp/compare/functions.py
@@ -122,6 +122,14 @@ class FunctionComparator:
             else:
                 orig_size = recomp_size
 
+        if recomp_size is None:
+            assert orig_size is not None
+            recomp_max = match.max_size(ImageId.RECOMP)
+            if recomp_max is not None:
+                recomp_size = min(recomp_max, orig_size)
+            else:
+                recomp_size = orig_size
+
         assert orig_size is not None and recomp_size is not None
 
         orig_raw = self.orig_bin.read(match.orig_addr, orig_size)

--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from reccmp.formats.exceptions import (
     InvalidStringError,
 )
-from reccmp.formats import PEImage, TextFile
+from reccmp.formats import Image, PEImage, TextFile
 from reccmp.cvdump import CvdumpTypesParser, CvdumpAnalysis
 from reccmp.parser import DecompCodebase
 from reccmp.parser.marker import ProjectAliases
@@ -147,7 +147,7 @@ def load_cvdump_lines(
 def load_markers(
     code_files: Sequence[TextFile],
     lines_db: LinesDb,
-    orig_bin: PEImage,
+    orig_bin: Image,
     target_id: str,
     db: EntityDb,
     encoding: str = "latin1",

--- a/reccmp/formats/image.py
+++ b/reccmp/formats/image.py
@@ -114,6 +114,9 @@ class Image:
         except InvalidVirtualAddressError:
             return False
 
+    def get_abs_addr(self, section: int, offset: int) -> int:
+        raise NotImplementedError
+
     def get_relative_addr(self, addr: int) -> tuple[int, int]:
         raise NotImplementedError
 

--- a/reccmp/formats/ne.py
+++ b/reccmp/formats/ne.py
@@ -352,6 +352,9 @@ class NEImage(Image):
             section_relocations=section_relocations,
         )
 
+    def is_relocated_addr(self, _: int) -> bool:
+        return False
+
     def get_module_name(self, index: int) -> str:
         modules_raw = self.view[
             self.mz_header.e_lfanew

--- a/tests/test_sanitize32.py
+++ b/tests/test_sanitize32.py
@@ -481,3 +481,85 @@ def test_16bit_mode():
         (0x1000, "call <OFFSET1>"),
         (0x1003, "shl bx, 1"),
     ]
+
+
+def test_16bit_calls():
+    """Should sanitize near and far calls."""
+    code = (
+        # call 0x20
+        b"\xe8\x1d\x00"
+        # lcall 0x1000, 0x10
+        b"\x9a\x10\x00\x00\x10"
+    )
+
+    start = 0x10000000
+    p = ParseAsm(is_32bit=False)
+    # Placeholders used for both.
+    assert p.parse_asm(code, start) == [
+        (start, "call <OFFSET1>"),
+        (start + 3, "lcall <OFFSET2>"),
+    ]
+
+    # Demonstrate address replacement.
+    def name_lookup(addr: int, *_, **__) -> str | None:
+        return {0x10000010: "Test", 0x10000020: "Hello"}.get(addr)
+
+    p = ParseAsm(name_lookup=name_lookup, is_32bit=False)
+    # Near call uses code seg to get full address.
+    # It also adds the instruction size to the raw value, similar to jumps.
+    # Capstone makes these adjustments automatically.
+    assert p.parse_asm(code, start) == [
+        (start, "call Hello"),
+        (start + 3, "lcall Test"),
+    ]
+
+
+def test_16bit_jump_table():
+    """Build the address of the jump table displacement by masking out
+    the current code seg and combining it with the offset."""
+    code = (
+        # jmp word ptr cs:[bx + 0x1010]
+        b"\x2e\xff\xa7\x10\x10" +
+        # nop padding to 16 bytes
+        (b"\x90" * 11) +
+        # jump table
+        b"\x20\x10"
+        b"\x30\x10"
+    )
+
+    start = 0x10001000
+    p = ParseAsm(is_32bit=False)
+    asm = p.parse_asm(code, start)
+
+    assert asm[0] == (start, "jmp word ptr cs:[bx + 0x1010]")
+    # Sanitized offsets are relative to the function start.
+    assert asm[-3:] == [
+        (None, "Jump table:"),
+        (start + 0x10, "start + 0x20"),
+        (start + 0x12, "start + 0x30"),
+    ]
+
+
+def test_32bit_jump_table():
+    """32-bit jump tables use absolute 32-bit addresses."""
+    code = (
+        # jmp dword ptr [eax*4 + 0x10000010]
+        b"\xff\x24\x85\x10\x00\x00\x10" +
+        # nop padding to 16 bytes
+        (b"\x90" * 9) +
+        # jump table
+        b"\x20\x00\x00\x10"
+        b"\x30\x00\x00\x10"
+    )
+
+    start = 0x10000000
+    p = ParseAsm(is_32bit=True)
+    asm = p.parse_asm(code, start)
+
+    assert asm[0] == (start, "jmp dword ptr [eax*4 + 0x10000010]")
+    # Sanitized offsets are relative to the function start.
+    assert asm[-3:] == [
+        (None, "Jump table:"),
+        (start + 0x10, "start + 0x20"),
+        (start + 0x14, "start + 0x30"),
+    ]


### PR DESCRIPTION
This is everything I needed to run `reccmp` on an NE image _except_ actually loading any data from the recomp. In [the decomp](https://github.com/disinvite/jman-decomp/) I'm working on, I added parsing for MSVC 1.5 format .map files because the PDBs only have type information and we can't read them with cvdump anyway. Adding .map support requires changes to the yml so it should be its own item.

What's in here:
- We have always assumed that an entity will have its recomp size set by the PDB. Until recently (#363) we did not use the orig size for anything. In my NE project, I _only_ had orig size (set via csv) so make sure we can still disassemble the function using that size only.
- `lcall` instructions have their `seg, offset` operands sanitized, just like the 32-bit `call` instruction.
- Jump tables with a 16-bit displacement assume the offset is into the current code segment. The offsets _in_ the table are smaller because they're not full pointers. These should be displayed correctly in the asm listing.
- Many things in `core.py` assume we will always have a `PEImage`. The easiest way to make this generic to work with any `Image` is to have two orchestration paths: one for NE with only the supported operations, and the main one for PE images.
- Make `get_abs_addr` a function on the abstract `Image`, not just `PEImage`.

I didn't see any regressions with the 32-bit projects I looked at. (Comparing asm output with `--dump`.)