### PR TITLE
First round of exhaustive parser tests

### DIFF
--- a/reccmp/parser/error.py
+++ b/reccmp/parser/error.py
@@ -57,6 +57,18 @@ class AlertCode(Enum):
     # WARN: The alias does not point to a valid marker type and has no effect.
     ALIAS_GOES_NOWHERE = 114
 
+    # WARN: A nameref annotation used different marker types.
+    # e.g. SYNTHETIC + FUNCTION
+    VARYING_MARKER_TYPES = 115
+
+    # WARN: Each line in the marker block must have the same tab stops
+    # as the completion token.
+    MARKER_NOT_ALIGNED = 116
+
+    # WARN: Each line in the marker block must have the same number of slashes.
+    # If this is a nameref, the completion token must also match.
+    VARYING_SLASH_DEPTH = 117
+
     # This code or higher is an error, not a warning
     DECOMP_ERROR_START = 200
 

--- a/tests/parser_helpers.py
+++ b/tests/parser_helpers.py
@@ -1,0 +1,119 @@
+"""Helpers for testing the C++ code parser."""
+
+import enum
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+
+
+class AnnotationType(enum.Enum):
+    LINE = enum.auto()
+    NAME = enum.auto()
+
+
+# fmt: off
+# Every marker type that can be completed by a code token.
+# Invalid patterns are commented.
+LINE_ANNOTATIONS = (
+    (MarkerType.FUNCTION,  AnnotationType.LINE),
+    (MarkerType.STUB,      AnnotationType.LINE),
+    (MarkerType.GLOBAL,    AnnotationType.LINE),
+    (MarkerType.STRING,    AnnotationType.LINE),
+    (MarkerType.VTABLE,    AnnotationType.LINE),
+    # (MarkerType.SYNTHETIC, AnnotationType.LINE),
+    # (MarkerType.TEMPLATE,  AnnotationType.LINE),
+    # (MarkerType.LIBRARY,   AnnotationType.LINE),
+)
+# fmt: on
+
+# fmt: off
+# Every marker type that can be completed by a comment token.
+# Invalid patterns are commented.
+NAME_ANNOTATIONS = (
+    (MarkerType.FUNCTION,  AnnotationType.NAME),
+    # (MarkerType.STUB,      AnnotationType.NAME),
+    (MarkerType.GLOBAL,    AnnotationType.NAME),
+    (MarkerType.STRING,    AnnotationType.NAME),
+    (MarkerType.VTABLE,    AnnotationType.NAME),
+    (MarkerType.SYNTHETIC, AnnotationType.NAME),
+    (MarkerType.TEMPLATE,  AnnotationType.NAME),
+    (MarkerType.LIBRARY,   AnnotationType.NAME),
+)
+# fmt: on
+
+# All accepted marker type and completion token patterns.
+VALID_ANNOTATIONS = (
+    *LINE_ANNOTATIONS,
+    *NAME_ANNOTATIONS,
+)
+
+
+_FUNCTION_TOKEN = "void function_one() {}"
+_VARIABLE_TOKEN = 'char* g_variable = "hello";'
+_VTABLE_TOKEN = "class Test {};"
+
+
+_CODE_COMPLETION_TOKENS = {
+    MarkerType.FUNCTION: _FUNCTION_TOKEN,
+    MarkerType.STUB: _FUNCTION_TOKEN,
+    MarkerType.GLOBAL: _VARIABLE_TOKEN,
+    MarkerType.STRING: _VARIABLE_TOKEN,
+    MarkerType.VTABLE: _VTABLE_TOKEN,
+    # MarkerType.SYNTHETIC: _FUNCTION_TOKEN,
+    # MarkerType.TEMPLATE: _FUNCTION_TOKEN,
+    # MarkerType.LIBRARY: _FUNCTION_TOKEN,
+}
+
+
+_FUNCTION_NAME = "Test::Function"
+_VARIABLE_NAME = "g_variable"
+_STRING_NAME = '"hello world"'
+_VTABLE_NAME = "class Test"
+
+
+_COMMENT_COMPLETION_TEXT = {
+    MarkerType.FUNCTION: _FUNCTION_NAME,
+    # MarkerType.STUB: _FUNCTION_NAME,
+    MarkerType.GLOBAL: _VARIABLE_NAME,
+    MarkerType.STRING: _STRING_NAME,
+    MarkerType.VTABLE: _VTABLE_NAME,
+    MarkerType.SYNTHETIC: _FUNCTION_NAME,
+    MarkerType.TEMPLATE: _FUNCTION_NAME,
+    MarkerType.LIBRARY: _FUNCTION_NAME,
+}
+
+
+def completion_token(
+    marker_type: MarkerType,
+    annotation_type: AnnotationType,
+    *,
+    slashes: str = "//",
+) -> str:
+    """Returns an example code line or comment that is
+    compatible with the given marker type.
+    NAME annotations can use an alternate slash prefix."""
+    if annotation_type == AnnotationType.NAME:
+        return f"{slashes} {_COMMENT_COMPLETION_TEXT[marker_type]}"
+
+    return _CODE_COMPLETION_TOKENS[marker_type]
+
+
+def sorted_alerts(parser: DecompParser) -> list[tuple[AlertCode, int]]:
+    """Helper to assert the count of parser warnings and errors along
+    with the specific line numbers and alert types (codes).
+    The order is not really important because reccmp-decomplint
+    applies this same sort before displaying the alert messages."""
+    alerts = ((a.code, a.line_number) for a in parser.alerts)
+    return sorted(alerts, key=lambda alert: (alert[1], alert[0].value))
+
+
+def symbol_tuples(parser: DecompParser) -> list[tuple[MarkerType, str, int]]:
+    """Returns (marker_type, reccmp_target, address) of each marker captured by the parser.
+    This is intended for tests that parametrize on VALID_ANNOTATIONS to assert that
+    we have accepted or rejected the markers in the code sample."""
+    return [(s.type, s.module, s.offset) for s in parser.iter_symbols()]
+
+
+def xfail_param(*value, reason: str = ""):
+    return pytest.param(*value, marks=pytest.mark.xfail(reason=reason))

--- a/tests/test_parser_common_alias.py
+++ b/tests/test_parser_common_alias.py
@@ -1,0 +1,133 @@
+"""The parser accepts aliases to built-in marker types, scoped by target.
+The alias behaves exactly the same as the original marker type.
+The original marker type can still be used.
+"""
+
+from textwrap import dedent
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+from .parser_helpers import (
+    AnnotationType,
+    VALID_ANNOTATIONS,
+    completion_token,
+    sorted_alerts,
+    symbol_tuples,
+)
+
+ALIAS_NAME = "ALIAS"
+"""n.b. The alias string has already been normalized by normalize_project_aliases()
+by this point, so it must be upper-case."""
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_no_aliases(marker_type: MarkerType, annotation_type: AnnotationType):
+    """Warns about an unrecognized marker regardless of completion token."""
+    parser = DecompParser()
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured nothing.
+    assert not symbol_tuples(parser)
+
+    # Warning for the unknown marker type.
+    assert sorted_alerts(parser) == [(AlertCode.UNKNOWN_ANNOTATION, 1)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_alias(marker_type: MarkerType, annotation_type: AnnotationType):
+    """Accepts an alias for all valid annotation types."""
+    parser = DecompParser(aliases={"TEST": {ALIAS_NAME: marker_type.name}})
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    # The alias does not persist beyond the parsing step.
+    # By all accounts, this is whatever marker type was aliased.
+    assert symbol_tuples(parser) == [(marker_type, "TEST", 0x1234)]
+
+    # No warnings.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_alias_and_original(marker_type: MarkerType, annotation_type: AnnotationType):
+    """Accepts both the alias and the original marker type."""
+    parser = DecompParser(aliases={"TEST": {ALIAS_NAME: marker_type.name}})
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+
+        // {marker_type.name}: TEST 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "TEST", 0x5555),
+    ]
+
+    # No warnings.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_alias_not_exact_syntax(
+    marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns when an alias does not match expected syntax."""
+    parser = DecompParser(aliases={"TEST": {ALIAS_NAME: marker_type.name}})
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME.lower()}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [(marker_type, "TEST", 0x1234)]
+
+    # Syntax warning.
+    assert sorted_alerts(parser) == [(AlertCode.NOT_STRICT_FORMAT, 1)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_alias_other_target(marker_type: MarkerType, annotation_type: AnnotationType):
+    """Ignores an alias that belongs to a different target."""
+    parser = DecompParser(aliases={"TEST": {ALIAS_NAME: marker_type.name}})
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME}: TEST 0x1234
+        // {ALIAS_NAME}: HELLO 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured markers for the "TEST" target.
+    assert symbol_tuples(parser) == [(marker_type, "TEST", 0x1234)]
+
+    # Warning for the "HELLO" target which does not have an alias.
+    assert sorted_alerts(parser) == [(AlertCode.UNKNOWN_ANNOTATION, 2)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_alias_chain(marker_type: MarkerType, annotation_type: AnnotationType):
+    """Does not follow an alias that points at another alias."""
+    parser = DecompParser(
+        aliases={"TEST": {"HELLO": ALIAS_NAME, ALIAS_NAME: marker_type.name}}
+    )
+    parser.read(dedent(f"""\
+        // {ALIAS_NAME}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+
+        // HELLO: TEST 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured only the marker that aliased the built-in type.
+    assert symbol_tuples(parser) == [(marker_type, "TEST", 0x1234)]
+
+    # Warning for the double alias marker.
+    assert sorted_alerts(parser) == [(AlertCode.UNKNOWN_ANNOTATION, 4)]

--- a/tests/test_parser_common_alignment.py
+++ b/tests/test_parser_common_alignment.py
@@ -1,0 +1,265 @@
+"""All lines in a marker sequence must have the same indent level using the
+same whitespace characters.
+
+If there is any disagreement, record AlertCode.MARKER_NOT_ALIGNED for each line.
+"""
+
+from textwrap import dedent
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+from .parser_helpers import (
+    AnnotationType,
+    VALID_ANNOTATIONS,
+    completion_token,
+    sorted_alerts,
+    symbol_tuples,
+)
+
+
+@pytest.fixture(name="parser")
+def fixture_parser() -> DecompParser:
+    return DecompParser()
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_aligned(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Does not warn for single marker aligned to completion token."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # No warning.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_aligned_indented(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Does not warn for single marker aligned to completion token
+    when both are indented."""
+    parser.read(dedent(f"""\
+        class Test {{
+            // {marker_type.name}: TEST 0x1234
+            {completion_token(marker_type, annotation_type)}
+        }};
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # No warning.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_group_aligned(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Does not warn for marker group aligned to completion token."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # No warning.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_group_aligned_indented(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Does not warn for marker group aligned to completion token
+    when all lines are indented."""
+    parser.read(dedent(f"""\
+        class Test {{
+            // {marker_type.name}: TEST 0x1234
+            // {marker_type.name}: HELLO 0x5555
+            {completion_token(marker_type, annotation_type)}
+        }};
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # No warning.
+    assert not parser.alerts
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_not_aligned(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a single marker not aligned to the completion token."""
+    parser.read(dedent(f"""\
+          // {marker_type.name}: TEST 0x1234
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 1),
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+    ]
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_not_aligned_indented(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a single marker not aligned to the completion token
+    when both are indented to different levels."""
+    parser.read(dedent(f"""\
+        class Outer {{
+            // {marker_type.name}: TEST 0x1234
+          {completion_token(marker_type, annotation_type)}
+        }};
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+        (AlertCode.MARKER_NOT_ALIGNED, 3),
+    ]
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_mixed_whitespace(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns when the marker and completion token have a different whitespace
+    prefix using the same number of characters."""
+    parser.read(dedent(f"""\
+        class Outer {{
+         // {marker_type.name}: TEST 0x1234
+        \t{completion_token(marker_type, annotation_type)}
+        }};
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+        (AlertCode.MARKER_NOT_ALIGNED, 3),
+    ]
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_group_first_not_aligned(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a marker group where the first line differs from
+    the second and final lines."""
+    parser.read(dedent(f"""\
+          // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 1),
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+        (AlertCode.MARKER_NOT_ALIGNED, 3),
+    ]
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_group_second_not_aligned(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a marker group where the second line differs from
+    the first and final lines."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+          // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 1),
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+        (AlertCode.MARKER_NOT_ALIGNED, 3),
+    ]
+
+
+@pytest.mark.xfail(reason="The parser does not check alignment.")
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_group_not_aligned_to_token(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a marker group where the final line differs from
+    the first and second lines."""
+    parser.read(dedent(f"""\
+          // {marker_type.name}: TEST 0x1234
+          // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Warning for each line in the sequence.
+    assert sorted_alerts(parser) == [
+        (AlertCode.MARKER_NOT_ALIGNED, 1),
+        (AlertCode.MARKER_NOT_ALIGNED, 2),
+        (AlertCode.MARKER_NOT_ALIGNED, 3),
+    ]

--- a/tests/test_parser_common_blank_lines.py
+++ b/tests/test_parser_common_blank_lines.py
@@ -1,0 +1,119 @@
+"""Each blank line in a marker group results in an AlertCode.UNEXPECTED_BLANK_LINE warning."""
+
+from textwrap import dedent
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+from .parser_helpers import (
+    AnnotationType,
+    VALID_ANNOTATIONS,
+    completion_token,
+    sorted_alerts,
+    symbol_tuples,
+    xfail_param,
+)
+
+
+@pytest.fixture(name="parser")
+def fixture_parser() -> DecompParser:
+    return DecompParser()
+
+
+# fmt: off
+TEST_CASES = [
+    (MarkerType.FUNCTION, AnnotationType.LINE),
+    (MarkerType.STUB,     AnnotationType.LINE),
+    (MarkerType.GLOBAL,   AnnotationType.LINE),
+    (MarkerType.STRING,   AnnotationType.LINE),
+    xfail_param(MarkerType.VTABLE,   AnnotationType.LINE),
+    #
+    (MarkerType.FUNCTION,  AnnotationType.NAME),
+    (MarkerType.GLOBAL,    AnnotationType.NAME),
+    (MarkerType.STRING,    AnnotationType.NAME),
+    xfail_param(MarkerType.VTABLE,    AnnotationType.NAME),
+    xfail_param(MarkerType.SYNTHETIC, AnnotationType.NAME),
+    xfail_param(MarkerType.TEMPLATE,  AnnotationType.NAME),
+    xfail_param(MarkerType.LIBRARY,   AnnotationType.NAME),
+]
+# fmt: on
+
+
+# Sanity check: remove after xfails are resolved
+# and replace the parameter list with VALID_ANNOTATIONS.
+if len(TEST_CASES) != len(VALID_ANNOTATIONS):
+    pytest.fail(
+        "Local TEST_CASES does not shadow VALID_ANNOTATIONS",
+    )
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", TEST_CASES)
+def test_blanks_between_markers(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a blank line between markers in a group."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+
+        // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # One warning for the blank line.
+    assert sorted_alerts(parser) == [(AlertCode.UNEXPECTED_BLANK_LINE, 2)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", TEST_CASES)
+def test_blanks_after_markers(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for a blank line between the last marker in a group and the completion token."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # One warning for the blank line.
+    assert sorted_alerts(parser) == [(AlertCode.UNEXPECTED_BLANK_LINE, 2)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", TEST_CASES)
+def test_multiple_blanks(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Warns for every blank line in a marker sequence, even if they are contiguous."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+
+
+        // {marker_type.name}: HELLO 0x5555
+
+
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # One warning for each blank line.
+    assert sorted_alerts(parser) == [
+        (AlertCode.UNEXPECTED_BLANK_LINE, 2),
+        (AlertCode.UNEXPECTED_BLANK_LINE, 3),
+        (AlertCode.UNEXPECTED_BLANK_LINE, 5),
+        (AlertCode.UNEXPECTED_BLANK_LINE, 6),
+    ]

--- a/tests/test_parser_common_duplicate_target.py
+++ b/tests/test_parser_common_duplicate_target.py
@@ -1,0 +1,141 @@
+"""If a marker type is repeated for a target in a marker group,
+reject all duplicate markers with an AlertCode.DUPLICATE_MODULE error.
+Only the first marker is accepted.
+
+This does not test cases where GLOBAL, STRING, and LINE markers can be combined.
+
+This does not test cases where the various function markers are combined.
+"""
+
+from textwrap import dedent
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+from .parser_helpers import (
+    AnnotationType,
+    VALID_ANNOTATIONS,
+    completion_token,
+    sorted_alerts,
+    symbol_tuples,
+)
+
+
+@pytest.fixture(name="parser")
+def fixture_parser() -> DecompParser:
+    return DecompParser()
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_same_type_different_target(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Accepts markers of the same type from different targets."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captures only the first marker.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # No errors.
+    assert not parser.alerts
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_same_type_same_target(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Rejects markers of the same type and target that repeat in a marker group."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: TEST 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captures only the first marker.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Rejects the duplicate marker with an error.
+    assert sorted_alerts(parser) == [(AlertCode.DUPLICATE_MODULE, 2)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_same_type_same_target_repeated(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Rejects all markers that repeat the type and target of a marker
+    earlier in the group."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: TEST 0x5555
+        // {marker_type.name}: TEST 0x9999
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captures only the first marker.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Rejects all duplicate markers with an error.
+    assert sorted_alerts(parser) == [
+        (AlertCode.DUPLICATE_MODULE, 2),
+        (AlertCode.DUPLICATE_MODULE, 3),
+    ]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_same_type_same_target_non_contiguous(
+    parser: DecompParser, marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Rejects markers of the same type and target that repeat in a marker group
+    even if they are not on consecutive lines."""
+    parser.read(dedent(f"""\
+        // {marker_type.name}: TEST 0x1234
+        // {marker_type.name}: HELLO 0x5555
+        // {marker_type.name}: TEST 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captures only the first marker.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Rejects the duplicate marker with an error.
+    assert sorted_alerts(parser) == [(AlertCode.DUPLICATE_MODULE, 3)]
+
+
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_aliased_type_same_target(
+    marker_type: MarkerType, annotation_type: AnnotationType
+):
+    """Rejects markers of the same type and target that repeat in a marker group
+    even when the first marker uses an alias of the duplicated marker types."""
+    parser = DecompParser(aliases={"TEST": {"ALIAS": marker_type.name}})
+    parser.read(dedent(f"""\
+        // ALIAS: TEST 0x1234
+        // {marker_type.name}: TEST 0x5555
+        // {marker_type.name}: TEST 0x9999
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captures only the first marker.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+    ]
+
+    # Rejects all duplicate markers with an error.
+    assert sorted_alerts(parser) == [
+        (AlertCode.DUPLICATE_MODULE, 2),
+        (AlertCode.DUPLICATE_MODULE, 3),
+    ]

--- a/tests/test_parser_common_slashes.py
+++ b/tests/test_parser_common_slashes.py
@@ -1,0 +1,142 @@
+"""All lines in a marker sequence must have the same number of frontslash
+characters, including the completion token for a nameref annotation.
+
+If there is any disagreement, record AlertCode.VARYING_SLASH_DEPTH for each comment line.
+"""
+
+from textwrap import dedent
+import pytest
+from reccmp.parser.parser import DecompParser
+from reccmp.parser.error import AlertCode
+from reccmp.parser.marker import MarkerType
+from .parser_helpers import (
+    AnnotationType,
+    LINE_ANNOTATIONS,
+    NAME_ANNOTATIONS,
+    VALID_ANNOTATIONS,
+    completion_token,
+    sorted_alerts,
+    symbol_tuples,
+    xfail_param,
+)
+
+
+@pytest.fixture(name="parser")
+def fixture_parser() -> DecompParser:
+    return DecompParser()
+
+
+SLASH_VARIANTS = [
+    "//",
+    xfail_param("///", reason="Not identified as marker."),
+    xfail_param("////", reason="Not identified as marker."),
+]
+
+
+@pytest.mark.parametrize("slashes", SLASH_VARIANTS)
+@pytest.mark.parametrize("marker_type, annotation_type", VALID_ANNOTATIONS)
+def test_slash_agreement(
+    parser: DecompParser,
+    marker_type: MarkerType,
+    annotation_type: AnnotationType,
+    slashes: str,
+):
+    """Markers and completion tokens can have more than two slashes
+    if all lines have the same number."""
+    parser.read(dedent(f"""\
+        {slashes} {marker_type.name}: TEST 0x1234
+        {slashes} {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type, slashes=slashes)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # No warning.
+    assert not parser.alerts
+
+
+# fmt: off
+LINE_SLASH_VARIANTS = [
+    ("//",   "///"),
+    ("///",  "//"),
+    ("///",  "////"),
+]
+# fmt: on
+
+
+@pytest.mark.xfail(reason="The parser does not check slashes.")
+@pytest.mark.parametrize("slashes", LINE_SLASH_VARIANTS)
+@pytest.mark.parametrize("marker_type, annotation_type", LINE_ANNOTATIONS)
+def test_slash_depth_mismatch_code(
+    parser: DecompParser,
+    marker_type: MarkerType,
+    annotation_type: AnnotationType,
+    slashes: tuple[str, str],
+):
+    """The slashes for the two markers do not agree.
+    Each marker is accepted, but with a VARYING_SLASH_DEPTH warning."""
+    first, second = slashes
+    parser.read(dedent(f"""\
+        {first} {marker_type.name}: TEST 0x1234
+        {second} {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Warnings for each comment line.
+    # No warning for the code completion token.
+    assert sorted_alerts(parser) == [
+        (AlertCode.VARYING_SLASH_DEPTH, 1),
+        (AlertCode.VARYING_SLASH_DEPTH, 2),
+    ]
+
+
+# fmt: off
+NAME_SLASH_VARIANTS = [
+    ("//",  "//",  "///"),
+    ("///", "//",  "//"),
+    ("///", "//",  "////"),
+    # more?
+]
+# fmt: on
+
+
+@pytest.mark.xfail(reason="The parser does not check slashes.")
+@pytest.mark.parametrize("slashes", NAME_SLASH_VARIANTS)
+@pytest.mark.parametrize("marker_type, annotation_type", NAME_ANNOTATIONS)
+def test_slash_depth_mismatch_nameref(
+    parser: DecompParser,
+    marker_type: MarkerType,
+    annotation_type: AnnotationType,
+    slashes: tuple[str, str, str],
+):
+    """The slashes for the two markers and the completion token do not agree.
+    All three lines get a VARYING_SLASH_DEPTH warning."""
+    first, second, third = slashes
+    parser.read(dedent(f"""\
+        {first} {marker_type.name}: TEST 0x1234
+        {second} {marker_type.name}: HELLO 0x5555
+        {completion_token(marker_type, annotation_type, slashes=third)}
+        """))
+
+    # Captured all markers.
+    assert symbol_tuples(parser) == [
+        (marker_type, "TEST", 0x1234),
+        (marker_type, "HELLO", 0x5555),
+    ]
+
+    # Warnings for each comment line.
+    assert sorted_alerts(parser) == [
+        (AlertCode.VARYING_SLASH_DEPTH, 1),
+        (AlertCode.VARYING_SLASH_DEPTH, 2),
+        (AlertCode.VARYING_SLASH_DEPTH, 3),
+    ]


### PR DESCRIPTION
Part of #509. I have more items I'm trying to sort into buckets that make sense. (For example: is comment/nameref parsing simple enough to be its own module, or distributed among modules for each marker type?)

Horizontal alignment and matching slash depth aren't even checked by the current parser, but the new one will make it a lot easier to add them to our syntax reporting.

Blank lines between the marker and "completion token" (my term for the comment or code line that finishes the annotation) aren't checked for all marker types. I can fix the bug pretty easily on the current parser to remove the xfails, but we may want to wait until all these new tests are in before starting the migration.