### PR TITLE
Make MSVC symbol truncation dependent on reported conversion in TYPES section of PDB

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -163,8 +163,9 @@ class Compare:
         load_data_sources(self._db, self.data_sources)
 
         # Match using PDB and annotation data
-        match_symbols(self._db, self.report, truncate=True)
-        match_functions(self._db, self.report, truncate=True)
+        truncate = self.cvdump_analysis.truncate_symbols
+        match_symbols(self._db, self.report, truncate=truncate)
+        match_functions(self._db, self.report, truncate=truncate)
         match_vtables(self._db, self.report)
         match_static_variables(self._db, self.report)
         match_variables(self._db, self.report)

--- a/reccmp/cvdump/analysis.py
+++ b/reccmp/cvdump/analysis.py
@@ -147,11 +147,12 @@ class CvdumpAnalysis:
     @property
     def truncate_symbols(self) -> bool:
         """Whether symbol names in this PDB are truncated to 255 characters.
-        This is a limitation of the original design of MSVC 4.x-era PDBs
-        (see C4786); on later toolchains truncating makes distinct long
-        symbols collide and produces arbitrary non-unique matches. If the
-        TYPES section was not dumped we cannot tell, so assume truncation
-        and keep the historical behavior."""
+
+        MSVC 4.x-era PDBs truncate long symbol names (see C4786). Later
+        toolchains don't, and truncating their names anyway can make
+        different long symbols collide and match incorrectly. If the TYPES
+        section was not dumped, we can't tell the PDB version, so assume
+        truncation, which matches the old behavior."""
         return self.parser.is_16bit_type_pool is not False
 
     def __init__(self, parser: CvdumpParser):

--- a/reccmp/cvdump/analysis.py
+++ b/reccmp/cvdump/analysis.py
@@ -147,10 +147,11 @@ class CvdumpAnalysis:
     @property
     def truncate_symbols(self) -> bool:
         """Whether symbol names in this PDB are truncated to 255 characters.
-        This is a quirk of MSVC 4.x-era PDBs (see C4786); on later toolchains
-        truncating makes distinct long symbols collide and produces arbitrary
-        non-unique matches. If the TYPES section was not dumped we cannot tell,
-        so assume truncation and keep the historical behavior."""
+        This is a limitation of the original design of MSVC 4.x-era PDBs
+        (see C4786); on later toolchains truncating makes distinct long
+        symbols collide and produces arbitrary non-unique matches. If the
+        TYPES section was not dumped we cannot tell, so assume truncation
+        and keep the historical behavior."""
         return self.parser.is_16bit_type_pool is not False
 
     def __init__(self, parser: CvdumpParser):

--- a/reccmp/cvdump/analysis.py
+++ b/reccmp/cvdump/analysis.py
@@ -144,6 +144,15 @@ class CvdumpAnalysis:
     parser: CvdumpParser
     lines: dict[PureWindowsPath, list[LineValue]]
 
+    @property
+    def truncate_symbols(self) -> bool:
+        """Whether symbol names in this PDB are truncated to 255 characters.
+        This is a quirk of MSVC 4.x-era PDBs (see C4786); on later toolchains
+        truncating makes distinct long symbols collide and produces arbitrary
+        non-unique matches. If the TYPES section was not dumped we cannot tell,
+        so assume truncation and keep the historical behavior."""
+        return self.parser.is_16bit_type_pool is not False
+
     def __init__(self, parser: CvdumpParser):
         """Read in as much information as we have from the parser.
         The more sections we have, the better our information will be."""

--- a/reccmp/cvdump/parser.py
+++ b/reccmp/cvdump/parser.py
@@ -124,8 +124,8 @@ class CvdumpParser:
         self.symbols_parser = CvdumpSymbolsParser()
 
         self.is_16bit_type_pool: bool | None = None
-        """Whether the PDB has a 16-bit type pool, which identifies an MSVC 4.x-era
-        PDB. None if the TYPES section was not dumped, so we could not tell."""
+        """Whether the PDB has a 16-bit type pool (an MSVC 4.x-era PDB).
+        None if there was no TYPES section to check."""
 
     @property
     def symbols(self) -> list[SymbolsEntry]:

--- a/reccmp/cvdump/parser.py
+++ b/reccmp/cvdump/parser.py
@@ -38,6 +38,12 @@ _data_regex = re.compile(
 # e.g. 0004 "C:\work\lego-island\isle\3rdparty\smartheap\SHLW32MT.LIB" "check.obj"
 _module_regex = re.compile(r"(?P<id>\w{4})(?: \"(?P<lib>.+?)\")?(?: \"(?P<obj>.+?)\")")
 
+# cvdump prints this at the top of the TYPES section when the PDB has a 16-bit
+# type pool (TPI header version <= impv41), which identifies an MSVC 4.x-era PDB.
+# https://github.com/microsoft/microsoft-pdb/blob/805655a/cvdump/dumppdb.cpp#L244-L246
+# https://github.com/microsoft/microsoft-pdb/blob/805655a/PDB/dbi/tpi.cpp#L321-L324
+_CONVERT_16BIT_TYPES_MESSAGE = "*** Converting 16-bit types to 32-bit equivalents"
+
 
 class LinesEntry(NamedTuple):
     """User functions only"""
@@ -116,6 +122,10 @@ class CvdumpParser:
 
         self.types = CvdumpTypesParser()
         self.symbols_parser = CvdumpSymbolsParser()
+
+        self.is_16bit_type_pool: bool | None = None
+        """Whether the PDB has a 16-bit type pool, which identifies an MSVC 4.x-era
+        PDB. None if the TYPES section was not dumped, so we could not tell."""
 
     @property
     def symbols(self) -> list[SymbolsEntry]:
@@ -200,6 +210,7 @@ class CvdumpParser:
 
     def read_section(self, name: str, section: str):
         if name == "TYPES":
+            self.is_16bit_type_pool = _CONVERT_16BIT_TYPES_MESSAGE in section
             self.types.read_all(section)
 
         elif name == "SYMBOLS":

--- a/tests/test_cvdump_sections.py
+++ b/tests/test_cvdump_sections.py
@@ -1,6 +1,5 @@
-"""Tests for parsing the overall structure of cvdump text: how the output
-splits into sections, and the flags derived from section content — here, the
-16-bit type pool marker that decides the symbol truncation policy."""
+"""Tests for splitting cvdump output into sections, and for the 16-bit
+type pool marker that controls symbol truncation."""
 
 from reccmp.cvdump.parser import CvdumpParser
 from reccmp.cvdump.analysis import CvdumpAnalysis
@@ -20,9 +19,8 @@ TYPES_32BIT = """
 
 
 def test_16bit_type_pool_truncates():
-    """A TYPES section that opens with the 16-bit conversion message marks an
-    MSVC 4.x-era PDB, whose symbol names are truncated at 255 characters. Both
-    the parser flag and the derived truncation policy must reflect that."""
+    """The 16-bit conversion message means this is an MSVC 4.x-era PDB,
+    so symbol names are truncated at 255 characters."""
     parser = CvdumpParser()
     parser.read_section("TYPES", TYPES_16BIT)
 
@@ -31,10 +29,9 @@ def test_16bit_type_pool_truncates():
 
 
 def test_32bit_type_pool_does_not_truncate():
-    """A TYPES section without the 16-bit conversion message means the type
-    pool is already 32-bit and symbol names are not truncated at 255
-    characters. Truncating them anyway would make distinct long symbols
-    collide and produce arbitrary non-unique matches."""
+    """Without the conversion message, the type pool is 32-bit and symbol
+    names are not truncated. Truncating anyway could make different long
+    symbols collide and match incorrectly."""
     parser = CvdumpParser()
     parser.read_section("TYPES", TYPES_32BIT)
 
@@ -43,9 +40,9 @@ def test_32bit_type_pool_does_not_truncate():
 
 
 def test_no_types_section_assumes_truncation():
-    """Cvdump output with no TYPES section carries no evidence about the type
-    pool either way, so the parser reports None and the analysis falls back to
-    truncating symbol names — the historical behavior."""
+    """With no TYPES section we can't tell the PDB version. The parser
+    reports None and the analysis assumes truncation, which matches the
+    old behavior."""
     parser = CvdumpParser()
 
     assert parser.is_16bit_type_pool is None
@@ -53,10 +50,10 @@ def test_no_types_section_assumes_truncation():
 
 
 def test_converting_message_does_not_split_a_new_section():
-    """The 16-bit conversion message begins with three asterisks, just like a
-    section header. It must not start a new section: iter_cvdump_sections has
-    to keep it inside the body of the TYPES section, both so the split into
-    sections stays correct and so the parser can see the message at all."""
+    """The 16-bit conversion message starts with three asterisks, like a
+    section header. iter_cvdump_sections should keep it inside the TYPES
+    section body instead of starting a new section there, otherwise the
+    parser never sees the message."""
     stdout = [
         "\n",
         "*** TYPES\n",

--- a/tests/test_cvdump_sections.py
+++ b/tests/test_cvdump_sections.py
@@ -1,6 +1,6 @@
-"""Detecting whether a PDB truncates symbol names to 255 characters.
-This is a quirk of MSVC 4.x-era PDBs, which cvdump announces by converting
-the 16-bit type pool at the top of the TYPES section."""
+"""Tests for parsing the overall structure of cvdump text: how the output
+splits into sections, and the flags derived from section content — here, the
+16-bit type pool marker that decides the symbol truncation policy."""
 
 from reccmp.cvdump.parser import CvdumpParser
 from reccmp.cvdump.analysis import CvdumpAnalysis
@@ -20,7 +20,9 @@ TYPES_32BIT = """
 
 
 def test_16bit_type_pool_truncates():
-    """An MSVC 4.x-era PDB truncates symbol names."""
+    """A TYPES section that opens with the 16-bit conversion message marks an
+    MSVC 4.x-era PDB, whose symbol names are truncated at 255 characters. Both
+    the parser flag and the derived truncation policy must reflect that."""
     parser = CvdumpParser()
     parser.read_section("TYPES", TYPES_16BIT)
 
@@ -29,8 +31,10 @@ def test_16bit_type_pool_truncates():
 
 
 def test_32bit_type_pool_does_not_truncate():
-    """A later toolchain does not, so truncating there would make distinct
-    long symbols collide."""
+    """A TYPES section without the 16-bit conversion message means the type
+    pool is already 32-bit and symbol names are not truncated at 255
+    characters. Truncating them anyway would make distinct long symbols
+    collide and produce arbitrary non-unique matches."""
     parser = CvdumpParser()
     parser.read_section("TYPES", TYPES_32BIT)
 
@@ -39,18 +43,20 @@ def test_32bit_type_pool_does_not_truncate():
 
 
 def test_no_types_section_assumes_truncation():
-    """Without the TYPES section we cannot tell, so keep the historical
-    behavior rather than guess."""
+    """Cvdump output with no TYPES section carries no evidence about the type
+    pool either way, so the parser reports None and the analysis falls back to
+    truncating symbol names — the historical behavior."""
     parser = CvdumpParser()
 
     assert parser.is_16bit_type_pool is None
     assert CvdumpAnalysis(parser).truncate_symbols is True
 
 
-def test_message_belongs_to_the_types_section():
-    """The message begins with three asterisks like a section header does, but
-    it is not one. It must land in the body of the TYPES section so that the
-    parser can see it."""
+def test_converting_message_does_not_split_a_new_section():
+    """The 16-bit conversion message begins with three asterisks, just like a
+    section header. It must not start a new section: iter_cvdump_sections has
+    to keep it inside the body of the TYPES section, both so the split into
+    sections stays correct and so the parser can see the message at all."""
     stdout = [
         "\n",
         "*** TYPES\n",

--- a/tests/test_cvdump_symbol_truncation.py
+++ b/tests/test_cvdump_symbol_truncation.py
@@ -10,12 +10,12 @@ from reccmp.cvdump.runner import iter_cvdump_sections
 TYPES_16BIT = """
 *** Converting 16-bit types to 32-bit equivalents
 
-0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
 """
 
 # The same for a PDB whose type pool is already 32-bit.
 TYPES_32BIT = """
-0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
 """
 
 
@@ -57,7 +57,7 @@ def test_message_belongs_to_the_types_section():
         "\n",
         "*** Converting 16-bit types to 32-bit equivalents\n",
         "\n",
-        "0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1\n",
+        "0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0\n",
         "\n",
         "*** SYMBOLS\n",
         "\n",

--- a/tests/test_cvdump_symbol_truncation.py
+++ b/tests/test_cvdump_symbol_truncation.py
@@ -1,0 +1,75 @@
+"""Detecting whether a PDB truncates symbol names to 255 characters.
+This is a quirk of MSVC 4.x-era PDBs, which cvdump announces by converting
+the 16-bit type pool at the top of the TYPES section."""
+
+from reccmp.cvdump.parser import CvdumpParser
+from reccmp.cvdump.analysis import CvdumpAnalysis
+from reccmp.cvdump.runner import iter_cvdump_sections
+
+# The first lines of the TYPES section for an MSVC 4.x-era PDB.
+TYPES_16BIT = """
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1
+"""
+
+# The same for a PDB whose type pool is already 32-bit.
+TYPES_32BIT = """
+0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1
+"""
+
+
+def test_16bit_type_pool_truncates():
+    """An MSVC 4.x-era PDB truncates symbol names."""
+    parser = CvdumpParser()
+    parser.read_section("TYPES", TYPES_16BIT)
+
+    assert parser.is_16bit_type_pool is True
+    assert CvdumpAnalysis(parser).truncate_symbols is True
+
+
+def test_32bit_type_pool_does_not_truncate():
+    """A later toolchain does not, so truncating there would make distinct
+    long symbols collide."""
+    parser = CvdumpParser()
+    parser.read_section("TYPES", TYPES_32BIT)
+
+    assert parser.is_16bit_type_pool is False
+    assert CvdumpAnalysis(parser).truncate_symbols is False
+
+
+def test_no_types_section_assumes_truncation():
+    """Without the TYPES section we cannot tell, so keep the historical
+    behavior rather than guess."""
+    parser = CvdumpParser()
+
+    assert parser.is_16bit_type_pool is None
+    assert CvdumpAnalysis(parser).truncate_symbols is True
+
+
+def test_message_belongs_to_the_types_section():
+    """The message begins with three asterisks like a section header does, but
+    it is not one. It must land in the body of the TYPES section so that the
+    parser can see it."""
+    stdout = [
+        "\n",
+        "*** TYPES\n",
+        "\n",
+        "*** Converting 16-bit types to 32-bit equivalents\n",
+        "\n",
+        "0x1000 : Length = 14, Leaf = 0x1201 LF_ARGLIST argument count = 1\n",
+        "\n",
+        "*** SYMBOLS\n",
+        "\n",
+    ]
+
+    sections = dict(iter_cvdump_sections(stdout))
+
+    assert sorted(sections) == ["SYMBOLS", "TYPES"]
+    assert "Converting 16-bit types" in sections["TYPES"]
+
+    parser = CvdumpParser()
+    for name, section in sections.items():
+        parser.read_section(name, section)
+
+    assert parser.is_16bit_type_pool is True


### PR DESCRIPTION
Compare.run() hardcoded truncate=True for match_symbols and match_functions. The 255-character truncation is a quirk of MSVC 4.x-era PDBs (C4786); on later toolchains it makes distinct long symbols collide and produces arbitrary non-unique matches. Add a truncate-symbols option to the project file target schema (default true, preserving current behavior) and plumb it through RecCmpTarget to Compare.