### PR TITLE
asm replacement: resolve one-past-the-end array references

### DIFF
--- a/reccmp/compare/asm/replacement.py
+++ b/reccmp/compare/asm/replacement.py
@@ -42,11 +42,37 @@ def create_name_lookup(
 
         # We will not return an offset name if this is not a variable
         # or if the offset is outside the range of the entity.
-        if entity.entity_type not in (
-            EntityType.DATA,
-            EntityType.OFFSET,
-        ) or offset >= entity.any_size(image_id):
+        # Exception: an offset exactly one past the end of the entity is
+        # allowed, so we can identify one-past-the-end pointers (a common
+        # compiler idiom for array end bounds). This case can only be reached
+        # when no other entity starts at the given address.
+        size = entity.any_size(image_id)
+        if (
+            entity.entity_type
+            not in (
+                EntityType.DATA,
+                EntityType.OFFSET,
+            )
+            or offset > size
+        ):
             return None
+
+        if offset == size:
+            # One-past-the-end reference: a common compiler idiom for the end
+            # bound of an array. Only allow this for arrays and structs; for
+            # a scalar an address just past the entity is much more likely to
+            # be an unrelated (unannotated) neighbor variable.
+            # Without type information, fall back to a size heuristic.
+            type_key = entity.get("data_type")
+            if (
+                CvdumpTypeKey(type_key).is_scalar()
+                if type_key is not None
+                else size < 8
+            ):
+                return None
+            # Skip the data_type offset lookup (the offset is outside the
+            # type) and use the raw offset suffix.
+            return entity.match_name(f"+{offset}")
 
         type_key = entity.get("data_type")
         if type_key:

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -86,8 +86,77 @@ def test_offset_name(db: EntityDb, entity_type: EntityType):
     assert lookup(100) is not None
     assert lookup(101) is not None
 
+    # One-past-the-end of an array-sized entity resolves to 'name+size'.
+    # (A common compiler idiom for the end bound of an array.)
+    assert lookup(110) == "Hello+10 (OFFSET)"
+
     # Outside the range = no name
-    assert lookup(110) is None
+    assert lookup(111) is None
+
+
+def test_one_past_end_prefers_existing_entity(db: EntityDb):
+    """A one-past-the-end name is a fallback: when an entity starts exactly at
+    the end-bound address, its own name wins."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA, size=10)
+        batch.set(ImageId.ORIG, 110, name="Neighbor", type=EntityType.DATA, size=4)
+
+    lookup = create_lookup(db)
+
+    name = lookup(110)
+    assert name is not None
+    assert "Neighbor" in name
+    assert "Hello" not in name
+
+
+def test_one_past_end_small_entity(db: EntityDb):
+    """Without type information, do not use the one-past-the-end name for a
+    small (scalar sized) entity. An address just past a small entity is more
+    likely to be an unrelated (unannotated) neighbor variable."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA, size=4)
+
+    lookup = create_lookup(db)
+
+    assert lookup(103) is not None
+    assert lookup(104) is None
+
+
+def test_one_past_end_scalar_type(db: EntityDb):
+    """A known scalar never gets a one-past-the-end name, regardless of size.
+    (T_REAL64 is 8 bytes and would pass a pure size heuristic.)"""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Hello",
+            type=EntityType.DATA,
+            size=8,
+            data_type=0x0041,
+        )
+
+    lookup = create_lookup(db)
+
+    assert lookup(107) is not None
+    assert lookup(108) is None
+
+
+def test_one_past_end_aggregate_type(db: EntityDb):
+    """A known array or struct admits the one-past-the-end name even when it
+    is smaller than the fallback size heuristic."""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Hello",
+            type=EntityType.DATA,
+            size=4,
+            data_type=0x1004,
+        )
+
+    lookup = create_lookup(db)
+
+    assert lookup(104) == "Hello+4 (OFFSET)"
 
 
 def test_offset_name_non_variables(db):


### PR DESCRIPTION
An address exactly one past the end of an annotated DATA entity (size >= 8) now resolves to `name+size` when no other entity starts at that address. This is the standard compiler idiom for an array's end bound, e.g. `cmp esi, offset g_array+SIZE`. Previously one side resolved to a raw address while the other resolved to a name (or vice versa), producing a guaranteed operand mismatch on both correct and incorrect source.

The size floor keeps small scalars out: an address just past a 4-byte entity is much more likely to be an unrelated, unannotated neighbor variable. Covered by new cases in `tests/test_name_replacement.py`, including the small-entity guard.

Found while verifying byte-identical rebuilds of LEGO Island with MSVC 4.2, where this class of false mismatch penalized correct source (mostly STL `_Tree` instantiations iterating to an array bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P88DB9e4CuwhuVz46toNb