### PR TITLE
Improve `parser/marker.py` code quality

### DIFF
--- a/reccmp/parser/marker.py
+++ b/reccmp/parser/marker.py
@@ -1,4 +1,5 @@
 import re
+from typing import NamedTuple
 from enum import Enum
 
 TargetAliases = dict[str, str]
@@ -43,97 +44,30 @@ markerExactRegex = re.compile(
 )
 
 
-class DecompMarker:
-    def __init__(
-        self, marker_type: str, module: str, offset: int, extra: str | None = None
-    ) -> None:
-        try:
-            self._type = MarkerType[marker_type.upper()]
-        except KeyError:
-            self._type = MarkerType.UNKNOWN
+MARKER_CATEGORY_MAP = {
+    MarkerType.FUNCTION: MarkerCategory.FUNCTION,
+    MarkerType.STUB: MarkerCategory.FUNCTION,
+    MarkerType.SYNTHETIC: MarkerCategory.FUNCTION,
+    MarkerType.TEMPLATE: MarkerCategory.FUNCTION,
+    MarkerType.LIBRARY: MarkerCategory.FUNCTION,
+    MarkerType.VTABLE: MarkerCategory.VTABLE,
+    MarkerType.GLOBAL: MarkerCategory.VARIABLE,
+    MarkerType.STRING: MarkerCategory.STRING,
+    MarkerType.LINE: MarkerCategory.ADDRESS,
+    MarkerType.UNKNOWN: MarkerCategory.ADDRESS,
+}
 
-        # Convert to upper here. A lot of other analysis depends on this name
-        # being consistent and predictable. If the name is _not_ capitalized
-        # we will emit a syntax error.
-        self._module: str = module.upper()
-        self._offset: int = offset
-        self._extra: str | None = extra
 
-    @property
-    def type(self) -> MarkerType:
-        return self._type
-
-    @property
-    def module(self) -> str:
-        return self._module
-
-    @property
-    def offset(self) -> int:
-        return self._offset
-
-    @property
-    def extra(self) -> str | None:
-        return self._extra
-
-    @property
-    def category(self) -> MarkerCategory:
-        if self.is_vtable():
-            return MarkerCategory.VTABLE
-
-        if self.is_variable():
-            return MarkerCategory.VARIABLE
-
-        if self.is_string():
-            return MarkerCategory.STRING
-
-        # TODO: worth another look if we add more types, but this covers it
-        if self.is_regular_function() or self.is_explicit_byname():
-            return MarkerCategory.FUNCTION
-
-        return MarkerCategory.ADDRESS
+class DecompMarker(NamedTuple):
+    type: MarkerType
+    module: str
+    offset: int
+    extra: str | None = None
 
     @property
     def key(self) -> tuple[MarkerCategory, str, str | None]:
         """For use with the MarkerDict. To detect/avoid marker collision."""
-        return (self.category, self.module, self.extra)
-
-    def is_regular_function(self) -> bool:
-        """Regular function, meaning: not an explicit byname lookup. FUNCTION
-        markers can be _implicit_ byname.
-        FUNCTION and STUB markers are (currently) the only heterogeneous marker types that
-        can be lumped together, although the reasons for doing so are a little vague."""
-        return self._type in (MarkerType.FUNCTION, MarkerType.STUB)
-
-    def is_explicit_byname(self) -> bool:
-        return self._type in (
-            MarkerType.SYNTHETIC,
-            MarkerType.TEMPLATE,
-            MarkerType.LIBRARY,
-        )
-
-    def is_variable(self) -> bool:
-        return self._type == MarkerType.GLOBAL
-
-    def is_synthetic(self) -> bool:
-        return self._type == MarkerType.SYNTHETIC
-
-    def is_template(self) -> bool:
-        return self._type == MarkerType.TEMPLATE
-
-    def is_vtable(self) -> bool:
-        return self._type == MarkerType.VTABLE
-
-    def is_library(self) -> bool:
-        return self._type == MarkerType.LIBRARY
-
-    def is_string(self) -> bool:
-        return self._type == MarkerType.STRING
-
-    def is_line(self) -> bool:
-        return self._type == MarkerType.LINE
-
-    def allowed_in_func(self) -> bool:
-        return self._type in (MarkerType.GLOBAL, MarkerType.STRING, MarkerType.LINE)
+        return (MARKER_CATEGORY_MAP[self.type], self.module, self.extra)
 
 
 def normalize_target_aliases(aliases: TargetAliases) -> TargetAliases:
@@ -189,16 +123,22 @@ def match_marker(
     if match is None:
         return None
 
-    marker_type = match.group("type")
-    target_name = match.group("module")
-
+    marker_type, target_name, offset_str, extra = match.groups()
     marker_type = resolve_alias(marker_type, target_name, aliases)
 
+    try:
+        enum_type = MarkerType[marker_type.upper()]
+    except KeyError:
+        enum_type = MarkerType.UNKNOWN
+
     return DecompMarker(
-        marker_type=marker_type,
-        module=target_name,
-        offset=int(match.group("offset"), 16),
-        extra=match.group("extra"),
+        type=enum_type,
+        # Convert to upper here. A lot of other analysis depends on this name
+        # being consistent and predictable. If the name is _not_ capitalized
+        # we will emit a syntax error.
+        module=target_name.upper(),
+        offset=int(offset_str, 16),
+        extra=extra,
     )
 
 

--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -18,6 +18,7 @@ from .util import (
 from .marker import (
     DecompMarker,
     MarkerCategory,
+    MarkerType,
     match_marker,
     is_marker_exact,
     ProjectAliases,
@@ -246,9 +247,9 @@ class DecompParser:
         if self.fun_markers.insert(marker):
             self._syntax_warning(AlertCode.DUPLICATE_MODULE)
 
-        if marker.is_template():
+        if marker.type == MarkerType.TEMPLATE:
             self.state = ReaderState.IN_TEMPLATE
-        elif marker.is_synthetic():
+        elif marker.type == MarkerType.SYNTHETIC:
             self.state = ReaderState.IN_SYNTHETIC
         else:
             self.state = ReaderState.IN_LIBRARY
@@ -332,7 +333,7 @@ class DecompParser:
             return
 
         for marker in self.var_markers.iter():
-            if marker.is_string():
+            if marker.type == MarkerType.STRING:
                 assert string is not None
                 self._symbols.append(
                     ParserString(
@@ -407,7 +408,10 @@ class DecompParser:
         # and we have moved on to something else.
         # This is unlikely to occur with well-formed code, but
         # we can recover easily by just ending the function here.
-        if self.state == ReaderState.IN_FUNC and not marker.allowed_in_func():
+        if self.state == ReaderState.IN_FUNC and marker.type not in (
+            MarkerType.GLOBAL,
+            MarkerType.STRING,
+        ):
             self._syntax_warning(AlertCode.MISSED_END_OF_FUNCTION)
             self._function_done(unexpected=True)
 
@@ -416,7 +420,7 @@ class DecompParser:
         # end if we detect a non-GLOBAL marker while state is IN_FUNC.
         # Maybe these cases should be syntax errors instead
 
-        if marker.is_regular_function():
+        if marker.type in (MarkerType.FUNCTION, MarkerType.STUB):
             if self.state in (
                 ReaderState.SEARCH,
                 ReaderState.WANT_SIG,
@@ -427,26 +431,26 @@ class DecompParser:
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
-        elif marker.is_template():
+        elif marker.type == MarkerType.TEMPLATE:
             if self.state in (ReaderState.SEARCH, ReaderState.IN_TEMPLATE):
                 self._nameref_marker(marker)
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
-        elif marker.is_synthetic():
+        elif marker.type == MarkerType.SYNTHETIC:
             if self.state in (ReaderState.SEARCH, ReaderState.IN_SYNTHETIC):
                 self._nameref_marker(marker)
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
-        elif marker.is_library():
+        elif marker.type == MarkerType.LIBRARY:
             if self.state in (ReaderState.SEARCH, ReaderState.IN_LIBRARY):
                 self._nameref_marker(marker)
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
         # Strings and variables are almost the same thing
-        elif marker.is_string() or marker.is_variable():
+        elif marker.type in (MarkerType.STRING, MarkerType.GLOBAL):
             if self.state in (
                 ReaderState.SEARCH,
                 ReaderState.IN_GLOBAL,
@@ -457,13 +461,13 @@ class DecompParser:
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
-        elif marker.is_vtable():
+        elif marker.type == MarkerType.VTABLE:
             if self.state in (ReaderState.SEARCH, ReaderState.IN_VTABLE):
                 self._vtable_marker(marker)
             else:
                 self._syntax_error(AlertCode.INCOMPATIBLE_MARKER)
 
-        elif marker.is_line():
+        elif marker.type == MarkerType.LINE:
             self._line_marker(marker)
 
         else:
@@ -566,7 +570,7 @@ class DecompParser:
             variable_name = None
 
             global_markers_queued = any(
-                m.is_variable() for m in self.var_markers.iter()
+                m.type == MarkerType.GLOBAL for m in self.var_markers.iter()
             )
 
             if len(line_strip) == 0:

--- a/tests/test_parser_util.py
+++ b/tests/test_parser_util.py
@@ -89,15 +89,15 @@ def test_marker_exact(line: str, exact: bool, _):
 
 def test_marker_dict_simple():
     d = MarkerDict()
-    d.insert(DecompMarker("FUNCTION", "TEST", 0x1234))
+    d.insert(DecompMarker(MarkerType.FUNCTION, "TEST", 0x1234))
     markers = list(d.iter())
     assert len(markers) == 1
 
 
 def test_marker_dict_ofs_replace():
     d = MarkerDict()
-    d.insert(DecompMarker("FUNCTION", "TEST", 0x1234))
-    d.insert(DecompMarker("FUNCTION", "TEST", 0x555))
+    d.insert(DecompMarker(MarkerType.FUNCTION, "TEST", 0x1234))
+    d.insert(DecompMarker(MarkerType.FUNCTION, "TEST", 0x555))
     markers = list(d.iter())
     assert len(markers) == 1
     assert markers[0].offset == 0x1234
@@ -105,8 +105,8 @@ def test_marker_dict_ofs_replace():
 
 def test_marker_dict_type_replace():
     d = MarkerDict()
-    d.insert(DecompMarker("FUNCTION", "TEST", 0x1234))
-    d.insert(DecompMarker("STUB", "TEST", 0x1234))
+    d.insert(DecompMarker(MarkerType.FUNCTION, "TEST", 0x1234))
+    d.insert(DecompMarker(MarkerType.STUB, "TEST", 0x1234))
     markers = list(d.iter())
     assert len(markers) == 1
     assert markers[0].type == MarkerType.FUNCTION


### PR DESCRIPTION
Part of #509.

Using an immutable `tuple` for the markers so we can delete some getter slop.