### PR TITLE
roadmap.py: use csv.writer for CSV export instead of a bare join

### DIFF
--- a/reccmp/tools/roadmap.py
+++ b/reccmp/tools/roadmap.py
@@ -8,6 +8,7 @@ in the original binary.
 
 import argparse
 import bisect
+import csv
 import logging
 import os
 from pathlib import Path
@@ -356,12 +357,11 @@ def export_to_csv(csv_file: str, results: list[RoadmapRow]):
     }
     csv_header = list(header_renames.get(f, f) for f in RoadmapRow._fields)
 
-    with open(csv_file, "w+", encoding="utf-8") as f:
-        f.write(",".join(csv_header))
-        f.write("\n")
+    with open(csv_file, "w+", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(csv_header)
         for row in results:
-            f.write(",".join(map(or_blank, row)))
-            f.write("\n")
+            writer.writerow(list(map(or_blank, row)))
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_tools_roadmap.py
+++ b/tests/test_tools_roadmap.py
@@ -1,12 +1,4 @@
-"""Testing the reccmp-roadmap tool's CSV export.
-
-Regression coverage for the unquoted-comma bug: `export_to_csv` used to build
-each line with a bare `",".join(...)`, so any field containing a comma (most
-commonly `name`, for a multi-argument template symbol like
-`set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >`) produced a row with extra
-columns once read back. In this project that silently invented dozens of fake
-"modules" on the very first parse of a real dump.
-"""
+"""Tests for the reccmp-roadmap tool's CSV export."""
 
 import csv
 
@@ -28,15 +20,8 @@ def _make_row(name: str, module: str = "LEGO1/define.cpp") -> RoadmapRow:
 
 
 def test_export_to_csv_quotes_field_with_comma(tmp_path):
-    """A field containing a comma (as in a multi-argument template symbol)
-    must be quoted so a CSV reader recovers the original column count.
-
-    Mutation proof: reverting `export_to_csv` to
-    `f.write(",".join(map(or_blank, row)))` makes this fail two ways -- the
-    row-back-in has more than `len(RoadmapRow._fields)` columns (the comma
-    inside `name` gets read as two extra delimiters), and the recovered
-    `name`/`module` values no longer match what was written.
-    """
+    """A field with a comma in it (like a multi-argument template symbol)
+    has to be quoted so a CSV reader gets the original columns back."""
     template_name = "set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >"
     row = _make_row(name=template_name)
 
@@ -69,8 +54,8 @@ def test_export_to_csv_quotes_field_with_comma(tmp_path):
 
 
 def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
-    """A comma-bearing field on one row must not shift the columns of
-    subsequent rows once read back."""
+    """A comma in one row shouldn't shift the columns of the rows after
+    it."""
     rows = [
         _make_row(name="foo<A,B>", module="ONE/a.cpp"),
         _make_row(name="bar", module="TWO/b.cpp"),
@@ -91,8 +76,8 @@ def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
 
 
 def test_export_to_csv_no_special_characters_unaffected(tmp_path):
-    """Plain values without commas/quotes still round-trip exactly
-    (no unwanted quoting introduced for the common case)."""
+    """Values without commas or quotes round-trip unchanged. The common
+    case gets no extra quoting."""
     row = _make_row(name="FUN_1000abcd", module="LEGO1/define.cpp")
 
     csv_file = tmp_path / "roadmap.csv"

--- a/tests/test_tools_roadmap.py
+++ b/tests/test_tools_roadmap.py
@@ -1,6 +1,7 @@
 """Tests for the reccmp-roadmap tool's CSV export."""
 
 import csv
+from pathlib import Path
 
 from reccmp.tools.roadmap import RoadmapRow, export_to_csv
 
@@ -19,38 +20,27 @@ def _make_row(name: str, module: str = "LEGO1/define.cpp") -> RoadmapRow:
     )
 
 
+def _write_and_read_back(tmp_path: Path, rows: list[RoadmapRow]) -> list[dict]:
+    """Export the rows to a CSV file, then parse the file back into a list
+    of dicts keyed by the header columns."""
+    csv_file = tmp_path / "roadmap.csv"
+    export_to_csv(str(csv_file), rows)
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
 def test_export_to_csv_quotes_field_with_comma(tmp_path):
     """A field with a comma in it (like a multi-argument template symbol)
     has to be quoted so a CSV reader gets the original columns back."""
     template_name = "set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >"
     row = _make_row(name=template_name)
 
-    csv_file = tmp_path / "roadmap.csv"
-    export_to_csv(str(csv_file), [row])
+    parsed = _write_and_read_back(tmp_path, [row])
 
-    with open(csv_file, newline="", encoding="utf-8") as f:
-        reader = csv.reader(f)
-        header = next(reader)
-        data_row = next(reader)
-
-        # No further rows: a mis-split row here would otherwise bleed into
-        # (and corrupt the column count of) whatever came next.
-        assert next(reader, None) is None
-
-    assert header == [
-        "orig_sect_ofs",
-        "recomp_sect_ofs",
-        "orig_addr",
-        "recomp_addr",
-        "displacement",
-        "row_type",
-        "size",
-        "name",
-        "module",
-    ]
-    assert len(data_row) == len(RoadmapRow._fields)
-    assert data_row[header.index("name")] == template_name
-    assert data_row[header.index("module")] == "LEGO1/define.cpp"
+    assert len(parsed) == 1
+    assert parsed[0]["name"] == template_name
+    assert parsed[0]["module"] == "LEGO1/define.cpp"
 
 
 def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
@@ -61,12 +51,7 @@ def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
         _make_row(name="bar", module="TWO/b.cpp"),
     ]
 
-    csv_file = tmp_path / "roadmap.csv"
-    export_to_csv(str(csv_file), rows)
-
-    with open(csv_file, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        parsed = list(reader)
+    parsed = _write_and_read_back(tmp_path, rows)
 
     assert len(parsed) == 2
     assert parsed[0]["name"] == "foo<A,B>"
@@ -76,16 +61,11 @@ def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
 
 
 def test_export_to_csv_no_special_characters_unaffected(tmp_path):
-    """Values without commas or quotes round-trip unchanged. The common
-    case gets no extra quoting."""
+    """Values with no comma or quote in them (the common case) come back
+    from the parser exactly as they went in."""
     row = _make_row(name="FUN_1000abcd", module="LEGO1/define.cpp")
 
-    csv_file = tmp_path / "roadmap.csv"
-    export_to_csv(str(csv_file), [row])
-
-    with open(csv_file, newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        parsed = list(reader)
+    parsed = _write_and_read_back(tmp_path, [row])
 
     assert parsed == [
         {

--- a/tests/test_tools_roadmap.py
+++ b/tests/test_tools_roadmap.py
@@ -1,0 +1,117 @@
+"""Testing the reccmp-roadmap tool's CSV export.
+
+Regression coverage for the unquoted-comma bug: `export_to_csv` used to build
+each line with a bare `",".join(...)`, so any field containing a comma (most
+commonly `name`, for a multi-argument template symbol like
+`set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >`) produced a row with extra
+columns once read back. In this project that silently invented dozens of fake
+"modules" on the very first parse of a real dump.
+"""
+
+import csv
+
+from reccmp.tools.roadmap import RoadmapRow, export_to_csv
+
+
+def _make_row(name: str, module: str = "LEGO1/define.cpp") -> RoadmapRow:
+    return RoadmapRow(
+        orig_sect_ofs="0001:00001000",
+        recomp_sect_ofs="0001:00001000",
+        orig_addr=0x1000,
+        recomp_addr=0x1000,
+        displacement=0,
+        sym_type="fun",
+        size=16,
+        name=name,
+        module=module,
+    )
+
+
+def test_export_to_csv_quotes_field_with_comma(tmp_path):
+    """A field containing a comma (as in a multi-argument template symbol)
+    must be quoted so a CSV reader recovers the original column count.
+
+    Mutation proof: reverting `export_to_csv` to
+    `f.write(",".join(map(or_blank, row)))` makes this fail two ways -- the
+    row-back-in has more than `len(RoadmapRow._fields)` columns (the comma
+    inside `name` gets read as two extra delimiters), and the recovered
+    `name`/`module` values no longer match what was written.
+    """
+    template_name = "set<MxAtom *,MxAtomCompare,allocator<MxAtom *> >"
+    row = _make_row(name=template_name)
+
+    csv_file = tmp_path / "roadmap.csv"
+    export_to_csv(str(csv_file), [row])
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        data_row = next(reader)
+
+        # No further rows: a mis-split row here would otherwise bleed into
+        # (and corrupt the column count of) whatever came next.
+        assert next(reader, None) is None
+
+    assert header == [
+        "orig_sect_ofs",
+        "recomp_sect_ofs",
+        "orig_addr",
+        "recomp_addr",
+        "displacement",
+        "row_type",
+        "size",
+        "name",
+        "module",
+    ]
+    assert len(data_row) == len(RoadmapRow._fields)
+    assert data_row[header.index("name")] == template_name
+    assert data_row[header.index("module")] == "LEGO1/define.cpp"
+
+
+def test_export_to_csv_multiple_rows_stay_aligned(tmp_path):
+    """A comma-bearing field on one row must not shift the columns of
+    subsequent rows once read back."""
+    rows = [
+        _make_row(name="foo<A,B>", module="ONE/a.cpp"),
+        _make_row(name="bar", module="TWO/b.cpp"),
+    ]
+
+    csv_file = tmp_path / "roadmap.csv"
+    export_to_csv(str(csv_file), rows)
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        parsed = list(reader)
+
+    assert len(parsed) == 2
+    assert parsed[0]["name"] == "foo<A,B>"
+    assert parsed[0]["module"] == "ONE/a.cpp"
+    assert parsed[1]["name"] == "bar"
+    assert parsed[1]["module"] == "TWO/b.cpp"
+
+
+def test_export_to_csv_no_special_characters_unaffected(tmp_path):
+    """Plain values without commas/quotes still round-trip exactly
+    (no unwanted quoting introduced for the common case)."""
+    row = _make_row(name="FUN_1000abcd", module="LEGO1/define.cpp")
+
+    csv_file = tmp_path / "roadmap.csv"
+    export_to_csv(str(csv_file), [row])
+
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        parsed = list(reader)
+
+    assert parsed == [
+        {
+            "orig_sect_ofs": "0001:00001000",
+            "recomp_sect_ofs": "0001:00001000",
+            "orig_addr": "0x1000",
+            "recomp_addr": "0x1000",
+            "displacement": "0x0",
+            "row_type": "fun",
+            "size": "0x10",
+            "name": "FUN_1000abcd",
+            "module": "LEGO1/define.cpp",
+        }
+    ]


### PR DESCRIPTION
`export_to_csv` wrote each row with `','.join()` and no quoting. C++ symbol names can contain literal commas — any multi-parameter template instantiation (`std::set<Foo *,FooCompare,std::allocator<Foo *> >`) or demangled multi-argument signature — so on read-back a CSV parser cannot tell the name's commas from column delimiters, and every column after the symbol shifts.

Switch to stdlib `csv.writer` with the file opened `newline=''`, matching the reader-side convention already used in `reccmp/compare/csv.py`. Fields without delimiters are written unchanged, so comma-free output is byte-identical to before.

Verified with a round-trip test (`tests/test_tools_roadmap.py`): under the previous join, a row carrying a two-parameter template name reads back as 11 columns instead of 9 and the symbol value truncates at its first comma; with `csv.writer` both round-trip intact.