### PR TITLE
Use text files for cvdump samples

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,6 +44,7 @@ jobs:
             '# codespell:ignore-begin.*?codespell:ignore-end *\n' \
           --ignore-regex remote-checkin-comment \
           -L SEH \
+          -S ./tests/cvdump_sample/*.txt \
           ./reccmp ./tests
 
   js-format:

--- a/tests/cvdump_sample/__init__.py
+++ b/tests/cvdump_sample/__init__.py
@@ -1,0 +1,65 @@
+"""Helper to load cvdump `TYPES` sample data from files in this directory.
+
+Many tests need cvdump output to populate the types database, and the text for
+the `TYPES` section can span many lines. The cvinfo key of a particular type
+is also important, although it does not have any intrinsic significance.
+`load_cvdump_sample` seeks to improve the situation.
+
+Calling `load_cvdump_sample(sample_name)` will load `{sample_name}.txt` from
+this directory. The dataclass returned has a list of aliases to type keys
+used in the `TYPES` section text that follows.
+
+The expected format is:
+    1. Aliases and type keys separated by a single space.
+       Type key in hex format with 0x prefix.
+    2. Blank line.
+    3. Cvdump text from TYPES section.
+
+For example:
+    alias-1 0x1000
+    alias-2 0x1001
+
+    0x1000 : Length = 10, Leaf = 0x1002 LF_POINTER
+        ...
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from reccmp.cvdump.cvinfo import CvdumpTypeKey
+
+SAMPLE_DIR = Path(__file__).parent
+
+
+@dataclass(frozen=True)
+class CvdumpSample:
+    _aliases: dict[str, CvdumpTypeKey]
+    text: str
+
+    def key(self, alias: str) -> CvdumpTypeKey:
+        return self._aliases[alias]
+
+
+def load_cvdump_sample(name: str) -> CvdumpSample:
+    """Read a sample file from the current directory with extension `.txt`
+    matching the given name. Raise any exceptions to the caller so the
+    associated tests will fail."""
+    contents = (SAMPLE_DIR / f"{name}.txt").read_text(encoding="utf-8")
+
+    # Split aliases and cvdump text on the first blank line.
+    alias_block, delimiter, text = contents.partition("\n\n")
+    if not delimiter:
+        # No blank line found: assume there are no aliases.
+        return CvdumpSample({}, contents)
+
+    aliases = {}
+    for line in alias_block.splitlines():
+        alias, space, key = line.partition(" ")
+        if not space or " " in key:
+            raise ValueError(f"Invalid alias line in sample file '{name}': {line}")
+
+        try:
+            aliases[alias] = CvdumpTypeKey(int(key, 16))
+        except ValueError as ex:
+            raise ValueError(f"Invalid key in sample file '{name}': {line}") from ex
+
+    return CvdumpSample(aliases, text)

--- a/tests/cvdump_sample/ghidra-integration-type-imports.txt
+++ b/tests/cvdump_sample/ghidra-integration-type-imports.txt
@@ -1,0 +1,102 @@
+pointer-to-char-key 0x1199
+legoanimactor-forward-ref-key 0x12C8
+legoanimactor-pointer-key 0x12C9
+union-key 0x1480
+hwnd-key 0x3159
+array-key 0x31BB
+procedure-key 0x4EF2
+enum-with-negative-value-key 0x5696
+legoanimactor-class-key 0x6081
+enum-key 0x608F
+
+0x1199 : Length = 10, Leaf = 0x1002 LF_POINTER
+    const Pointer (NEAR32), Size: 0
+    Element type : T_RCHAR(0070)
+
+0x12c8 : Length = 42, Leaf = 0x1505 LF_STRUCTURE
+    # members = 0,  field list type 0x0000, FORWARD REF,
+    Derivation list type 0x0000, VT shape type 0x0000
+    Size = 0, class name = LegoAnimActorEntry, UDT(0x00006081)
+
+0x12c9 : Length = 10, Leaf = 0x1002 LF_POINTER
+    Pointer (NEAR32), Size: 0
+    Element type : 0x12C8
+
+0x12cd : Length = 314, Leaf = 0x1203 LF_FIELDLIST
+    list[10] = LF_MEMBER, protected, type = T_LONG(0012), offset = 8
+        member name = 'm_duration'
+    list[11] = LF_MEMBER, protected, type = 0x12C9, offset = 12
+        member name = 'm_modelList'
+    list[12] = LF_MEMBER, protected, type = T_ULONG(0022), offset = 16
+        member name = 'm_numActors'
+
+0x12cf : Length = 30, Leaf = 0x1504 LF_CLASS
+    # members = 15,  field list type 0x12cd, CONSTRUCTOR,
+    Derivation list type 0x0000, VT shape type 0x12ce
+    Size = 24, class name = LegoAnim, UDT(0x000012cf)
+
+0x147f : Length = 74, Leaf = 0x1203 LF_FIELDLIST
+    list[0] = LF_MEMBER, public, type = T_ULONG(0022), offset = 0
+        member name = 'LowPart'
+    list[1] = LF_MEMBER, public, type = T_LONG(0012), offset = 4
+        member name = 'HighPart'
+    list[2] = LF_MEMBER, public, type = 0x147E, offset = 0
+        member name = 'u'
+    list[3] = LF_MEMBER, public, type = T_QUAD(0013), offset = 0
+        member name = 'QuadPart'
+
+0x1480 : Length = 30, Leaf = 0x1506 LF_UNION
+    # members = 4,  field list type 0x147f, Size = 8    ,class name = _LARGE_INTEGER, UDT(0x00001480)
+
+0x3159 : Length = 30, Leaf = 0x1505 LF_STRUCTURE
+    # members = 0,  field list type 0x0000, FORWARD REF,
+    Derivation list type 0x0000, VT shape type 0x0000
+    Size = 0, class name = HWND__
+
+0x31bb : Length = 14, Leaf = 0x1503 LF_ARRAY
+    Element type = T_ULONG(0022)
+    Index type = T_SHORT(0011)
+    length = 16
+    Name =
+
+0x4ef1 : Length = 18, Leaf = 0x1201 LF_ARGLIST argument count = 3
+    list[0] = T_32PRCHAR(0470)
+    list[1] = T_LONG(0012)
+    list[2] = T_32PVOID(0403)
+
+0x4ef2 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+    Return type = T_VOID(0003), Call type = C Near
+    Func attr = none
+    # Parms = 3, Arg list type = 0x4ef1
+
+0x5695 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+    list[0] = LF_ENUMERATE, public, value = (LF_CHAR) -1(0xFF), name = 'c_unknownminusone'
+    list[1] = LF_ENUMERATE, public, value = 8, name = 'c_unknown8'
+
+0x5696 : Length = 42, Leaf = 0x1507 LF_ENUM
+    # members = 2,  type = T_INT4(0074) field list type 0x5695
+NESTED,     enum name = LegoCarBuild::Unknown0xf8, UDT(0x00005696)
+
+0x6080 : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+    list[1] = LF_MEMBER, public, type = T_32PRCHAR(0470), offset = 0
+        member name = 'm_name'
+    list[2] = LF_MEMBER, public, type = T_ULONG(0022), offset = 4
+        member name = 'm_type'
+
+0x6081 : Length = 42, Leaf = 0x1505 LF_STRUCTURE
+    # members = 3,  field list type 0x6080,
+    Derivation list type 0x0000, VT shape type 0x0000
+    Size = 8, class name = LegoAnimActorEntry, UDT(0x00006081)
+
+0x608e : Length = 130, Leaf = 0x1203 LF_FIELDLIST
+    list[0] = LF_ENUMERATE, public, value = 0, name = 'c_initial'
+    list[1] = LF_ENUMERATE, public, value = 1, name = 'c_ready'
+    list[2] = LF_ENUMERATE, public, value = 2, name = 'c_hit'
+    list[3] = LF_ENUMERATE, public, value = 3, name = 'c_hitAnimation'
+    list[4] = LF_ENUMERATE, public, value = 4, name = 'c_disabled'
+    list[5] = LF_ENUMERATE, public, value = 255, name = 'c_maxState'
+    list[6] = LF_ENUMERATE, public, value = 256, name = 'c_noCollide'
+
+0x608f : Length = 42, Leaf = 0x1507 LF_ENUM
+    # members = 7,  type = T_INT4(0074) field list type 0x608e
+NESTED,     enum name = LegoPathActor::ActorState, UDT(0x0000608f)

--- a/tests/test_ghidra_integration_type_imports.py
+++ b/tests/test_ghidra_integration_type_imports.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 from reccmp.cvdump.cvinfo import CVInfoTypeEnum, CvdumpTypeKey, CvdumpTypeMap
 from reccmp.ghidra.importer.exceptions import TypeNotFoundError, TypeNotImplementedError
+from .cvdump_sample import CvdumpSample, load_cvdump_sample
 from .ghidra_integration_test_setup import GhidraTypeTestHelper
 from .helpers import assert_instance
 
@@ -17,116 +18,15 @@ if TYPE_CHECKING:
     from ghidra.program.model.data import DataType
 
 
-# Shortened version of a BETA10 recompilation
-# codespell:ignore-begin
-CVDUMP_TYPES = """
-0x1199 : Length = 10, Leaf = 0x1002 LF_POINTER
-	const Pointer (NEAR32), Size: 0
-	Element type : T_RCHAR(0070)
-
-0x12c8 : Length = 42, Leaf = 0x1505 LF_STRUCTURE
-	# members = 0,  field list type 0x0000, FORWARD REF,
-	Derivation list type 0x0000, VT shape type 0x0000
-	Size = 0, class name = LegoAnimActorEntry, UDT(0x00006081)
-
-0x12c9 : Length = 10, Leaf = 0x1002 LF_POINTER
-	Pointer (NEAR32), Size: 0
-	Element type : 0x12C8
-
-0x12cd : Length = 314, Leaf = 0x1203 LF_FIELDLIST
-    list[10] = LF_MEMBER, protected, type = T_LONG(0012), offset = 8
-		member name = 'm_duration'
-	list[11] = LF_MEMBER, protected, type = 0x12C9, offset = 12
-		member name = 'm_modelList'
-	list[12] = LF_MEMBER, protected, type = T_ULONG(0022), offset = 16
-		member name = 'm_numActors'
-
-0x12cf : Length = 30, Leaf = 0x1504 LF_CLASS
-	# members = 15,  field list type 0x12cd, CONSTRUCTOR,
-	Derivation list type 0x0000, VT shape type 0x12ce
-	Size = 24, class name = LegoAnim, UDT(0x000012cf)
-
-0x147f : Length = 74, Leaf = 0x1203 LF_FIELDLIST
-	list[0] = LF_MEMBER, public, type = T_ULONG(0022), offset = 0
-		member name = 'LowPart'
-	list[1] = LF_MEMBER, public, type = T_LONG(0012), offset = 4
-		member name = 'HighPart'
-	list[2] = LF_MEMBER, public, type = 0x147E, offset = 0
-		member name = 'u'
-	list[3] = LF_MEMBER, public, type = T_QUAD(0013), offset = 0
-		member name = 'QuadPart'
-
-0x1480 : Length = 30, Leaf = 0x1506 LF_UNION
-	# members = 4,  field list type 0x147f, Size = 8	,class name = _LARGE_INTEGER, UDT(0x00001480)
-
-0x3159 : Length = 30, Leaf = 0x1505 LF_STRUCTURE
-	# members = 0,  field list type 0x0000, FORWARD REF,
-	Derivation list type 0x0000, VT shape type 0x0000
-	Size = 0, class name = HWND__
-
-0x31bb : Length = 14, Leaf = 0x1503 LF_ARRAY
-	Element type = T_ULONG(0022)
-	Index type = T_SHORT(0011)
-	length = 16
-	Name =
-
-0x4ef1 : Length = 18, Leaf = 0x1201 LF_ARGLIST argument count = 3
-	list[0] = T_32PRCHAR(0470)
-	list[1] = T_LONG(0012)
-	list[2] = T_32PVOID(0403)
-
-0x4ef2 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
-	Return type = T_VOID(0003), Call type = C Near
-	Func attr = none
-	# Parms = 3, Arg list type = 0x4ef1
-
-0x5695 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
-	list[0] = LF_ENUMERATE, public, value = (LF_CHAR) -1(0xFF), name = 'c_unknownminusone'
-	list[1] = LF_ENUMERATE, public, value = 8, name = 'c_unknown8'
-
-0x5696 : Length = 42, Leaf = 0x1507 LF_ENUM
-	# members = 2,  type = T_INT4(0074) field list type 0x5695
-NESTED, 	enum name = LegoCarBuild::Unknown0xf8, UDT(0x00005696)
-
-0x6080 : Length = 62, Leaf = 0x1203 LF_FIELDLIST
-	list[1] = LF_MEMBER, public, type = T_32PRCHAR(0470), offset = 0
-		member name = 'm_name'
-	list[2] = LF_MEMBER, public, type = T_ULONG(0022), offset = 4
-		member name = 'm_type'
-
-0x6081 : Length = 42, Leaf = 0x1505 LF_STRUCTURE
-	# members = 3,  field list type 0x6080,
-	Derivation list type 0x0000, VT shape type 0x0000
-	Size = 8, class name = LegoAnimActorEntry, UDT(0x00006081)
-
-0x608e : Length = 130, Leaf = 0x1203 LF_FIELDLIST
-	list[0] = LF_ENUMERATE, public, value = 0, name = 'c_initial'
-	list[1] = LF_ENUMERATE, public, value = 1, name = 'c_ready'
-	list[2] = LF_ENUMERATE, public, value = 2, name = 'c_hit'
-	list[3] = LF_ENUMERATE, public, value = 3, name = 'c_hitAnimation'
-	list[4] = LF_ENUMERATE, public, value = 4, name = 'c_disabled'
-	list[5] = LF_ENUMERATE, public, value = 255, name = 'c_maxState'
-	list[6] = LF_ENUMERATE, public, value = 256, name = 'c_noCollide'
-
-0x608f : Length = 42, Leaf = 0x1507 LF_ENUM
-	# members = 7,  type = T_INT4(0074) field list type 0x608e
-NESTED, 	enum name = LegoPathActor::ActorState, UDT(0x0000608f)
-"""
-# codespell:ignore-end
-
-pointer_to_char_key = CvdumpTypeKey(0x1199)
-legoanimactor_forward_ref_key = CvdumpTypeKey(0x12C8)
-legoanimactor_pointer_key = CvdumpTypeKey(0x12C9)
-union_key = CvdumpTypeKey(0x1480)
-hwnd_key = CvdumpTypeKey(0x3159)
-array_key = CvdumpTypeKey(0x31BB)
-procedure_key = CvdumpTypeKey(0x4EF2)
-enum_with_negative_value_key = CvdumpTypeKey(0x5696)
-legoanimactor_class_key = CvdumpTypeKey(0x6081)
-enum_key = CvdumpTypeKey(0x608F)
+@pytest.fixture(name="cvdump_sample", scope="module")
+def cvdump_sample_fixture():
+    """Shortened version of a BETA10 recompilation"""
+    return load_cvdump_sample("ghidra-integration-type-imports")
 
 
 def _assert_legoanimactorentry(imported_structure: "DataType"):
+    """Helper to assert the contents of the `LegoAnimActorEntry` struct
+    used in multiple tests."""
     from ghidra.program.model.data import Structure
 
     assert isinstance(imported_structure, Structure)
@@ -152,6 +52,8 @@ verified_types = tuple(
 def test_ghidra_scalar_types(
     type_helper: GhidraTypeTestHelper, scalar_type: CVInfoTypeEnum
 ):
+    """Importing primitive (scalar) types.
+    The type database should resolve these without reading any sample data."""
     from ghidra.program.model.data import Pointer
 
     cv_type_info = CvdumpTypeMap[scalar_type]
@@ -159,28 +61,35 @@ def test_ghidra_scalar_types(
     ghidra_type = type_helper.type_importer.import_pdb_type_into_ghidra(scalar_type)
     assert ghidra_type.length == cv_type_info.size
 
+    # Make sure primitive pointer types are recognized as such.
     if cv_type_info.pointer is not None:
         assert isinstance(ghidra_type, Pointer)
 
+    # Repeating the import does not create a duplicate type in Ghidra's database.
     second_import = type_helper.type_importer.import_pdb_type_into_ghidra(scalar_type)
     assert second_import == ghidra_type
 
 
 def test_ghidra_type_not_found(type_helper: GhidraTypeTestHelper):
+    """Should raise `TypeNotFoundError` if the type key does not exist in our type database."""
     with pytest.raises(TypeNotFoundError, match="Failed to find referenced type"):
         type_helper.type_importer.import_pdb_type_into_ghidra(CvdumpTypeKey(0x1001))
 
 
-def test_ghidra_type_class(type_helper: GhidraTypeTestHelper):
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
-    imported_structure = type_helper.type_importer.import_pdb_type_into_ghidra(
-        legoanimactor_class_key
-    )
+def test_ghidra_type_class(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing `LegoAnimActorEntry`, a struct with no virtual functions."""
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("legoanimactor-class-key")
+
+    imported_structure = type_helper.type_importer.import_pdb_type_into_ghidra(key)
+
+    # Make sure the imported type matches the expected struct.
     _assert_legoanimactorentry(imported_structure)
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(
-        legoanimactor_class_key
-    )
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_structure
 
 
@@ -189,32 +98,49 @@ def test_ghidra_verify_test_isolation(ghidra: "FlatProgramAPI"):
     assert not list(ghidra.getDataTypes("LegoAnimActorEntry"))
 
 
-def test_ghidra_forward_ref_to_pdb_type(type_helper: GhidraTypeTestHelper):
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
-    imported_structure = type_helper.type_importer.import_pdb_type_into_ghidra(
-        legoanimactor_forward_ref_key
-    )
+def test_ghidra_forward_ref_to_pdb_type(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing a cvdump leaf with a forward reference to another leaf in the text."""
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("legoanimactor-forward-ref-key")
+
+    imported_structure = type_helper.type_importer.import_pdb_type_into_ghidra(key)
+
+    # Make sure the imported type matches the expected struct.
     _assert_legoanimactorentry(imported_structure)
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(
-        legoanimactor_forward_ref_key
-    )
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_structure
 
 
-def test_forward_ref_to_missing_type(type_helper: GhidraTypeTestHelper):
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+def test_forward_ref_to_missing_type(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing a cvdump leaf with a forward reference that is unresolved in the text.
+    We have seen this with `HWND__` in real data, so we use that in the example.
+    In this case, `HWND__` does not already exist, so it is impossible to complete the import.
+    """
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("hwnd-key")
 
     with pytest.raises(
         TypeNotImplementedError,
         match="forward ref without target, needs to be created manually:",
     ):
-        type_helper.type_importer.import_pdb_type_into_ghidra(hwnd_key)
+        type_helper.type_importer.import_pdb_type_into_ghidra(key)
 
 
 def test_forward_ref_to_pre_existing_type(
-    ghidra: "FlatProgramAPI", type_helper: GhidraTypeTestHelper
+    ghidra: "FlatProgramAPI",
+    type_helper: GhidraTypeTestHelper,
+    cvdump_sample: CvdumpSample,
 ):
+    """Importing a cvdump leaf with a forward reference that is unresolved in the text.
+    We have seen this with `HWND__` in real data, so we use that in the example.
+    In this case, we create `HWND__` manually so the forward reference can be completed.
+    """
     data_type_manager = ghidra.getCurrentProgram().getDataTypeManager()
     from ghidra.program.model.data import (
         TypedefDataType,
@@ -222,62 +148,82 @@ def test_forward_ref_to_pre_existing_type(
         DataTypeConflictHandler,
     )
 
+    # Make sure `HWND__` exists in Ghidra before importing the cvdump type.
     hwnd = data_type_manager.addDataType(
         TypedefDataType("HWND__", VoidDataType()), DataTypeConflictHandler.KEEP_HANDLER
     )
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("hwnd-key")
 
-    imported_hwnd = type_helper.type_importer.import_pdb_type_into_ghidra(hwnd_key)
+    # The type imported by the forward reference should match the type we created manually.
+    imported_hwnd = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert imported_hwnd == hwnd
 
 
-def test_ghidra_pointer_to_class(type_helper: GhidraTypeTestHelper):
+def test_ghidra_pointer_to_class(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing `LegoAnimActorEntry*`, which also creates `LegoAnimActorEntry`."""
     from ghidra.program.model.data import Pointer
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("legoanimactor-pointer-key")
+
+    # Ghidra recognized it as a pointer.
     imported_pointer = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(
-            legoanimactor_pointer_key
-        ),
+        type_helper.type_importer.import_pdb_type_into_ghidra(key),
         Pointer,
     )
+
+    # The struct was also imported and our pointer points at it.
     _assert_legoanimactorentry(imported_pointer.dataType)
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(
-        legoanimactor_pointer_key
-    )
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_pointer
 
 
-def test_pointer_to_scalar(type_helper: GhidraTypeTestHelper):
+def test_pointer_to_scalar(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing `const char*` from an LF_POINTER leaf.
+    Ghidra has no concept of `const` so this should resolve to `char*`."""
     from ghidra.program.model.data import Pointer
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("pointer-to-char-key")
+
+    # Ghidra recognized it as a pointer.
     imported_pointer = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(pointer_to_char_key),
+        type_helper.type_importer.import_pdb_type_into_ghidra(key),
         Pointer,
     )
+
+    # Ghidra recognized it as a `char*` pointer.
     assert (
         imported_pointer.dataType
         == type_helper.type_importer.import_pdb_type_into_ghidra(CVInfoTypeEnum.T_CHAR)
     )
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(
-        pointer_to_char_key
-    )
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_pointer
 
 
-def test_array(type_helper: GhidraTypeTestHelper):
+def test_array(type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample):
+    """Importing `unsigned long[4]` array."""
     from ghidra.program.model.data import Array
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("array-key")
 
+    # Ghidra recognized it as an pointer.
     imported_array = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(array_key), Array
+        type_helper.type_importer.import_pdb_type_into_ghidra(key), Array
     )
 
+    # The array length, total size, and element type were all set properly.
     assert imported_array.getLength() == 16
     assert imported_array.getElementLength() == 4
     assert (
@@ -285,18 +231,24 @@ def test_array(type_helper: GhidraTypeTestHelper):
         == type_helper.type_importer.import_pdb_type_into_ghidra(CVInfoTypeEnum.T_ULONG)
     )
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(array_key)
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_array
 
 
-def test_enum(type_helper: GhidraTypeTestHelper):
+def test_enum(type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample):
+    """Importing an `int` enum type."""
     from ghidra.program.model.data import Enum
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("enum-key")
 
+    # Ghidra recognized it as an enum.
     imported_enum = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(enum_key), Enum
+        type_helper.type_importer.import_pdb_type_into_ghidra(key), Enum
     )
+
+    # The names and (non-contiguous) values of the enum were all imported correctly.
     assert imported_enum.getDisplayName() == "ActorState"
     assert imported_enum.getCount() == 7
     assert list(imported_enum.getNames()) == [
@@ -318,55 +270,65 @@ def test_enum(type_helper: GhidraTypeTestHelper):
         256,
     ]
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(enum_key)
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_enum
 
 
-def test_enum_with_negative_value(type_helper: GhidraTypeTestHelper):
+def test_enum_with_negative_value(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
+    """Importing an `int` enum with a number that resolves to a negative number."""
     from ghidra.program.model.data import Enum
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("enum-with-negative-value-key")
 
+    # Ghidra recognized it as an enum.
     imported_enum = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(
-            enum_with_negative_value_key
-        ),
+        type_helper.type_importer.import_pdb_type_into_ghidra(key),
         Enum,
     )
+
+    # The names and (non-contiguous) values of the enum were all imported correctly.
     assert imported_enum.getDisplayName() == "Unknown0xf8"
     assert imported_enum.getCount() == 2
     assert list(imported_enum.getNames()) == ["c_unknownminusone", "c_unknown8"]
     assert list(imported_enum.getValues()) == [-1, 8]
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(
-        enum_with_negative_value_key
-    )
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_enum
 
 
-def test_fallback_procedure_import(type_helper: GhidraTypeTestHelper):
+def test_fallback_procedure_import(
+    type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample
+):
     """The feature is not fully implemented. This test asserts on the fallback behaviour."""
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("procedure-key")
 
-    imported_type = type_helper.type_importer.import_pdb_type_into_ghidra(procedure_key)
+    imported_type = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     # Fallback behaviour. This assertion should be changed if proper support is implemented
     assert imported_type == type_helper.type_importer.import_pdb_type_into_ghidra(
         CVInfoTypeEnum.T_VOID
     )
 
-    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(procedure_key)
+    # Repeating the import does not create a duplicate type in Ghidra's database.
+    second_import = type_helper.type_importer.import_pdb_type_into_ghidra(key)
     assert second_import == imported_type
 
 
 @pytest.mark.xfail(reason="Union import not yet implemented")
-def test_union(type_helper: GhidraTypeTestHelper):
+def test_union(type_helper: GhidraTypeTestHelper, cvdump_sample: CvdumpSample):
     from ghidra.program.model.data import Union
 
-    type_helper.set_up_cvdump_types(CVDUMP_TYPES)
+    type_helper.set_up_cvdump_types(cvdump_sample.text)
+    key = cvdump_sample.key("union-key")
 
     _imported_union = assert_instance(
-        type_helper.type_importer.import_pdb_type_into_ghidra(union_key), Union
+        type_helper.type_importer.import_pdb_type_into_ghidra(key), Union
     )
 
     # More assertions are needed once we have proper support


### PR DESCRIPTION
Is it worth moving cvdump `TYPES` excerpts to their own files? I set up a very simple format for sample text files that also gives the type keys a more self-documenting name.

To demonstrate, I updated `test_ghidra_integration_type_imports.py` along with adding docstrings and (semi-redundant) comments to help things flow better visually.

My reason for doing this: I have a dozen or so samples of various inheritance patterns designed to exercise the vbase slim behavior in the Ghidra import. By necessity, the test files almost entirely consist of cvdump text, and I couldn't find a great way to structure the files that:
1. keeps relevant sample data near its tests
2. stays under 1000 lines (`pylint` limit)
3. doesn't spread loosely related tests across many files.