### PR TITLE
Prefer a known orig vtable size over the recomp size estimate

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -191,7 +191,7 @@ class Compare:
             set_max_size(self._db, img_id)
 
         match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
-        check_vtables(self._db, self.orig_bin, self.recomp_bin)
+        check_vtables(self._db)
         match_ref(self._db, self.report)
         unique_names_for_overloaded_functions(self._db)
         name_thunks(self._db)

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -274,11 +274,12 @@ class Compare:
             )
             recomp_size = 4 * (recomp_size // 4)
 
-        # The recomp size is an estimate (next-symbol distance or section
-        # contribution) and may over-count the table by a trailing alignment
-        # slot, so reading the orig table at that size can walk past the end of
-        # the real table. If a data source gives us the orig size, read each
-        # table at its own size instead.
+        # The PDB doesn't record a size for the vtable itself, so the recomp
+        # size is an estimate: it's either the gap between this symbol and the
+        # next, or the size listed in cvdump's SECTION CONTRIBUTIONS output.
+        # Either estimate can include alignment padding after the table, and
+        # reading the orig table with the padded size would run past the
+        # actual end of the table. Just use the orig size if known.
         orig_size = match.size(ImageId.ORIG)
         if orig_size is None:
             orig_size = recomp_size
@@ -294,10 +295,10 @@ class Compare:
         orig_addrs = [t for (t,) in struct.iter_unpack("<L", orig_table)]
         recomp_addrs = [t for (t,) in struct.iter_unpack("<L", recomp_table)]
 
-        # Drop the trailing alignment slot that the recomp size may over-count,
-        # so it does not read as a virtual function that orig is missing.
-        # A real address past the end of the orig table is a virtual function
-        # that orig does not have, so keep it: zip_longest displays it with
+        # Trailing null entries on the recomp side are alignment padding, not
+        # virtual functions missing from orig, so drop them. Non-null entries
+        # past the end of the orig table are kept: these are virtual functions
+        # that only exist in recomp, and zip_longest will show them with
         # "(no match)" on the orig side.
         while len(recomp_addrs) > len(orig_addrs) and recomp_addrs[-1] == 0:
             recomp_addrs.pop()

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -262,7 +262,9 @@ class Compare:
         return compare
 
     def _compare_vtable(self, match: ReccmpMatch) -> EntityCompareResult:
-        vtable_size = match.any_size()
+        # Prefer the orig size if we have it (e.g. from a data source):
+        # the recomp size may be an estimate that over-reads the orig table.
+        vtable_size = match.any_size(ImageId.ORIG)
 
         # The vtable size should always be a multiple of 4 because that
         # is the pointer size. If it is not (for whatever reason)

--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -1,6 +1,7 @@
 import logging
 import difflib
 import struct
+from itertools import zip_longest
 from typing import Callable, Iterator
 from typing_extensions import Self
 from reccmp.project.detect import RecCmpTarget
@@ -190,7 +191,7 @@ class Compare:
             set_max_size(self._db, img_id)
 
         match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
-        check_vtables(self._db, self.orig_bin)
+        check_vtables(self._db, self.orig_bin, self.recomp_bin)
         match_ref(self._db, self.report)
         unique_names_for_overloaded_functions(self._db)
         name_thunks(self._db)
@@ -262,26 +263,46 @@ class Compare:
         return compare
 
     def _compare_vtable(self, match: ReccmpMatch) -> EntityCompareResult:
-        # Prefer the orig size if we have it (e.g. from a data source):
-        # the recomp size may be an estimate that over-reads the orig table.
-        vtable_size = match.any_size(ImageId.ORIG)
+        recomp_size = match.any_size(ImageId.RECOMP)
 
         # The vtable size should always be a multiple of 4 because that
         # is the pointer size. If it is not (for whatever reason)
         # it would cause iter_unpack to blow up so let's just fix it.
-        if vtable_size % 4 != 0:
+        if recomp_size % 4 != 0:
             logger.warning(
-                "Vtable for class %s has irregular size %d", match.name, vtable_size
+                "Vtable for class %s has irregular size %d", match.name, recomp_size
             )
-            vtable_size = 4 * (vtable_size // 4)
+            recomp_size = 4 * (recomp_size // 4)
 
-        orig_table = self.orig_bin.read(match.orig_addr, vtable_size)
-        recomp_table = self.recomp_bin.read(match.recomp_addr, vtable_size)
+        # The recomp size is an estimate (next-symbol distance or section
+        # contribution) and may over-count the table by a trailing alignment
+        # slot, so reading the orig table at that size can walk past the end of
+        # the real table. If a data source gives us the orig size, read each
+        # table at its own size instead.
+        orig_size = match.size(ImageId.ORIG)
+        if orig_size is None:
+            orig_size = recomp_size
+        elif orig_size % 4 != 0:
+            logger.warning(
+                "Vtable for class %s has irregular orig size %d", match.name, orig_size
+            )
+            orig_size = 4 * (orig_size // 4)
 
-        raw_addrs = zip(
-            [t for (t,) in struct.iter_unpack("<L", orig_table)],
-            [t for (t,) in struct.iter_unpack("<L", recomp_table)],
-        )
+        orig_table = self.orig_bin.read(match.orig_addr, orig_size)
+        recomp_table = self.recomp_bin.read(match.recomp_addr, recomp_size)
+
+        orig_addrs = [t for (t,) in struct.iter_unpack("<L", orig_table)]
+        recomp_addrs = [t for (t,) in struct.iter_unpack("<L", recomp_table)]
+
+        # Drop the trailing alignment slot that the recomp size may over-count,
+        # so it does not read as a virtual function that orig is missing.
+        # A real address past the end of the orig table is a virtual function
+        # that orig does not have, so keep it: zip_longest displays it with
+        # "(no match)" on the orig side.
+        while len(recomp_addrs) > len(orig_addrs) and recomp_addrs[-1] == 0:
+            recomp_addrs.pop()
+
+        raw_addrs = zip_longest(orig_addrs, recomp_addrs)
 
         def match_text(m: ReccmpEntity | None, raw_addr: int | None = None) -> str:
             """Format the function reference at this vtable index as text.
@@ -312,8 +333,14 @@ class Compare:
 
         # Now compare each pointer from the two vtables.
         for i, (raw_orig, raw_recomp) in enumerate(raw_addrs):
-            orig = self._db.get(ImageId.ORIG, raw_orig)
-            recomp = self._db.get(ImageId.RECOMP, raw_recomp)
+            orig = (
+                self._db.get(ImageId.ORIG, raw_orig) if raw_orig is not None else None
+            )
+            recomp = (
+                self._db.get(ImageId.RECOMP, raw_recomp)
+                if raw_recomp is not None
+                else None
+            )
 
             if (
                 orig is not None

--- a/reccmp/compare/verify.py
+++ b/reccmp/compare/verify.py
@@ -3,98 +3,30 @@ These functions report problems with the current entities that limit or block fu
 """
 
 import logging
-import struct
-from reccmp.formats.pe import PEImage
 from reccmp.types import EntityType, ImageId
 from .db import EntityDb
 
 logger = logging.getLogger(__name__)
 
 
-def _table_has_entries_past(image: PEImage, addr: int, start: int, end: int) -> bool:
-    """Whether the vtable at `addr` has any real entry in the byte range
-    [start, end). The size that produced `end` may over-count the table by a
-    trailing alignment slot, so only a non-null pointer counts as an entry."""
-    start = 4 * (start // 4)
-    end = 4 * (end // 4)
-    if end <= start:
-        return False
+def check_vtables(db: EntityDb):
+    """Alert to vtable size information that cannot be correct.
 
-    tail = image.read(addr + start, end - start)
-    return any(addr != 0 for addr, in struct.iter_unpack("<L", tail))
-
-
-def check_vtables(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
-    """Alert to cases where the recomp vtable is larger than the one in the orig binary.
-
-    If a data source gives the orig vtable's true size, we can compare the two
-    tables directly. Otherwise the orig size is unknown and we estimate it from:
-    1. The address of the following vtable in orig, which gives an upper bound on the size.
-    2. The pointers in the orig vtable. If any are zero bytes, this is alignment padding between two vtables.
-
-    Both estimates read the orig table at the *recomp* size, which is itself an
-    estimate (next-symbol distance or section contribution) and may over-count
-    the table by a trailing alignment slot. Reading that far into orig walks
-    past the end of the real table and reports a size difference that is not
-    there, so a known orig size takes priority over either estimate.
-
-    Comparing the two sizes does not settle it either, for the same reason:
-    a recomp size greater than the orig size may be nothing but that trailing
-    slot. Compare the entries instead. A null pointer past the end of the orig
-    table is padding; a real address is a virtual function that orig does not
-    have.
+    A size difference between the two vtables is not reported here: it shows up
+    in the regular vtable comparison output. The one thing worth flagging ahead
+    of that comparison is an impossible input: a supplied orig vtable size that
+    runs into the next entity cannot be correct, and points at a problem with
+    the data source rather than a real size difference.
     """
     for match in db.get_matches_by_type(EntityType.VTABLE):
-        assert (
-            match.name is not None
-            and match.orig_addr is not None
-            and match.recomp_addr is not None
-        )
+        assert match.name is not None
 
         orig_size = match.size(ImageId.ORIG)
-        if orig_size is not None:
-            # We know the orig size, so the estimates below do not apply.
-            orig_max = match.max_size(ImageId.ORIG)
-            if orig_max is not None and orig_max < orig_size:
-                # Not a size difference: the orig size we were given runs into
-                # the next entity, so it cannot be correct.
-                logger.warning(
-                    "Orig vtable size for %s overruns the next entity", match.name
-                )
-                continue
-
-            if _table_has_entries_past(
-                recomp_bin,
-                match.recomp_addr,
-                orig_size,
-                match.any_size(ImageId.RECOMP),
-            ):
-                logger.warning(
-                    "Recomp vtable is larger than orig vtable for %s",
-                    match.name,
-                )
-
+        if orig_size is None:
             continue
-
-        vtable_size = match.any_size(ImageId.RECOMP)
 
         orig_max = match.max_size(ImageId.ORIG)
-        if orig_max is not None and orig_max < vtable_size:
+        if orig_max is not None and orig_max < orig_size:
             logger.warning(
-                "Recomp vtable is larger than orig vtable for %s",
-                match.name,
-            )
-            continue
-
-        # TODO: We might want to fix this at the source (cvdump) instead.
-        # Any problem will be logged later when we compare the vtable.
-        vtable_size = 4 * (vtable_size // 4)
-        orig_table = orig_bin.read(match.orig_addr, vtable_size)
-
-        # Check for a gap (null pointer) in the orig vtable.
-        # This may or may not be present, but if it is there, we know the vtable
-        # on the recomp side is larger.
-        if any(addr == 0 for addr, in struct.iter_unpack("<L", orig_table)):
-            logger.warning(
-                "Recomp vtable is larger than orig vtable for %s", match.name
+                "Orig vtable size for %s overruns the next entity", match.name
             )

--- a/reccmp/compare/verify.py
+++ b/reccmp/compare/verify.py
@@ -10,13 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 def check_vtables(db: EntityDb):
-    """Alert to vtable size information that cannot be correct.
+    """Check vtable sizes provided by the data source.
 
-    A size difference between the two vtables is not reported here: it shows up
-    in the regular vtable comparison output. The one thing worth flagging ahead
-    of that comparison is an impossible input: a supplied orig vtable size that
-    runs into the next entity cannot be correct, and points at a problem with
-    the data source rather than a real size difference.
+    Size differences between the orig and recomp vtables are reported by the
+    vtable comparison, so they are not checked here. The only check is that a
+    user-provided orig vtable size does not extend past the next entity in the
+    binary. If it does, the size can't be right, so warn about it.
     """
     for match in db.get_matches_by_type(EntityType.VTABLE):
         assert match.name is not None

--- a/reccmp/compare/verify.py
+++ b/reccmp/compare/verify.py
@@ -11,14 +11,38 @@ from .db import EntityDb
 logger = logging.getLogger(__name__)
 
 
-def check_vtables(db: EntityDb, orig_bin: PEImage):
+def _table_has_entries_past(image: PEImage, addr: int, start: int, end: int) -> bool:
+    """Whether the vtable at `addr` has any real entry in the byte range
+    [start, end). The size that produced `end` may over-count the table by a
+    trailing alignment slot, so only a non-null pointer counts as an entry."""
+    start = 4 * (start // 4)
+    end = 4 * (end // 4)
+    if end <= start:
+        return False
+
+    tail = image.read(addr + start, end - start)
+    return any(addr != 0 for addr, in struct.iter_unpack("<L", tail))
+
+
+def check_vtables(db: EntityDb, orig_bin: PEImage, recomp_bin: PEImage):
     """Alert to cases where the recomp vtable is larger than the one in the orig binary.
-    We can tell by looking at:
+
+    If a data source gives the orig vtable's true size, we can compare the two
+    tables directly. Otherwise the orig size is unknown and we estimate it from:
     1. The address of the following vtable in orig, which gives an upper bound on the size.
     2. The pointers in the orig vtable. If any are zero bytes, this is alignment padding between two vtables.
-    A data source can supply the orig vtable's true size. When present it takes
-    priority over the recomp size, which is an estimate (next-symbol distance or
-    section contribution) that may include trailing alignment padding.
+
+    Both estimates read the orig table at the *recomp* size, which is itself an
+    estimate (next-symbol distance or section contribution) and may over-count
+    the table by a trailing alignment slot. Reading that far into orig walks
+    past the end of the real table and reports a size difference that is not
+    there, so a known orig size takes priority over either estimate.
+
+    Comparing the two sizes does not settle it either, for the same reason:
+    a recomp size greater than the orig size may be nothing but that trailing
+    slot. Compare the entries instead. A null pointer past the end of the orig
+    table is padding; a real address is a virtual function that orig does not
+    have.
     """
     for match in db.get_matches_by_type(EntityType.VTABLE):
         assert (
@@ -27,7 +51,32 @@ def check_vtables(db: EntityDb, orig_bin: PEImage):
             and match.recomp_addr is not None
         )
 
-        vtable_size = match.any_size(ImageId.ORIG)
+        orig_size = match.size(ImageId.ORIG)
+        if orig_size is not None:
+            # We know the orig size, so the estimates below do not apply.
+            orig_max = match.max_size(ImageId.ORIG)
+            if orig_max is not None and orig_max < orig_size:
+                # Not a size difference: the orig size we were given runs into
+                # the next entity, so it cannot be correct.
+                logger.warning(
+                    "Orig vtable size for %s overruns the next entity", match.name
+                )
+                continue
+
+            if _table_has_entries_past(
+                recomp_bin,
+                match.recomp_addr,
+                orig_size,
+                match.any_size(ImageId.RECOMP),
+            ):
+                logger.warning(
+                    "Recomp vtable is larger than orig vtable for %s",
+                    match.name,
+                )
+
+            continue
+
+        vtable_size = match.any_size(ImageId.RECOMP)
 
         orig_max = match.max_size(ImageId.ORIG)
         if orig_max is not None and orig_max < vtable_size:

--- a/reccmp/compare/verify.py
+++ b/reccmp/compare/verify.py
@@ -16,6 +16,9 @@ def check_vtables(db: EntityDb, orig_bin: PEImage):
     We can tell by looking at:
     1. The address of the following vtable in orig, which gives an upper bound on the size.
     2. The pointers in the orig vtable. If any are zero bytes, this is alignment padding between two vtables.
+    A data source can supply the orig vtable's true size. When present it takes
+    priority over the recomp size, which is an estimate (next-symbol distance or
+    section contribution) that may include trailing alignment padding.
     """
     for match in db.get_matches_by_type(EntityType.VTABLE):
         assert (
@@ -24,8 +27,10 @@ def check_vtables(db: EntityDb, orig_bin: PEImage):
             and match.recomp_addr is not None
         )
 
+        vtable_size = match.any_size(ImageId.ORIG)
+
         orig_max = match.max_size(ImageId.ORIG)
-        if orig_max is not None and orig_max < match.any_size():
+        if orig_max is not None and orig_max < vtable_size:
             logger.warning(
                 "Recomp vtable is larger than orig vtable for %s",
                 match.name,
@@ -34,7 +39,7 @@ def check_vtables(db: EntityDb, orig_bin: PEImage):
 
         # TODO: We might want to fix this at the source (cvdump) instead.
         # Any problem will be logged later when we compare the vtable.
-        vtable_size = 4 * (match.any_size() // 4)
+        vtable_size = 4 * (vtable_size // 4)
         orig_table = orig_bin.read(match.orig_addr, vtable_size)
 
         # Check for a gap (null pointer) in the orig vtable.

--- a/reccmp/compare/verify.py
+++ b/reccmp/compare/verify.py
@@ -10,13 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 def check_vtables(db: EntityDb):
-    """Check vtable sizes provided by the data source.
-
-    Size differences between the orig and recomp vtables are reported by the
-    vtable comparison, so they are not checked here. The only check is that a
-    user-provided orig vtable size does not extend past the next entity in the
-    binary. If it does, the size can't be right, so warn about it.
-    """
+    """Check for entities (vtables only, for now) where the known size and
+    the calculated max size are in conflict. A known size that extends past
+    the next entity in the binary can't be right, so warn about it."""
     for match in db.get_matches_by_type(EntityType.VTABLE):
         assert match.name is not None
 

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -572,33 +572,46 @@ def test_report_function_accuracy():
 def test_compare_vtable_recomp_longer():
     """An extra virtual function on the recomp side should appear in the
     diff when the orig vtable size is known."""
+    base_addr = 0x400000
     function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
     functions = function_bytes + function_bytes
 
-    vtable_addr0 = b"\x00\x00\x00\x00"
-    vtable_addr4 = b"\x04\x00\x00\x00"
+    func0_ptr = base_addr.to_bytes(4, "little")
+    func1_ptr = (base_addr + 4).to_bytes(4, "little")
 
     # Orig has one virtual function; recomp has a second one.
-    orig_mem = functions + vtable_addr0
-    recomp_mem = functions + vtable_addr0 + vtable_addr4
+    orig_mem = functions + func0_ptr
+    recomp_mem = functions + func0_ptr + func1_ptr
 
-    orig_bin = RawImage.from_memory(orig_mem)
-    recomp_bin = RawImage.from_memory(recomp_mem)
+    orig_bin = RawImage.from_memory(orig_mem, base_addr=base_addr)
+    recomp_bin = RawImage.from_memory(recomp_mem, base_addr=base_addr)
 
     pdb = Mock(spec=CvdumpAnalysis)
     compare = Compare(orig_bin, recomp_bin, pdb, "HELLO")
 
     with get_db(compare).batch() as batch:
-        batch.set(ImageId.RECOMP, 0, type=EntityType.FUNCTION, name="func0", size=1)
-        batch.set(ImageId.RECOMP, 4, type=EntityType.FUNCTION, name="func1", size=1)
-        batch.set(ImageId.ORIG, 8, type=EntityType.VTABLE, name="hello", size=4)
-        batch.set(ImageId.RECOMP, 8, type=EntityType.VTABLE, name="hello", size=8)
-        batch.match(0, 0)
-        batch.match(4, 4)
-        batch.match(8, 8)
+        batch.set(
+            ImageId.RECOMP, base_addr, type=EntityType.FUNCTION, name="func0", size=1
+        )
+        batch.set(
+            ImageId.RECOMP,
+            base_addr + 4,
+            type=EntityType.FUNCTION,
+            name="func1",
+            size=1,
+        )
+        batch.set(
+            ImageId.ORIG, base_addr + 8, type=EntityType.VTABLE, name="hello", size=4
+        )
+        batch.set(
+            ImageId.RECOMP, base_addr + 8, type=EntityType.VTABLE, name="hello", size=8
+        )
+        batch.match(base_addr, base_addr)
+        batch.match(base_addr + 4, base_addr + 4)
+        batch.match(base_addr + 8, base_addr + 8)
 
     report = to_report(compare)
-    e = report.entities[8]
+    e = report.entities[base_addr + 8]
     assert e is not None
 
     # The extra entry shows up in the diff and makes the match fail.
@@ -614,31 +627,38 @@ def test_compare_vtable_recomp_longer():
 def test_compare_vtable_recomp_trailing_padding():
     """Alignment padding after the recomp vtable should not show up in the
     diff as an extra virtual function."""
+    base_addr = 0x400000
     function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
     padding = b"\x00\x00\x00\x00"
 
-    vtable_addr0 = b"\x00\x00\x00\x00"
+    func0_ptr = base_addr.to_bytes(4, "little")
 
     # Both tables hold one virtual function followed by an alignment slot.
-    orig_mem = function_bytes + vtable_addr0 + padding
-    recomp_mem = function_bytes + vtable_addr0 + padding
+    orig_mem = function_bytes + func0_ptr + padding
+    recomp_mem = function_bytes + func0_ptr + padding
 
-    orig_bin = RawImage.from_memory(orig_mem)
-    recomp_bin = RawImage.from_memory(recomp_mem)
+    orig_bin = RawImage.from_memory(orig_mem, base_addr=base_addr)
+    recomp_bin = RawImage.from_memory(recomp_mem, base_addr=base_addr)
 
     pdb = Mock(spec=CvdumpAnalysis)
     compare = Compare(orig_bin, recomp_bin, pdb, "HELLO")
 
     with get_db(compare).batch() as batch:
-        batch.set(ImageId.RECOMP, 0, type=EntityType.FUNCTION, name="func0", size=1)
-        batch.set(ImageId.ORIG, 4, type=EntityType.VTABLE, name="hello", size=4)
+        batch.set(
+            ImageId.RECOMP, base_addr, type=EntityType.FUNCTION, name="func0", size=1
+        )
+        batch.set(
+            ImageId.ORIG, base_addr + 4, type=EntityType.VTABLE, name="hello", size=4
+        )
         # The recomp size includes the alignment padding after the table.
-        batch.set(ImageId.RECOMP, 4, type=EntityType.VTABLE, name="hello", size=8)
-        batch.match(0, 0)
-        batch.match(4, 4)
+        batch.set(
+            ImageId.RECOMP, base_addr + 4, type=EntityType.VTABLE, name="hello", size=8
+        )
+        batch.match(base_addr, base_addr)
+        batch.match(base_addr + 4, base_addr + 4)
 
     report = to_report(compare)
-    e = report.entities[4]
+    e = report.entities[base_addr + 4]
     assert e is not None
 
     # The padding is ignored, so the two tables match.
@@ -649,6 +669,12 @@ def test_compare_vtable_recomp_trailing_padding():
     assert udiff == [
         (
             "@@ -vtable0x00,1 +vtable0x00,1 @@",
-            [{"both": [("vtable0x00", "(0x0 / 0x0)  :  func0", "vtable0x00")]}],
+            [
+                {
+                    "both": [
+                        ("vtable0x00", "(0x400000 / 0x400000)  :  func0", "vtable0x00")
+                    ]
+                }
+            ],
         )
     ]

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -567,3 +567,88 @@ def test_report_function_accuracy():
         ]
     )
     assert report_function_accuracy(report) == (2, 1.5, 1.5)
+
+
+def test_compare_vtable_recomp_longer():
+    """A virtual function that exists only in recomp is still displayed in the
+    diff when we know the orig vtable's true size."""
+    function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
+    functions = function_bytes + function_bytes
+
+    vtable_addr0 = b"\x00\x00\x00\x00"
+    vtable_addr4 = b"\x04\x00\x00\x00"
+
+    # Orig has one virtual function; recomp has a second one.
+    orig_mem = functions + vtable_addr0
+    recomp_mem = functions + vtable_addr0 + vtable_addr4
+
+    orig_bin = RawImage.from_memory(orig_mem)
+    recomp_bin = RawImage.from_memory(recomp_mem)
+
+    pdb = Mock(spec=CvdumpAnalysis)
+    compare = Compare(orig_bin, recomp_bin, pdb, "HELLO")
+
+    with get_db(compare).batch() as batch:
+        batch.set(ImageId.RECOMP, 0, type=EntityType.FUNCTION, name="func0", size=1)
+        batch.set(ImageId.RECOMP, 4, type=EntityType.FUNCTION, name="func1", size=1)
+        batch.set(ImageId.ORIG, 8, type=EntityType.VTABLE, name="hello", size=4)
+        batch.set(ImageId.RECOMP, 8, type=EntityType.VTABLE, name="hello", size=8)
+        batch.match(0, 0)
+        batch.match(4, 4)
+        batch.match(8, 8)
+
+    report = to_report(compare)
+    e = report.entities[8]
+    assert e is not None
+
+    # The extra entry is displayed and costs us the match.
+    assert e.accuracy != 1.0
+
+    udiff = get_udiff(e)
+    assert udiff is not None
+    rendered = repr(udiff)
+    assert "vtable0x04" in rendered
+    assert "func1" in rendered
+
+
+def test_compare_vtable_recomp_trailing_padding():
+    """The recomp size may over-count the table by a trailing alignment slot.
+    That slot is not a virtual function and must not appear in the diff."""
+    function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
+    padding = b"\x00\x00\x00\x00"
+
+    vtable_addr0 = b"\x00\x00\x00\x00"
+
+    # Both tables hold one virtual function followed by an alignment slot.
+    orig_mem = function_bytes + vtable_addr0 + padding
+    recomp_mem = function_bytes + vtable_addr0 + padding
+
+    orig_bin = RawImage.from_memory(orig_mem)
+    recomp_bin = RawImage.from_memory(recomp_mem)
+
+    pdb = Mock(spec=CvdumpAnalysis)
+    compare = Compare(orig_bin, recomp_bin, pdb, "HELLO")
+
+    with get_db(compare).batch() as batch:
+        batch.set(ImageId.RECOMP, 0, type=EntityType.FUNCTION, name="func0", size=1)
+        batch.set(ImageId.ORIG, 4, type=EntityType.VTABLE, name="hello", size=4)
+        # The recomp size takes in the alignment slot after the table.
+        batch.set(ImageId.RECOMP, 4, type=EntityType.VTABLE, name="hello", size=8)
+        batch.match(0, 0)
+        batch.match(4, 4)
+
+    report = to_report(compare)
+    e = report.entities[4]
+    assert e is not None
+
+    # The padding slot is dropped, so the two tables match.
+    assert e.accuracy == 1.0
+
+    udiff = get_udiff(e)
+    assert udiff is not None
+    assert udiff == [
+        (
+            "@@ -vtable0x00,1 +vtable0x00,1 @@",
+            [{"both": [("vtable0x00", "(0x0 / 0x0)  :  func0", "vtable0x00")]}],
+        )
+    ]

--- a/tests/test_compare_output.py
+++ b/tests/test_compare_output.py
@@ -570,8 +570,8 @@ def test_report_function_accuracy():
 
 
 def test_compare_vtable_recomp_longer():
-    """A virtual function that exists only in recomp is still displayed in the
-    diff when we know the orig vtable's true size."""
+    """An extra virtual function on the recomp side should appear in the
+    diff when the orig vtable size is known."""
     function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
     functions = function_bytes + function_bytes
 
@@ -601,7 +601,7 @@ def test_compare_vtable_recomp_longer():
     e = report.entities[8]
     assert e is not None
 
-    # The extra entry is displayed and costs us the match.
+    # The extra entry shows up in the diff and makes the match fail.
     assert e.accuracy != 1.0
 
     udiff = get_udiff(e)
@@ -612,8 +612,8 @@ def test_compare_vtable_recomp_longer():
 
 
 def test_compare_vtable_recomp_trailing_padding():
-    """The recomp size may over-count the table by a trailing alignment slot.
-    That slot is not a virtual function and must not appear in the diff."""
+    """Alignment padding after the recomp vtable should not show up in the
+    diff as an extra virtual function."""
     function_bytes = b"\xc3\x00\x00\x00"  # `ret` padded to 4 bytes
     padding = b"\x00\x00\x00\x00"
 
@@ -632,7 +632,7 @@ def test_compare_vtable_recomp_trailing_padding():
     with get_db(compare).batch() as batch:
         batch.set(ImageId.RECOMP, 0, type=EntityType.FUNCTION, name="func0", size=1)
         batch.set(ImageId.ORIG, 4, type=EntityType.VTABLE, name="hello", size=4)
-        # The recomp size takes in the alignment slot after the table.
+        # The recomp size includes the alignment padding after the table.
         batch.set(ImageId.RECOMP, 4, type=EntityType.VTABLE, name="hello", size=8)
         batch.match(0, 0)
         batch.match(4, 4)
@@ -641,7 +641,7 @@ def test_compare_vtable_recomp_trailing_padding():
     e = report.entities[4]
     assert e is not None
 
-    # The padding slot is dropped, so the two tables match.
+    # The padding is ignored, so the two tables match.
     assert e.accuracy == 1.0
 
     udiff = get_udiff(e)

--- a/tests/test_compare_verify.py
+++ b/tests/test_compare_verify.py
@@ -1,7 +1,5 @@
 """Tests for the entity problem checks in compare/verify.py (check_vtables)."""
 
-import struct
-from unittest.mock import Mock
 import pytest
 from reccmp.types import EntityType, ImageId
 from reccmp.compare.db import EntityDb
@@ -11,13 +9,6 @@ from reccmp.compare.verify import check_vtables
 @pytest.fixture(name="db")
 def fixture_db() -> EntityDb:
     return EntityDb()
-
-
-def stub_image(table: bytes) -> Mock:
-    """Stub binary whose read() serves a window into the given vtable bytes."""
-    image = Mock()
-    image.read = lambda addr, size: table[addr : addr + size]
-    return image
 
 
 def set_vtable_match(
@@ -45,39 +36,13 @@ def set_vtable_match(
         batch.match(0, 0)
 
 
-def test_known_orig_size_ignores_recomp_padding(db, caplog):
-    """The recomp size may over-count the table by a trailing alignment slot.
-    That slot is not a virtual function, so it must not be reported as one."""
+def test_size_difference_not_warned(db, caplog):
+    """A recomp vtable larger than orig is not reported here: the difference
+    shows up in the regular vtable comparison. (Warning dropped on review.)"""
     set_vtable_match(db, orig_size=8, recomp_size=12)
-    # Two real entries, then the alignment slot. Both tables are identical.
-    table = struct.pack("<3L", 0x1000, 0x2000, 0)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
-
-    assert "is larger than orig vtable" not in caplog.text
-
-
-def test_known_orig_size_reports_real_extra_entry(db, caplog):
-    """A non-null pointer past the end of the orig table is a virtual function
-    that orig does not have, and is still reported."""
-    set_vtable_match(db, orig_size=8, recomp_size=12)
-    orig_table = struct.pack("<3L", 0x1000, 0x2000, 0)
-    recomp_table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
-
-    with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(orig_table), stub_image(recomp_table))
-
-    assert "is larger than orig vtable" in caplog.text
-
-
-def test_known_orig_size_equal_sizes_no_warning(db, caplog):
-    """Nothing to report when the two sizes agree."""
-    set_vtable_match(db, orig_size=8, recomp_size=8)
-    table = struct.pack("<2L", 0x1000, 0x2000)
-
-    with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
+        check_vtables(db)
 
     assert not caplog.text
 
@@ -87,46 +52,18 @@ def test_known_orig_size_conflicts_with_upper_bound(db, caplog):
     correct. That is a problem with the data source, not a size difference, so
     it is reported as its own thing."""
     set_vtable_match(db, orig_size=12, recomp_size=12, orig_max_size=8)
-    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
+        check_vtables(db)
 
     assert "overruns the next entity" in caplog.text
-    assert "is larger than orig vtable" not in caplog.text
 
 
-def test_unknown_orig_size_max_size_heuristic(db, caplog):
-    """Without an orig size, the next-entity upper bound heuristic still
-    applies to the recomp size."""
-    set_vtable_match(db, recomp_size=12, orig_max_size=8)
-    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
-
-    with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
-
-    assert "is larger than orig vtable" in caplog.text
-
-
-def test_unknown_orig_size_null_scan_heuristic(db, caplog):
-    """Without an orig size, a null pointer inside the recomp-sized window
-    still marks the recomp vtable as larger."""
+def test_unknown_orig_size_no_warning(db, caplog):
+    """Without an orig size there is nothing to validate."""
     set_vtable_match(db, recomp_size=16)
-    table = struct.pack("<4L", 0x1000, 0x2000, 0, 0)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
+        check_vtables(db)
 
-    assert "is larger than orig vtable" in caplog.text
-
-
-def test_unknown_orig_size_clean_table_no_warning(db, caplog):
-    """Without an orig size, a table with no nulls inside the window and a
-    roomy upper bound is not reported."""
-    set_vtable_match(db, recomp_size=12, orig_max_size=16)
-    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
-
-    with caplog.at_level("WARNING"):
-        check_vtables(db, stub_image(table), stub_image(table))
-
-    assert "is larger than orig vtable" not in caplog.text
+    assert not caplog.text

--- a/tests/test_compare_verify.py
+++ b/tests/test_compare_verify.py
@@ -13,11 +13,11 @@ def fixture_db() -> EntityDb:
     return EntityDb()
 
 
-def orig_bin_with_table(table: bytes) -> Mock:
-    """Stub binary whose read() serves a window into the given orig vtable bytes."""
-    orig_bin = Mock()
-    orig_bin.read = lambda addr, size: table[:size]
-    return orig_bin
+def stub_image(table: bytes) -> Mock:
+    """Stub binary whose read() serves a window into the given vtable bytes."""
+    image = Mock()
+    image.read = lambda addr, size: table[addr : addr + size]
+    return image
 
 
 def set_vtable_match(
@@ -29,7 +29,7 @@ def set_vtable_match(
     with db.batch() as batch:
         batch.set(
             ImageId.ORIG,
-            100,
+            0,
             name="Pet::`vftable'",
             type=EntityType.VTABLE,
             size=orig_size,
@@ -37,39 +37,63 @@ def set_vtable_match(
         )
         batch.set(
             ImageId.RECOMP,
-            500,
+            0,
             name="Pet::`vftable'",
             type=EntityType.VTABLE,
             size=recomp_size,
         )
-        batch.match(100, 500)
+        batch.match(0, 0)
 
 
-def test_known_orig_size_overrules_recomp_estimate(db, caplog):
-    """The recomp size is an estimate (next-symbol distance or section
-    contribution) that may include trailing alignment padding. A known orig
-    size must take priority so the padding bytes after the true table are
-    never scanned for null pointers."""
-    set_vtable_match(db, orig_size=8, recomp_size=16)
-    # Two real entries, then null alignment padding after the table.
-    table = struct.pack("<4L", 0x1000, 0x2000, 0, 0)
+def test_known_orig_size_ignores_recomp_padding(db, caplog):
+    """The recomp size may over-count the table by a trailing alignment slot.
+    That slot is not a virtual function, so it must not be reported as one."""
+    set_vtable_match(db, orig_size=8, recomp_size=12)
+    # Two real entries, then the alignment slot. Both tables are identical.
+    table = struct.pack("<3L", 0x1000, 0x2000, 0)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, orig_bin_with_table(table))
+        check_vtables(db, stub_image(table), stub_image(table))
 
     assert "is larger than orig vtable" not in caplog.text
 
 
+def test_known_orig_size_reports_real_extra_entry(db, caplog):
+    """A non-null pointer past the end of the orig table is a virtual function
+    that orig does not have, and is still reported."""
+    set_vtable_match(db, orig_size=8, recomp_size=12)
+    orig_table = struct.pack("<3L", 0x1000, 0x2000, 0)
+    recomp_table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, stub_image(orig_table), stub_image(recomp_table))
+
+    assert "is larger than orig vtable" in caplog.text
+
+
+def test_known_orig_size_equal_sizes_no_warning(db, caplog):
+    """Nothing to report when the two sizes agree."""
+    set_vtable_match(db, orig_size=8, recomp_size=8)
+    table = struct.pack("<2L", 0x1000, 0x2000)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, stub_image(table), stub_image(table))
+
+    assert not caplog.text
+
+
 def test_known_orig_size_conflicts_with_upper_bound(db, caplog):
-    """A supplied orig size that exceeds the next-entity upper bound is
-    still reported."""
+    """A supplied orig size that exceeds the next-entity upper bound cannot be
+    correct. That is a problem with the data source, not a size difference, so
+    it is reported as its own thing."""
     set_vtable_match(db, orig_size=12, recomp_size=12, orig_max_size=8)
     table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, orig_bin_with_table(table))
+        check_vtables(db, stub_image(table), stub_image(table))
 
-    assert "is larger than orig vtable" in caplog.text
+    assert "overruns the next entity" in caplog.text
+    assert "is larger than orig vtable" not in caplog.text
 
 
 def test_unknown_orig_size_max_size_heuristic(db, caplog):
@@ -79,7 +103,7 @@ def test_unknown_orig_size_max_size_heuristic(db, caplog):
     table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, orig_bin_with_table(table))
+        check_vtables(db, stub_image(table), stub_image(table))
 
     assert "is larger than orig vtable" in caplog.text
 
@@ -91,7 +115,7 @@ def test_unknown_orig_size_null_scan_heuristic(db, caplog):
     table = struct.pack("<4L", 0x1000, 0x2000, 0, 0)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, orig_bin_with_table(table))
+        check_vtables(db, stub_image(table), stub_image(table))
 
     assert "is larger than orig vtable" in caplog.text
 
@@ -103,6 +127,6 @@ def test_unknown_orig_size_clean_table_no_warning(db, caplog):
     table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
 
     with caplog.at_level("WARNING"):
-        check_vtables(db, orig_bin_with_table(table))
+        check_vtables(db, stub_image(table), stub_image(table))
 
     assert "is larger than orig vtable" not in caplog.text

--- a/tests/test_compare_verify.py
+++ b/tests/test_compare_verify.py
@@ -1,0 +1,108 @@
+"""Tests for the entity problem checks in compare/verify.py (check_vtables)."""
+
+import struct
+from unittest.mock import Mock
+import pytest
+from reccmp.types import EntityType, ImageId
+from reccmp.compare.db import EntityDb
+from reccmp.compare.verify import check_vtables
+
+
+@pytest.fixture(name="db")
+def fixture_db() -> EntityDb:
+    return EntityDb()
+
+
+def orig_bin_with_table(table: bytes) -> Mock:
+    """Stub binary whose read() serves a window into the given orig vtable bytes."""
+    orig_bin = Mock()
+    orig_bin.read = lambda addr, size: table[:size]
+    return orig_bin
+
+
+def set_vtable_match(
+    db: EntityDb,
+    orig_size: int | None = None,
+    recomp_size: int | None = None,
+    orig_max_size: int | None = None,
+):
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Pet::`vftable'",
+            type=EntityType.VTABLE,
+            size=orig_size,
+            max_size=orig_max_size,
+        )
+        batch.set(
+            ImageId.RECOMP,
+            500,
+            name="Pet::`vftable'",
+            type=EntityType.VTABLE,
+            size=recomp_size,
+        )
+        batch.match(100, 500)
+
+
+def test_known_orig_size_overrules_recomp_estimate(db, caplog):
+    """The recomp size is an estimate (next-symbol distance or section
+    contribution) that may include trailing alignment padding. A known orig
+    size must take priority so the padding bytes after the true table are
+    never scanned for null pointers."""
+    set_vtable_match(db, orig_size=8, recomp_size=16)
+    # Two real entries, then null alignment padding after the table.
+    table = struct.pack("<4L", 0x1000, 0x2000, 0, 0)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, orig_bin_with_table(table))
+
+    assert "is larger than orig vtable" not in caplog.text
+
+
+def test_known_orig_size_conflicts_with_upper_bound(db, caplog):
+    """A supplied orig size that exceeds the next-entity upper bound is
+    still reported."""
+    set_vtable_match(db, orig_size=12, recomp_size=12, orig_max_size=8)
+    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, orig_bin_with_table(table))
+
+    assert "is larger than orig vtable" in caplog.text
+
+
+def test_unknown_orig_size_max_size_heuristic(db, caplog):
+    """Without an orig size, the next-entity upper bound heuristic still
+    applies to the recomp size."""
+    set_vtable_match(db, recomp_size=12, orig_max_size=8)
+    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, orig_bin_with_table(table))
+
+    assert "is larger than orig vtable" in caplog.text
+
+
+def test_unknown_orig_size_null_scan_heuristic(db, caplog):
+    """Without an orig size, a null pointer inside the recomp-sized window
+    still marks the recomp vtable as larger."""
+    set_vtable_match(db, recomp_size=16)
+    table = struct.pack("<4L", 0x1000, 0x2000, 0, 0)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, orig_bin_with_table(table))
+
+    assert "is larger than orig vtable" in caplog.text
+
+
+def test_unknown_orig_size_clean_table_no_warning(db, caplog):
+    """Without an orig size, a table with no nulls inside the window and a
+    roomy upper bound is not reported."""
+    set_vtable_match(db, recomp_size=12, orig_max_size=16)
+    table = struct.pack("<3L", 0x1000, 0x2000, 0x3000)
+
+    with caplog.at_level("WARNING"):
+        check_vtables(db, orig_bin_with_table(table))
+
+    assert "is larger than orig vtable" not in caplog.text

--- a/tests/test_compare_verify.py
+++ b/tests/test_compare_verify.py
@@ -37,8 +37,7 @@ def set_vtable_match(
 
 
 def test_size_difference_not_warned(db, caplog):
-    """A recomp vtable larger than orig is not reported here: the difference
-    shows up in the regular vtable comparison. (Warning dropped on review.)"""
+    """Size differences are reported by the vtable comparison, not here."""
     set_vtable_match(db, orig_size=8, recomp_size=12)
 
     with caplog.at_level("WARNING"):
@@ -48,9 +47,8 @@ def test_size_difference_not_warned(db, caplog):
 
 
 def test_known_orig_size_conflicts_with_upper_bound(db, caplog):
-    """A supplied orig size that exceeds the next-entity upper bound cannot be
-    correct. That is a problem with the data source, not a size difference, so
-    it is reported as its own thing."""
+    """Warn if the orig vtable size from the data source extends past the
+    next entity. A size like that can't be right."""
     set_vtable_match(db, orig_size=12, recomp_size=12, orig_max_size=8)
 
     with caplog.at_level("WARNING"):
@@ -60,7 +58,7 @@ def test_known_orig_size_conflicts_with_upper_bound(db, caplog):
 
 
 def test_unknown_orig_size_no_warning(db, caplog):
-    """Without an orig size there is nothing to validate."""
+    """No orig size means there is nothing to check."""
     set_vtable_match(db, recomp_size=16)
 
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
The recomp vtable size is an estimate (next-symbol distance or section contribution, per SymbolNode.size()) that may include trailing alignment padding. When check_vtables reads the orig vtable through that window, the padding bytes after the true table scan as null pointers and produce false 'recomp vtable is larger' warnings. A data source can supply the orig vtable's true size; prefer it via any_size(ImageId.ORIG) in check_vtables and _compare_vtable. Behavior is unchanged when no orig size is available (any_size falls back to the recomp size).

Measured on an MSVC 7.0 target driven by CSV data sources: 32 of 32 'recomp vtable is larger' warnings were this false positive.