### PR TITLE
Allow `RawImage` test helper to set a base addr

### DIFF
--- a/tests/raw_image.py
+++ b/tests/raw_image.py
@@ -18,20 +18,32 @@ class RawImage(Image):
     size: int
     """Total size of the image including physical bytes (`data` property) and uninitialized memory."""
 
+    base_addr: int
+    """The starting virtual address in the image. (Equivalent to PE imagebase)"""
+
     @classmethod
-    def from_memory(cls, data: bytes = b"", *, bss: int = 0) -> "RawImage":
+    def from_memory(
+        cls, data: bytes = b"", *, base_addr: int = 0, bss: int = 0
+    ) -> "RawImage":
         """Creates the image's memory in this order:
         1. Physical bytes from the `data` parameter.
         2. Zero or more bytes of uninitialized data as directed by the `bss` parameter.
+
+        Setting the optional `base_addr` parameter allows for address values that more
+        closely imitate a real image where this is needed.
         """
         assert bss >= 0
+        assert base_addr >= 0
         size = len(data) + bss
         view = memoryview(data).toreadonly()
 
-        return cls(data=data, view=view, filepath=Path(""), size=size)
+        return cls(
+            data=data, view=view, filepath=Path(""), size=size, base_addr=base_addr
+        )
 
     def seek(self, vaddr: int) -> tuple[memoryview, int]:
-        if 0 <= vaddr < self.size:
-            return (memoryview(self.data[vaddr:]), self.size - vaddr)
+        offset = vaddr - self.base_addr
+        if 0 <= offset < self.size:
+            return (memoryview(self.data[offset:]), self.size - offset)
 
         raise InvalidVirtualAddressError

--- a/tests/test_image_raw.py
+++ b/tests/test_image_raw.py
@@ -205,3 +205,23 @@ def test_string_reads(memory: bytes, expected_string: bytes, expected_widechar: 
     img = RawImage.from_memory(memory)
     assert img.read_string(0) == expected_string
     assert img.read_widechar(0) == expected_widechar
+
+
+@pytest.mark.parametrize("base_addr", (0x1000, 0x400000, 0x1000000))
+def test_base_addr(base_addr: int):
+    """`base_addr` defines the minimum address for the image.
+    Reads on addresses before `base_addr` should fail.
+    Reads on addresses after `base_addr` should work as expected."""
+    img = RawImage.from_memory(b"hello\x00", bss=10, base_addr=base_addr)
+
+    # Reads from zero (default base_addr) no longer work
+    with pytest.raises(InvalidVirtualAddressError):
+        img.read(0, 1)
+
+    assert img.read(base_addr, 1) == b"h"
+    assert img.read(base_addr + 10, 1) == b"\x00"
+    assert img.read_string(base_addr) == b"hello"
+
+    # Cannot read past the end of the image
+    with pytest.raises(InvalidVirtualAddressError):
+        img.read(base_addr + 16, 1)


### PR DESCRIPTION
This is so we can use more realistic addresses for pointers instead of small values like 0 or 4.