### PR TITLE
Support folded VTABLE annotations

### DIFF
--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -12,6 +12,7 @@ from reccmp.formats import PEImage, TextFile
 from reccmp.cvdump import CvdumpTypesParser, CvdumpAnalysis
 from reccmp.parser import DecompCodebase
 from reccmp.parser.marker import ProjectAliases
+from reccmp.parser.node import ParserVtable
 from reccmp.types import EntityType, ImageId
 from reccmp.compare.event import (
     ReccmpEvent,
@@ -223,14 +224,26 @@ def load_markers(
                     parent_function=var.parent_function,
                 )
 
+        vtables_by_offset: dict[int, list[ParserVtable]] = {}
         for tbl in codebase.iter_vtables():
+            vtables_by_offset.setdefault(tbl.offset, []).append(tbl)
+
+        for offset, candidates in vtables_by_offset.items():
+            primary = candidates[0]
             batch.set(
                 ImageId.ORIG,
-                tbl.offset,
-                name=tbl.name,
-                base_class=tbl.base_class,
+                offset,
+                name=primary.name,
+                base_class=primary.base_class,
                 type=EntityType.VTABLE,
             )
+
+            if len(candidates) > 1:
+                batch.set(
+                    ImageId.ORIG,
+                    offset,
+                    folded_vtables=[(tbl.name, tbl.base_class) for tbl in candidates],
+                )
 
         for string in codebase.iter_strings():
             # Not that we don't trust you, but we're checking the string

--- a/reccmp/compare/match_msvc.py
+++ b/reccmp/compare/match_msvc.py
@@ -178,6 +178,30 @@ def match_functions(
                 )
 
 
+def _find_vtable_match(
+    class_name: str, base_class: str | None, vtable_name_index: EntityIndex
+) -> int | None:
+    """Try to resolve a single class_name/base_class candidate against the
+    recomp vtable name index."""
+
+    # Most classes will not use multiple inheritance, so try the regular vtable
+    # first, unless a base class is provided.
+    if base_class is None or base_class == class_name:
+        bare_vftable = f"{class_name}::`vftable'"
+
+        if bare_vftable in vtable_name_index:
+            return vtable_name_index.pop(bare_vftable)
+
+    # If we didn't find a match above, search for the multiple inheritance vtable.
+    for_name = base_class if base_class is not None else class_name
+    for_vftable = f"{class_name}::`vftable'{{for `{for_name}'}}"
+
+    if for_vftable in vtable_name_index:
+        return vtable_name_index.pop(for_vftable)
+
+    return None
+
+
 def match_vtables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop):
     """The requirements for matching are:
     1.  Recomp entity has name attribute in this format: "Pizza::`vftable'"
@@ -215,31 +239,21 @@ def match_vtables(db: EntityDb, report: ReccmpReportProtocol = reccmp_report_nop
             assert ent.orig_addr is not None
 
             base_class = ent.get("base_class")
+            candidates = ent.get("folded_vtables") or [(class_name, base_class)]
 
-            # Most classes will not use multiple inheritance, so try the regular vtable
-            # first, unless a base class is provided.
-            if base_class is None or base_class == class_name:
-                bare_vftable = f"{class_name}::`vftable'"
-
-                if bare_vftable in vtable_name_index:
-                    recomp_addr = vtable_name_index.pop(bare_vftable)
+            for candidate_name, candidate_base_class in candidates:
+                recomp_addr = _find_vtable_match(
+                    candidate_name, candidate_base_class, vtable_name_index
+                )
+                if recomp_addr is not None:
                     batch.match(ent.orig_addr, recomp_addr)
-                    continue
-
-            # If we didn't find a match above, search for the multiple inheritance vtable.
-            for_name = base_class if base_class is not None else class_name
-            for_vftable = f"{class_name}::`vftable'{{for `{for_name}'}}"
-
-            if for_vftable in vtable_name_index:
-                recomp_addr = vtable_name_index.pop(for_vftable)
-                batch.match(ent.orig_addr, recomp_addr)
-                continue
-
-            report(
-                ReccmpEvent.NO_MATCH,
-                ent.orig_addr,
-                msg=f"Failed to match vtable at 0x{ent.orig_addr:x} for class '{class_name}' (base={base_class or 'None'})",
-            )
+                    break
+            else:
+                report(
+                    ReccmpEvent.NO_MATCH,
+                    ent.orig_addr,
+                    msg=f"Failed to match vtable at 0x{ent.orig_addr:x} for class '{class_name}' (base={base_class or 'None'})",
+                )
 
 
 def match_static_variables(

--- a/reccmp/parser/codebase.py
+++ b/reccmp/parser/codebase.py
@@ -50,10 +50,10 @@ class DecompCodebase:
         unique = []
 
         for s in self._symbols:
-            # Must retain FOLDED functions because they will reuse the address.
+            # Must retain FOLDED functions/vtables because they will reuse the address.
             # Question: should we keep *all* annotations for this address if *any* are folded?
             if s.offset in used_addr and not (
-                isinstance(s, ParserFunction) and s.is_folded
+                isinstance(s, (ParserFunction, ParserVtable)) and s.is_folded
             ):
                 duplicates.append(s)
             else:

--- a/reccmp/parser/linter.py
+++ b/reccmp/parser/linter.py
@@ -2,7 +2,7 @@ from pathlib import PurePath
 from typing import Iterator, Sequence
 from .parser import ReccmpParserResult
 from .error import AlertCode, ParserAlert
-from .node import ParserFunction, ParserString
+from .node import ParserFunction, ParserString, ParserVtable
 
 
 def file_is_header(path: PurePath) -> bool:
@@ -84,7 +84,9 @@ def check_offset_uniqueness(results: Sequence[ReccmpParserResult]) -> list[Parse
 
     for result in results:
         for marker in result.tokens:
-            is_folded = isinstance(marker, ParserFunction) and marker.is_folded
+            is_folded = (
+                isinstance(marker, (ParserFunction, ParserVtable)) and marker.is_folded
+            )
             is_string = isinstance(marker, ParserString)
 
             module_addresses = seen_addresses.setdefault(marker.module, set())

--- a/reccmp/parser/node.py
+++ b/reccmp/parser/node.py
@@ -70,6 +70,9 @@ class ParserVariable(ParserSymbol):
 class ParserVtable(ParserSymbol):
     base_class: str | None = None
 
+    # True if this address is shared by many identical VMTs.
+    is_folded: bool = False
+
 
 @dataclass
 class ParserString(ParserSymbol):

--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -297,6 +297,8 @@ class DecompParser:
 
     def _vtable_done(self, class_name: str):
         for marker in self.tbl_markers.iter():
+            is_folded = marker.extra is not None and marker.extra.lower() == "folded"
+
             self._symbols.append(
                 ParserVtable(
                     type=marker.type,
@@ -305,7 +307,8 @@ class DecompParser:
                     offset=marker.offset,
                     name=self.curly.get_prefix(class_name),
                     filename=self.filename,
-                    base_class=marker.extra,
+                    base_class=None if is_folded else marker.extra,
+                    is_folded=is_folded,
                 )
             )
 

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -447,6 +447,8 @@ def test_load_code_vtable(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     assert entity.get("name") == "Pizza"
     assert entity.get("base_class") is None
 
+    assert entity.get("folded_vtables") is None
+
 
 def test_load_code_vtable_vbase(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
     """Should set base_class for VTABLE entities with virtual inheritance."""
@@ -475,6 +477,33 @@ def test_load_code_vtable_vbase(db: EntityDb, lines_db: LinesDb, binfile: PEImag
     assert entity.get("type") == EntityType.VTABLE
     assert entity.get("name") == "Pizza"
     assert entity.get("base_class") == "Pizza"
+
+
+def test_load_code_vtable_folded(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
+    files = (
+        TextFile(
+            PurePath("test.h"),
+            dedent("""\
+                // VTABLE: TEST 0x100d7380 FOLDED
+                class Pizza {
+                };
+
+                // VTABLE: TEST 0x100d7380 FOLDED
+                class Lunch {
+                };
+                """),
+        ),
+    )
+    load_markers(files, lines_db, binfile, "TEST", db)
+
+    entity = db.get(ImageId.ORIG, 0x100D7380)
+    assert entity is not None
+    assert entity.get("type") == EntityType.VTABLE
+
+    assert entity.get("name") == "Pizza"
+    assert entity.get("base_class") is None
+
+    assert entity.get("folded_vtables") == [("Pizza", None), ("Lunch", None)]
 
 
 def test_load_code_variable(db: EntityDb, lines_db: LinesDb, binfile: PEImage):

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -190,6 +190,39 @@ def test_ignore_folded_and_regular_duplicate():
     assert alerts[0].code == AlertCode.DUPLICATE_OFFSET
 
 
+def test_ignore_folded_duplicate_vtable():
+    """Do not alert to folded vtables that reuse an address."""
+    folded_lines = """\
+    // VTABLE: TEST 0x1000 FOLDED
+    class Folded {
+    };
+
+    // VTABLE: TEST 0x1000 FOLDED
+    class First {
+    };
+    """
+
+    result = create_parser_result(folded_lines, PurePath("test.cpp"))
+    assert not check_offset_uniqueness([result, result])
+
+
+def test_ignore_folded_and_regular_duplicate_vtable():
+    """Should alert when folded and non-folded vtables reuse an address."""
+    folded_lines = """\
+    // VTABLE: TEST 0x1000 FOLDED
+    class Folded {
+    };
+
+    // VTABLE: TEST 0x1000
+    class First {
+    };
+    """
+
+    result = create_parser_result(folded_lines, PurePath("test.cpp"))
+    alerts = check_offset_uniqueness([result, result])
+    assert alerts[0].code == AlertCode.DUPLICATE_OFFSET
+
+
 def test_ignore_folded_order():
     """Skip folded functions and do not check their order."""
     folded_lines = """\

--- a/tests/test_match_msvc.py
+++ b/tests/test_match_msvc.py
@@ -410,6 +410,57 @@ def test_match_vtables_incompatible_base_class(db):
     assert db.get(ImageId.ORIG, 100).recomp_addr is None
 
 
+def test_match_vtables_folded(db):
+    """Match a folded vtable by trying each candidate name"""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Pizza",
+            type=EntityType.VTABLE,
+            folded_vtables=[("Pizza", None), ("Lunch", None)],
+        )
+        batch.set(ImageId.RECOMP, 200, name="Lunch::`vftable'", type=EntityType.VTABLE)
+
+    match_vtables(db)
+
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
+
+
+def test_match_vtables_folded_first_candidate(db):
+    """The first folded candidate can match too, not just the last"""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Pizza",
+            type=EntityType.VTABLE,
+            folded_vtables=[("Pizza", None), ("Lunch", None)],
+        )
+        batch.set(ImageId.RECOMP, 200, name="Pizza::`vftable'", type=EntityType.VTABLE)
+
+    match_vtables(db)
+
+    assert db.get(ImageId.ORIG, 100).recomp_addr == 200
+
+
+def test_match_vtables_folded_no_match(db, report):
+    """Report a single failure if none of the folded candidates match."""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Pizza",
+            type=EntityType.VTABLE,
+            folded_vtables=[("Pizza", None), ("Lunch", None)],
+        )
+
+    match_vtables(db, report)
+
+    report.assert_called_once_with(ReccmpEvent.NO_MATCH, 100, msg=ANY)
+    assert db.get(ImageId.ORIG, 100).recomp_addr is None
+
+
 #### match_static_variables ####
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -782,6 +782,28 @@ def test_folded_mixed_by_module(parser):
     assert len(parser.alerts) == 0
 
 
+def test_folded_option_vtable(parser):
+    """Read FOLDED option from VTABLE annotations."""
+    parser.read("""\
+        // VTABLE: HELLO 0x1234 FOLDED
+        class Pizza {
+        };
+
+        // VTABLE: HELLO 0x5555
+        class Lunch {
+        };
+        """)
+
+    assert parser.vtables[0].offset == 0x1234
+    assert parser.vtables[0].is_folded is True
+    assert parser.vtables[0].base_class is None
+
+    assert parser.vtables[1].offset == 0x5555
+    assert parser.vtables[1].is_folded is False
+
+    assert len(parser.alerts) == 0
+
+
 def test_variables_calling_constructor(parser):
     """Can extract the variable name for variables initialized by a constructor."""
     parser.read("""\


### PR DESCRIPTION
I ran into an issue where /OPT:ICF set for MSVC seems to have folded identical vtables, so wanted to suggest this change