### PR TITLE
Make `cydifflib` an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ We also have tooling to import the information from the decompilation into [Ghid
 
 We have established some [best practices](docs/recommendations.md) that have no impact on `reccmp`'s output, but have made a positive impact on the LEGO Island decompilation.
 
+[`cydifflib`](https://github.com/rapidfuzz/CyDifflib) is a drop-in replacement for Python's builtin [`difflib`](https://docs.python.org/3/library/difflib.html) module that offers better performance. If `cydifflib` is installed in the environment where you run `reccmp`, we will use it.
+
 ## Contributing
 
 Feel free to contribute to this project if you are interested! More information can be found at [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/reccmp/compare/pinned_sequences.py
+++ b/reccmp/compare/pinned_sequences.py
@@ -1,14 +1,7 @@
 from itertools import pairwise
 import itertools
-from typing import Iterable, Iterator, Sequence, TYPE_CHECKING
-from reccmp.difflib import DiffOpcode, get_grouped_opcodes
-
-# cydifflib has no type stubs, but we expect it to match the builtin difflib API exactly.
-if TYPE_CHECKING:
-    from difflib import SequenceMatcher
-else:
-    # better performance than the stock `difflib`
-    from cydifflib import SequenceMatcher
+from typing import Iterable, Iterator, Sequence
+from reccmp.difflib import DiffOpcode, SequenceMatcher, get_grouped_opcodes
 
 
 class SequenceMatcherWithPins:

--- a/reccmp/difflib.py
+++ b/reccmp/difflib.py
@@ -1,6 +1,20 @@
 """Wrappers and items related to the builtin python difflib module."""
 
-from typing import Literal, Iterator
+from typing import Literal, Iterator, TYPE_CHECKING
+
+# `cydifflib` is a drop-in replacement for the builtin `difflib` that has
+# better performance. This was previously a required dependency (GH #477)
+# but it is now used only if we can import it.
+if TYPE_CHECKING:
+    # cydifflib has no type stubs, but we expect it to match
+    # the builtin difflib API exactly.
+    from difflib import SequenceMatcher
+else:
+    try:
+        from cydifflib import SequenceMatcher
+    except ImportError:
+        from difflib import SequenceMatcher
+
 
 DiffTag = Literal["delete", "equal", "insert", "replace"]
 DiffOpcode = tuple[DiffTag, int, int, int, int]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pydantic==2.13.4
 ruamel.yaml==0.19.1
 pydemumble==0.0.1
 pyghidra==3.1.0
-cydifflib==1.2.0


### PR DESCRIPTION
Fixes #515. pyproject.toml [supports optional dependencies](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies), so if we fully migrate to that, it might make sense to have a "performance" feature set.