### PR TITLE
asm compare: cross-side operand equivalence and shared table locations

### DIFF
--- a/reccmp/compare/asm/instgen.py
+++ b/reccmp/compare/asm/instgen.py
@@ -6,7 +6,7 @@ import bisect
 import struct
 from functools import cache
 from enum import Enum, auto
-from typing import Iterable, Literal, NamedTuple
+from typing import Iterable, Literal, Mapping, NamedTuple
 from capstone import Cs, CS_ARCH_X86, CS_MODE_16, CS_MODE_32  # type: ignore
 from .const import JUMP_MNEMONICS
 
@@ -65,7 +65,20 @@ def stop_at_int3(
 
 class InstructGen:
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, blob: bytes, start: int, is_32bit: bool = True) -> None:
+    def __init__(
+        self,
+        blob: bytes,
+        start: int,
+        is_32bit: bool = True,
+        seeds: Mapping[int, SectionType] | None = None,
+    ) -> None:
+        """seeds provides table locations that are known before we start
+        the analysis. A jump or data table is normally detected from the
+        instruction that reads it, but that instruction may come *after*
+        the table, in which case we have already disassembled the table
+        bytes as (junk) code. The caller can break this chicken-and-egg
+        problem by seeding the tables detected on a previous run or by the
+        disassembly of the same function in another image."""
         self.is_32bit = is_32bit
         self.blob = blob
         self.start = start
@@ -81,6 +94,11 @@ class InstructGen:
         self.sections: list[FuncSection] = []
 
         self.confirmed_addrs: dict[int, SectionType] = {}
+        if seeds:
+            for addr, type_ in seeds.items():
+                if type_ != SectionType.CODE and self.start < addr < self.end:
+                    self.confirmed_addrs[addr] = type_
+
         self.analysis()
 
     def _finish_code_section(self, contents: list[DisasmLiteTuple]):
@@ -112,13 +130,14 @@ class InstructGen:
 
         # Assume the start of every function is code.
         if addr == self.start:
-            self.section_end = self.end
-            return SectionType.CODE
+            new_type = SectionType.CODE
+        else:
+            # The start of a new section must be an address that we've seen.
+            maybe_type = self.confirmed_addrs.get(addr)
+            if maybe_type is None:
+                return None
 
-        # The start of a new section must be an address that we've seen.
-        new_type = self.confirmed_addrs.get(addr)
-        if new_type is None:
-            return None
+            new_type = maybe_type
 
         self.cur_section_type = new_type
 

--- a/reccmp/compare/asm/parse.py
+++ b/reccmp/compare/asm/parse.py
@@ -8,12 +8,28 @@ placeholder string."""
 
 import re
 from functools import cache
+from typing import Mapping
 from typing_extensions import Buffer
 from .const import JUMP_MNEMONICS, SINGLE_OPERAND_INSTS
 from .instgen import DisasmLiteTuple, InstructGen, SectionType
 from .replacement import AddrTestProtocol, NameReplacementProtocol
 
 AsmExcerpt = list[tuple[int | None, str]]
+
+OpRecord = tuple[str, tuple[tuple[int, str, bool], ...]]
+"""Record of the address operands in one sanitized instruction:
+(final instruction text,
+ ((operand address, replacement text, strict), ...)).
+The replacement text is the exact string that was inserted into (or, for
+an immediate that we chose not to replace, kept in) the instruction text.
+strict is True for operands that can only refer to the exact start of an
+entity: a call target or an indirect pointer slot. Used for cross-side
+operand equivalence."""
+
+SectionLayout = tuple[tuple[str, int, int], ...]
+"""Shape of the disassembly: one (section type name, relative start, item
+count) triple per section, with the start relative to the function start.
+Two functions with the same code should produce the same layout."""
 
 ptr_replace_regex = re.compile(r"(?<=\[)(0x[0-9a-f]+)(?=\])")
 
@@ -34,6 +50,7 @@ def from_hex(string: str) -> int | None:
 
 
 class ParseAsm:
+    # pylint: disable=too-many-instance-attributes
     def __init__(
         self,
         addr_test: AddrTestProtocol | None = None,
@@ -48,9 +65,23 @@ class ParseAsm:
         self.indirect_replacements: dict[int, str] = {}
         self.number_placeholders = True
 
+        # Address operands of each sanitized instruction from the last
+        # parse_asm() call, keyed by instruction address.
+        self.op_records: dict[int, OpRecord] = {}
+        self._cur_ops: list[tuple[int, str, bool]] = []
+
+        # Section layout and confirmed table locations (relative to the
+        # function start) from the last parse_asm() call.
+        self.last_layout: SectionLayout = ()
+        self.last_tables: dict[int, SectionType] = {}
+
     def reset(self):
         self.replacements = {}
         self.indirect_replacements = {}
+        self.op_records = {}
+        self._cur_ops = []
+        self.last_layout = ()
+        self.last_tables = {}
 
     def is_addr(self, value: int) -> bool:
         """Wrapper for user-provided address test"""
@@ -75,30 +106,34 @@ class ParseAsm:
         number = len(self.replacements) + len(self.indirect_replacements) + 1
         return f"<OFFSET{number}>" if self.number_placeholders else "<OFFSET>"
 
+    def _record_op(self, addr: int, text: str, strict: bool = False):
+        """Note an address operand of the instruction being sanitized."""
+        self._cur_ops.append((addr, text, strict))
+
     def replace(self, addr: int, exact: bool = False) -> str:
         """Provide a replacement name for the given address."""
         if addr in self.replacements:
-            return self.replacements[addr]
+            text = self.replacements[addr]
+        elif (name := self.lookup(addr, exact=exact)) is not None:
+            self.replacements[addr] = text = name
+        else:
+            text = self._next_placeholder()
+            self.replacements[addr] = text
 
-        if (name := self.lookup(addr, exact=exact)) is not None:
-            self.replacements[addr] = name
-            return name
-
-        placeholder = self._next_placeholder()
-        self.replacements[addr] = placeholder
-        return placeholder
+        self._record_op(addr, text, strict=exact)
+        return text
 
     def indirect_replace(self, addr: int) -> str:
         if addr in self.indirect_replacements:
-            return self.indirect_replacements[addr]
+            text = self.indirect_replacements[addr]
+        elif (name := self.lookup(addr, exact=True, indirect=True)) is not None:
+            self.indirect_replacements[addr] = text = name
+        else:
+            text = self._next_placeholder()
+            self.indirect_replacements[addr] = text
 
-        if (name := self.lookup(addr, exact=True, indirect=True)) is not None:
-            self.indirect_replacements[addr] = name
-            return name
-
-        placeholder = self._next_placeholder()
-        self.indirect_replacements[addr] = placeholder
-        return placeholder
+        self._record_op(addr, text, strict=True)
+        return text
 
     def hex_replace_always(self, match: re.Match) -> str:
         """If a pointer value was matched, always insert a placeholder"""
@@ -121,8 +156,13 @@ class ParseAsm:
         value = int(match.group(1), 16)
         placeholder = self.lookup(value)
         if placeholder is not None:
+            self._record_op(value, placeholder)
             return placeholder
 
+        # Even though we keep the raw value, record it as a potential
+        # address operand so that cross-side refinement can still try to
+        # match it up against the other side.
+        self._record_op(value, match.group(0))
         return match.group(0)
 
     def hex_replace_indirect(self, match: re.Match) -> str:
@@ -193,11 +233,25 @@ class ParseAsm:
 
         return (inst_mnemonic, op_str)
 
-    def parse_asm(self, data: Buffer, start_addr: int) -> AsmExcerpt:
+    def parse_asm(
+        self,
+        data: Buffer,
+        start_addr: int,
+        table_seeds: Mapping[int, SectionType] | None = None,
+    ) -> AsmExcerpt:
+        """Disassemble and sanitize the given code.
+        table_seeds provides known jump/data table locations, relative to
+        start_addr, to guide the disassembly. (e.g. shared from the
+        disassembly of the same function in the other image)"""
         self.reset()
         asm: AsmExcerpt = []
 
-        ig = InstructGen(bytes(data), start_addr, self.is_32bit)
+        seeds = (
+            {start_addr + rel: type_ for rel, type_ in table_seeds.items()}
+            if table_seeds is not None
+            else None
+        )
+        ig = InstructGen(bytes(data), start_addr, self.is_32bit, seeds=seeds)
 
         for section in ig.sections:
             if section.type == SectionType.CODE:
@@ -217,7 +271,13 @@ class ParseAsm:
                         or inst_size > 4
                         or not self.is_32bit
                     ):
+                        self._cur_ops = []
                         result = self.sanitize(inst)
+                        if self._cur_ops:
+                            self.op_records[inst_address] = (
+                                " ".join(result),
+                                tuple(self._cur_ops),
+                            )
                     else:
                         result = (inst_mnemonic, inst_op_str)
 
@@ -238,5 +298,19 @@ class ParseAsm:
                 asm.append((None, "Data table:"))
                 for ofs, b in section.contents:
                     asm.append((ofs, hex(b)))
+
+        self.last_layout = tuple(
+            (
+                section.type.name,
+                (section.contents[0][0] - start_addr) if section.contents else -1,
+                len(section.contents),
+            )
+            for section in ig.sections
+        )
+        self.last_tables = {
+            addr - start_addr: type_
+            for addr, type_ in ig.confirmed_addrs.items()
+            if type_ != SectionType.CODE
+        }
 
         return asm

--- a/reccmp/compare/asm/refine.py
+++ b/reccmp/compare/asm/refine.py
@@ -1,0 +1,351 @@
+"""Cross-side operand equivalence.
+
+The orig and recomp assembly are sanitized independently: each address
+operand is replaced by the name of the entity it resolves to, or by a
+numbered placeholder. Two operands therefore only compare equal if both
+sides produce the same text. This misses operands that are displaced but
+structurally identical: they point at the same matched entity with the
+same delta, but at least one side cannot produce a (or produces a
+different) name for its address. For example:
+
+- A reference one-past-the-end of an array that coincides with the start
+  of the next variable in one image but not in the other.
+- A reference into the function's own body (e.g. its jump tables) which
+  moved because the function linked at a different address.
+- A walking pointer bound like `array + sizeof(array) + field_offset`.
+
+This module re-examines the mismatching line pairs of the initial diff.
+If two lines differ only in address operands, and every such operand pair
+shares an interpretation -- the same matched entity at the same delta, or
+the same delta from a pair of operands that already compare equal -- then
+the pair is turned into a match: the recomp line is rewritten to the orig
+text and the diff opcodes are patched in place.
+
+Two properties keep this safe:
+
+- Equivalence is strictly symmetric. BOTH sides must yield the same
+  interpretation under the same rule. A one-sided fuzzy resolution (e.g.
+  "this is probably entity X plus some slack") is never accepted, because
+  it would override the exact resolution on the other side.
+- The diff is patched locally: a refined pair becomes an equal pair, and
+  nothing else moves. The match ratio can only increase, and the diff is
+  never re-run on the rewritten text (which could pair the rewritten
+  lines with unrelated lines elsewhere in the function).
+"""
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from reccmp.difflib import DiffOpcode
+from .parse import AsmExcerpt, OpRecord
+from .replacement import CandidateLookupProtocol
+
+# Upper bound for the displacement from an anchor operand pair.
+# (i.e. operands equated by the same delta from an already-matching
+# operand pair rather than by an annotated entity)
+ANCHOR_DELTA_LIMIT = 0x1000
+
+_SENTINEL = "\x00"
+
+
+def instruction_skeleton(record: OpRecord) -> str | None:
+    """Mask out each address operand from the instruction text.
+    Two instructions that differ only in address operands have the same
+    skeleton. Returns None if some replacement text cannot be located in
+    the instruction text. (This should not happen, but if it does, the
+    instruction is not usable for operand comparison.)"""
+    text, ops = record
+    for i, (_, op_text, _) in enumerate(ops):
+        index = text.find(op_text)
+        if index == -1:
+            return None
+
+        text = f"{text[:index]}{_SENTINEL}{i}{_SENTINEL}{text[index + len(op_text) :]}"
+
+    return text
+
+
+def _merge_opcodes(codes: list[DiffOpcode]) -> list[DiffOpcode]:
+    """Merge adjacent opcodes with the same tag."""
+    merged: list[DiffOpcode] = []
+    for code in codes:
+        if merged and merged[-1][0] == code[0]:
+            tag, i1, _, j1, _ = merged[-1]
+            merged[-1] = (tag, i1, code[2], j1, code[4])
+        else:
+            merged.append(code)
+
+    return merged
+
+
+@dataclass(frozen=True)
+class RefinedDiff:
+    recomp: AsmExcerpt
+    opcodes: list[DiffOpcode]
+    # Number of line pairs upgraded to a match, for audit logging.
+    refined_pairs: int
+
+
+@dataclass(frozen=True)
+class OperandRefiner:
+    """Turns mismatching diff line pairs whose address operands are
+    structurally equivalent into matches. See the module docstring."""
+
+    orig_candidates: CandidateLookupProtocol
+    recomp_candidates: CandidateLookupProtocol
+    # Function under comparison: start address in each image and the
+    # number of bytes that are certainly interior to the function in
+    # both images.
+    orig_start: int
+    recomp_start: int
+    self_reach: int
+
+    def refine(
+        self,
+        orig: AsmExcerpt,
+        recomp: AsmExcerpt,
+        opcodes: Sequence[DiffOpcode],
+        orig_records: Mapping[int, OpRecord],
+        recomp_records: Mapping[int, OpRecord],
+    ) -> RefinedDiff | None:
+        """Detect structurally equivalent line pairs among the 'replace'
+        blocks of the diff. Each equivalent pair is scored as a match:
+        the recomp line text is rewritten to the orig text and the diff
+        opcodes are patched accordingly. Returns None if no line pair
+        was refined."""
+        anchors = self._harvest_anchors(
+            orig, recomp, opcodes, orig_records, recomp_records
+        )
+
+        new_recomp: AsmExcerpt | None = None
+        new_opcodes: list[DiffOpcode] = []
+        refined_pairs = 0
+
+        for code in opcodes:
+            tag, i1, i2, j1, j2 = code
+            if tag != "replace":
+                new_opcodes.append(code)
+                continue
+
+            # If the block sizes differ, compare the leading pairs.
+            refined = [
+                self._equivalent_lines(
+                    orig[i1 + k], recomp[j1 + k], orig_records, recomp_records, anchors
+                )
+                for k in range(min(i2 - i1, j2 - j1))
+            ]
+            if not any(refined):
+                new_opcodes.append(code)
+                continue
+
+            if new_recomp is None:
+                new_recomp = list(recomp)
+
+            for k, is_refined in enumerate(refined):
+                if is_refined:
+                    refined_pairs += 1
+                    new_recomp[j1 + k] = (recomp[j1 + k][0], orig[i1 + k][1])
+
+            new_opcodes.extend(_split_replace_block(code, refined))
+
+        if new_recomp is None:
+            return None
+
+        return RefinedDiff(
+            recomp=new_recomp,
+            opcodes=_merge_opcodes(new_opcodes),
+            refined_pairs=refined_pairs,
+        )
+
+    def _get_op_records(
+        self,
+        orig_line: tuple[int | None, str],
+        recomp_line: tuple[int | None, str],
+        orig_records: Mapping[int, OpRecord],
+        recomp_records: Mapping[int, OpRecord],
+    ) -> tuple[OpRecord, OpRecord] | None:
+        """Operand records for the given line pair, or None if either line
+        has no address operands or was modified after sanitization.
+        (e.g. by assert_fixup)"""
+        orig_addr, orig_text = orig_line
+        recomp_addr, recomp_text = recomp_line
+        if orig_addr is None or recomp_addr is None:
+            return None
+
+        orig_record = orig_records.get(orig_addr)
+        recomp_record = recomp_records.get(recomp_addr)
+        if orig_record is None or recomp_record is None:
+            return None
+
+        if orig_record[0] != orig_text or recomp_record[0] != recomp_text:
+            return None
+
+        return (orig_record, recomp_record)
+
+    def _harvest_anchors(
+        self,
+        orig: AsmExcerpt,
+        recomp: AsmExcerpt,
+        opcodes: Sequence[DiffOpcode],
+        orig_records: Mapping[int, OpRecord],
+        recomp_records: Mapping[int, OpRecord],
+    ) -> list[tuple[int, int]]:
+        """Address operand pairs (orig addr, recomp addr) that the diff has
+        already matched up: both operands got the same replacement text on
+        a line that compares equal. Such a pair pins down the location of
+        the same object in both images -- even an object we know nothing
+        else about, when the operands are matching placeholders -- and can
+        then anchor references displaced from it."""
+        anchors: set[tuple[int, int]] = set()
+
+        for tag, i1, i2, j1, j2 in opcodes:
+            if tag != "equal":
+                continue
+
+            for i, j in zip(range(i1, i2), range(j1, j2)):
+                records = self._get_op_records(
+                    orig[i], recomp[j], orig_records, recomp_records
+                )
+                if records is None:
+                    continue
+
+                orig_ops, recomp_ops = records[0][1], records[1][1]
+                if len(orig_ops) != len(recomp_ops):
+                    continue
+
+                for (orig_value, orig_op, _), (recomp_value, recomp_op, _) in zip(
+                    orig_ops, recomp_ops
+                ):
+                    # A raw hex operand does not pair up two addresses;
+                    # the values are simply identical.
+                    if orig_op == recomp_op and not orig_op.startswith("0x"):
+                        anchors.add((orig_value, recomp_value))
+
+        return sorted(anchors)
+
+    def _equivalent_lines(
+        self,
+        orig_line: tuple[int | None, str],
+        recomp_line: tuple[int | None, str],
+        orig_records: Mapping[int, OpRecord],
+        recomp_records: Mapping[int, OpRecord],
+        anchors: Sequence[tuple[int, int]],
+    ) -> bool:
+        """Do these mismatching lines differ only in address operands that
+        are structurally equivalent?"""
+        records = self._get_op_records(
+            orig_line, recomp_line, orig_records, recomp_records
+        )
+        if records is None:
+            return False
+
+        orig_record, recomp_record = records
+        orig_ops, recomp_ops = orig_record[1], recomp_record[1]
+        if not orig_ops or len(orig_ops) != len(recomp_ops):
+            return False
+
+        skeleton = instruction_skeleton(orig_record)
+        if skeleton is None or skeleton != instruction_skeleton(recomp_record):
+            return False
+
+        return all(
+            self._equivalent_operands(orig_op, recomp_op, anchors)
+            for orig_op, recomp_op in zip(orig_ops, recomp_ops)
+        )
+
+    # A cascade of accept/reject rules reads clearest with early returns.
+    # pylint: disable-next=too-many-return-statements
+    def _equivalent_operands(
+        self,
+        orig_op: tuple[int, str, bool],
+        recomp_op: tuple[int, str, bool],
+        anchors: Sequence[tuple[int, int]],
+    ) -> bool:
+        orig_value, orig_text, orig_strict = orig_op
+        recomp_value, recomp_text, recomp_strict = recomp_op
+
+        if orig_text == recomp_text:
+            # This operand did not cause the mismatch.
+            return True
+
+        orig_cands = self.orig_candidates(orig_value)
+        recomp_cands = self.recomp_candidates(recomp_value)
+
+        if orig_strict or recomp_strict:
+            # A call target or indirect pointer slot refers to the exact
+            # start of an entity, so only the delta=0 interpretation
+            # counts.
+            if (orig_value, 0) in recomp_cands:
+                # The same matched entity on both sides.
+                return True
+
+            # If a matched entity claims either address exactly, but is
+            # not matched with the other address, then the operands refer
+            # to two different things.
+            if any(delta == 0 for _, delta in orig_cands) or any(
+                delta == 0 for _, delta in recomp_cands
+            ):
+                return False
+
+            # Otherwise: no annotation covers this operand (e.g. a call
+            # to a static function that is invisible in the PDB), and it
+            # may still be equated by the position-based rules below.
+        elif orig_cands & recomp_cands:
+            # Same matched entity at the same delta.
+            return True
+        elif any(delta == 0 for _, delta in orig_cands) and any(
+            delta == 0 for _, delta in recomp_cands
+        ):
+            # Both operands sit exactly on matched entities that do not
+            # intersect: they name two different things.
+            return False
+
+        # Reference into the body of the function under comparison?
+        # (e.g. its own jump tables)
+        delta = orig_value - self.orig_start
+        if delta == recomp_value - self.recomp_start and 0 <= delta < self.self_reach:
+            return True
+
+        # Same delta from an anchor pair? This can equate references into
+        # objects that are not annotated at all, if some other reference
+        # to the object has already been matched up.
+        return any(
+            orig_value - orig_anchor == recomp_value - recomp_anchor
+            and abs(orig_value - orig_anchor) <= ANCHOR_DELTA_LIMIT
+            for orig_anchor, recomp_anchor in anchors
+        )
+
+
+def _split_replace_block(code: DiffOpcode, refined: Sequence[bool]) -> list[DiffOpcode]:
+    """Split a 'replace' opcode into alternating 'equal' (refined pairs)
+    and 'replace' segments. Any leftover lines (if the block sides have
+    different lengths) stay mismatched."""
+    _, i1, i2, j1, j2 = code
+    length = len(refined)
+    result: list[DiffOpcode] = []
+
+    start = 0
+    while start < length:
+        end = start
+        while end < length and refined[end] == refined[start]:
+            end += 1
+
+        if refined[start]:
+            result.append(("equal", i1 + start, i1 + end, j1 + start, j1 + end))
+        elif end == length:
+            # Attach the leftover lines to the final mismatching segment.
+            result.append(("replace", i1 + start, i2, j1 + start, j2))
+            return result
+
+        else:
+            result.append(("replace", i1 + start, i1 + end, j1 + start, j1 + end))
+
+        start = end
+
+    # The final segment was refined. Emit the leftover lines separately.
+    if i1 + length < i2:
+        result.append(("delete", i1 + length, i2, j2, j2))
+    elif j1 + length < j2:
+        result.append(("insert", i2, i2, j1 + length, j2))
+
+    return result

--- a/reccmp/compare/asm/replacement.py
+++ b/reccmp/compare/asm/replacement.py
@@ -42,11 +42,37 @@ def create_name_lookup(
 
         # We will not return an offset name if this is not a variable
         # or if the offset is outside the range of the entity.
-        if entity.entity_type not in (
-            EntityType.DATA,
-            EntityType.OFFSET,
-        ) or offset >= entity.any_size(image_id):
+        # Exception: an offset exactly one past the end of the entity is
+        # allowed, so we can identify one-past-the-end pointers (a common
+        # compiler idiom for array end bounds). This case can only be reached
+        # when no other entity starts at the given address.
+        size = entity.any_size(image_id)
+        if (
+            entity.entity_type
+            not in (
+                EntityType.DATA,
+                EntityType.OFFSET,
+            )
+            or offset > size
+        ):
             return None
+
+        if offset == size:
+            # One-past-the-end reference: a common compiler idiom for the end
+            # bound of an array. Only allow this for arrays and structs; for
+            # a scalar an address just past the entity is much more likely to
+            # be an unrelated (unannotated) neighbor variable.
+            # Without type information, fall back to a size heuristic.
+            type_key = entity.get("data_type")
+            if (
+                CvdumpTypeKey(type_key).is_scalar()
+                if type_key is not None
+                else size < 8
+            ):
+                return None
+            # Skip the data_type offset lookup (the offset is outside the
+            # type) and use the raw offset suffix.
+            return entity.match_name(f"+{offset}")
 
         type_key = entity.get("data_type")
         if type_key:

--- a/reccmp/compare/asm/replacement.py
+++ b/reccmp/compare/asm/replacement.py
@@ -4,6 +4,18 @@ from reccmp.compare.db import EntityDb, ReccmpEntity
 from reccmp.cvdump.types import CvdumpTypeKey
 from reccmp.types import EntityType, ImageId
 
+# Bounds for cross-side operand candidates. See create_candidate_lookup.
+# A reference may point slightly before an entity (e.g. array base biased
+# by the first index) or up to one-past-the-end plus a small field offset
+# (e.g. the end bound of an array of structs, anchored on a struct member).
+CANDIDATE_REACH_BEFORE = 16
+CANDIDATE_SLACK_AFTER = 4
+
+# How far back (in bytes) to scan for entities that could contain the
+# search address. This must cover interior references into large entities
+# (data arrays, structs).
+CANDIDATE_SCAN_BACK = 0x2000
+
 
 class AddrTestProtocol(Protocol):
     def __call__(self, addr: int, /) -> bool: ...
@@ -13,6 +25,84 @@ class NameReplacementProtocol(Protocol):
     def __call__(
         self, addr: int, exact: bool = False, indirect: bool = False
     ) -> str | None: ...
+
+
+class CandidateLookupProtocol(Protocol):
+    def __call__(self, addr: int, /) -> frozenset[tuple[int, int]]: ...
+
+
+def create_candidate_lookup(db: EntityDb, image_id: ImageId) -> CandidateLookupProtocol:
+    """Function generator for cross-side operand equivalence candidates.
+
+    The returned lookup describes an address as the set of plausible
+    interpretations (entity, delta): every *matched* entity nearby whose
+    address range -- widened by a small tolerance -- covers the search
+    address. Each candidate is expressed as (entity orig addr, delta) so
+    that the same interpretation resolves to the same key in both images.
+
+    Two operand addresses, one per image, refer to the same thing
+    structurally if some interpretation is shared by both sides: the same
+    matched entity at the same delta. The caller must intersect the
+    candidate sets of both sides; a candidate on its own proves nothing.
+    This symmetry requirement is what makes the wider tolerances safe:
+    a one-sided resolution of "entity + slack" is never accepted."""
+    assert image_id in (ImageId.ORIG, ImageId.RECOMP), "Invalid image id"
+
+    # A code entity is a unit: a reference just before or just past it
+    # does not relate to it. Only its exact address and its interior
+    # (e.g. embedded jump tables) can anchor a reference.
+    code_types = frozenset(
+        {
+            EntityType.FUNCTION,
+            EntityType.THUNK,
+            EntityType.VTORDISP,
+            EntityType.IMPORT_THUNK,
+        }
+    )
+
+    # Variables, by contrast, are covered with a small tolerance before
+    # the start and past the end, since a reference may be biased by an
+    # array index or by a struct member offset.
+    # Only entities that occupy bytes in the binary can anchor a
+    # reference at all: passenger types (LINE, LABEL) and imports are
+    # excluded.
+    data_types = frozenset(
+        (EntityType.solid_types() | {EntityType.OFFSET, EntityType.POINTER})
+        - code_types
+    )
+
+    @cache
+    def lookup(addr: int) -> frozenset[tuple[int, int]]:
+        candidates = set()
+
+        scan = range(addr - CANDIDATE_SCAN_BACK, addr + CANDIDATE_REACH_BEFORE + 1)
+        for entity in db.all_in_range(image_id, scan):
+            if not entity.matched:
+                continue
+
+            entity_type = entity.entity_type
+            base_addr = entity.addr(image_id)
+            assert base_addr is not None
+            delta = addr - base_addr
+
+            size = entity.any_size(image_id)
+            if entity_type in data_types:
+                in_range = (
+                    -CANDIDATE_REACH_BEFORE <= delta <= size + CANDIDATE_SLACK_AFTER
+                )
+            elif entity_type in code_types:
+                in_range = 0 <= delta < max(size, 1)
+            else:
+                continue
+
+            if in_range:
+                # The entity is matched so orig_addr is set.
+                assert entity.orig_addr is not None
+                candidates.add((entity.orig_addr, delta))
+
+        return frozenset(candidates)
+
+    return lookup
 
 
 def create_name_lookup(

--- a/reccmp/compare/functions.py
+++ b/reccmp/compare/functions.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 from functools import cache
 import struct
@@ -6,8 +7,11 @@ from typing import Callable, Iterator
 from reccmp.compare.lines import LinesDb
 from reccmp.compare.pinned_sequences import SequenceMatcherWithPins
 from reccmp.compare.asm.fixes import assert_fixup, find_effective_match
+from reccmp.compare.asm.instgen import SectionType
 from reccmp.compare.asm.parse import AsmExcerpt, ParseAsm
+from reccmp.compare.asm.refine import OperandRefiner
 from reccmp.compare.asm.replacement import (
+    create_candidate_lookup,
     create_name_lookup,
 )
 from reccmp.compare.db import EntityDb, ReccmpMatch
@@ -64,6 +68,9 @@ def create_bin_lookup(bin_file: Image) -> Callable[[int], int | None]:
     return lookup
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class FunctionComparator:
     # pylint: disable=too-many-instance-attributes
@@ -98,6 +105,8 @@ class FunctionComparator:
             ),
             is_32bit=self.is_32bit,
         )
+        self.orig_candidates = create_candidate_lookup(self.db, ImageId.ORIG)
+        self.recomp_candidates = create_candidate_lookup(self.db, ImageId.RECOMP)
 
     def _source_ref_of_recomp_addr(self, recomp_addr: int | None) -> str | None:
         if recomp_addr is None:
@@ -142,8 +151,9 @@ class FunctionComparator:
         except IndexError:
             pass
 
-        orig_combined = self.orig_sanitize.parse_asm(orig_raw, match.orig_addr)
-        recomp_combined = self.recomp_sanitize.parse_asm(recomp_raw, match.recomp_addr)
+        orig_combined, recomp_combined = self._parse_asm_with_shared_tables(
+            match, orig_raw, recomp_raw
+        )
 
         # Check for assert calls only if we expect to find them
         if has_asserts(self.orig_bin):
@@ -158,8 +168,82 @@ class FunctionComparator:
             orig_combined, recomp_combined, line_annotations
         )
 
+        refiner = OperandRefiner(
+            orig_candidates=self.orig_candidates,
+            recomp_candidates=self.recomp_candidates,
+            orig_start=match.orig_addr,
+            recomp_start=match.recomp_addr,
+            # Strictly interior to the function in both images. Anything
+            # past the last byte may belong to a different neighbor
+            # function in each image.
+            self_reach=min(orig_size, recomp_size),
+        )
+
         return self._compare_function_assembly(
-            orig_combined, recomp_combined, split_points
+            orig_combined, recomp_combined, split_points, refiner
+        )
+
+    def _parse_asm_with_shared_tables(
+        self, match: ReccmpMatch, orig_raw: bytes, recomp_raw: bytes
+    ) -> tuple[AsmExcerpt, AsmExcerpt]:
+        """Disassemble and sanitize both sides of the match.
+
+        A jump or data table is only detected once we disassemble the
+        instruction that reads it. If that instruction comes after the
+        table, the table bytes have already been read as junk code, and
+        the junk differs between the images (the table contents are
+        relocated), or one side even stops early on an undecodable byte.
+        The result is a diff mismatch on code that is not actually
+        different.
+
+        If the two sides disagree on the section layout, share the table
+        locations (which are function-relative) between the sides and
+        re-parse, so both get the chance to split their sections in the
+        same spot. Keep the result only if the sides converge on the same
+        layout."""
+        orig_combined = self.orig_sanitize.parse_asm(orig_raw, match.orig_addr)
+        recomp_combined = self.recomp_sanitize.parse_asm(recomp_raw, match.recomp_addr)
+
+        if self.orig_sanitize.last_layout == self.recomp_sanitize.last_layout or (
+            not self.orig_sanitize.last_tables and not self.recomp_sanitize.last_tables
+        ):
+            return (orig_combined, recomp_combined)
+
+        tables = (self.orig_sanitize.last_tables, self.recomp_sanitize.last_tables)
+        for _ in range(3):
+            # Merge the tables detected by each side. If both sides claim
+            # the same location, prefer the jump table: it is detected
+            # from the more specific instruction pattern.
+            seeds: dict[int, SectionType] = {}
+            for side in tables:
+                for rel_addr, type_ in side.items():
+                    if seeds.get(rel_addr) != SectionType.ADDR_TAB:
+                        seeds[rel_addr] = type_
+
+            orig_combined = self.orig_sanitize.parse_asm(
+                orig_raw, match.orig_addr, table_seeds=seeds
+            )
+            recomp_combined = self.recomp_sanitize.parse_asm(
+                recomp_raw, match.recomp_addr, table_seeds=seeds
+            )
+
+            new_tables = (
+                self.orig_sanitize.last_tables,
+                self.recomp_sanitize.last_tables,
+            )
+            if new_tables == tables:
+                break
+
+            tables = new_tables
+
+        if self.orig_sanitize.last_layout == self.recomp_sanitize.last_layout:
+            return (orig_combined, recomp_combined)
+
+        # The sides did not converge: the code is presumably really
+        # different. Restore the unseeded parse.
+        return (
+            self.orig_sanitize.parse_asm(orig_raw, match.orig_addr),
+            self.recomp_sanitize.parse_asm(recomp_raw, match.recomp_addr),
         )
 
     @staticmethod
@@ -183,19 +267,48 @@ class FunctionComparator:
         orig: AsmExcerpt,
         recomp: AsmExcerpt,
         split_points: list[tuple[int, int]],
+        refiner: OperandRefiner,
     ) -> EntityCompareResult:
         # Detach addresses from asm lines for the text diff.
         orig_asm = [x[1] for x in orig]
         recomp_asm = [x[1] for x in recomp]
 
         diff = SequenceMatcherWithPins(orig_asm, recomp_asm, split_points)
+        codes = diff.get_opcodes()
+        ratio = diff.ratio()
 
-        if diff.ratio() != 1.0:
+        if ratio != 1.0:
+            # Some of the mismatching line pairs may differ only in
+            # operands that refer to the same thing on both sides.
+            refined = refiner.refine(
+                orig,
+                recomp,
+                codes,
+                self.orig_sanitize.op_records,
+                self.recomp_sanitize.op_records,
+            )
+            if refined is not None:
+                logger.debug(
+                    "refined %d operand pair(s) in function at 0x%x",
+                    refined.refined_pairs,
+                    refiner.orig_start,
+                )
+                recomp = refined.recomp
+                recomp_asm = [x[1] for x in recomp]
+                codes = refined.opcodes
+
+                # The refinement turns mismatching pairs into matches and
+                # moves nothing else, so the ratio follows directly from
+                # the patched opcodes. (2*matches / total lines, as in
+                # difflib.SequenceMatcher.ratio)
+                total = len(orig_asm) + len(recomp_asm)
+                matched = sum(i2 - i1 for tag, i1, i2, _, _ in codes if tag == "equal")
+                ratio = 2 * matched / total if total > 0 else 1.0
+
+        if ratio != 1.0:
             # Check whether we can resolve register swaps which are actually
             # perfect matches modulo compiler entropy.
-            is_effective = find_effective_match(
-                diff.get_opcodes(), orig_asm, recomp_asm
-            )
+            is_effective = find_effective_match(codes, orig_asm, recomp_asm)
         else:
             is_effective = False
 
@@ -220,12 +333,12 @@ class FunctionComparator:
 
         return EntityCompareResult(
             diff=RawDiffOutput(
-                codes=diff.get_opcodes(),
+                codes=codes,
                 orig_inst=orig_for_printing,
                 recomp_inst=recomp_for_printing,
             ),
             is_effective_match=is_effective,
-            match_ratio=diff.ratio(),
+            match_ratio=ratio,
         )
 
     def _collect_line_annotations(self, recomp: AsmExcerpt) -> list[ReccmpMatch]:

--- a/tests/test_candidate_lookup.py
+++ b/tests/test_candidate_lookup.py
@@ -1,0 +1,151 @@
+"""Tests for the cross-side operand equivalence candidates.
+An address is described by the set of (matched entity, delta) pairs that
+could plausibly refer to it. Two operands (one per image) are equivalent
+if they share an interpretation. See create_candidate_lookup."""
+
+import pytest
+from reccmp.types import EntityType, ImageId
+from reccmp.compare.db import EntityDb
+from reccmp.compare.asm.replacement import create_candidate_lookup
+
+
+@pytest.fixture(name="db")
+def fixture_db() -> EntityDb:
+    return EntityDb()
+
+
+def test_matched_entities_only(db: EntityDb):
+    """Only matched entities can anchor a candidate: the interpretation
+    must exist in both images to be comparable."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Test", type=EntityType.DATA, size=10)
+        batch.set(ImageId.ORIG, 200, name="Hello", type=EntityType.DATA, size=10)
+        batch.set(ImageId.RECOMP, 1200, name="Hello", type=EntityType.DATA, size=10)
+        batch.match(200, 1200)
+
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+
+    # No candidates for the unmatched entity.
+    assert not lookup(104)
+
+    # The matched entity anchors interior references on both sides.
+    assert (200, 4) in lookup(204)
+    assert (200, 4) in create_candidate_lookup(db, ImageId.RECOMP)(1204)
+
+
+def test_candidate_windows(db: EntityDb):
+    """Candidates cover the entity range widened by a small tolerance:
+    a bit before the start and a bit past the end."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 1000, name="Hello", type=EntityType.DATA, size=100)
+        batch.set(ImageId.RECOMP, 5000, name="Hello", type=EntityType.DATA, size=100)
+        batch.match(1000, 5000)
+
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+
+    # Interior and exact.
+    assert (1000, 0) in lookup(1000)
+    assert (1000, 50) in lookup(1050)
+    assert (1000, 99) in lookup(1099)
+
+    # One-past-the-end and slightly beyond (e.g. the end bound of an
+    # array of structs, offset by a struct member).
+    assert (1000, 100) in lookup(1100)
+    assert (1000, 104) in lookup(1104)
+    assert (1000, 105) not in lookup(1105)
+
+    # Slightly before the entity (e.g. an array base biased by the
+    # first index).
+    assert (1000, -4) in lookup(996)
+    assert (1000, -16) in lookup(984)
+    assert (1000, -17) not in lookup(983)
+
+
+def test_collision_produces_both_candidates(db: EntityDb):
+    """One-past-the-end of one entity can coincide with the start of the
+    next. Both interpretations must be produced: the other image decides
+    which one (if any) is shared."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 1000, name="table", type=EntityType.DATA, size=100)
+        batch.set(ImageId.RECOMP, 5000, name="table", type=EntityType.DATA, size=100)
+        batch.match(1000, 5000)
+        # Directly follows the table in orig only.
+        batch.set(ImageId.ORIG, 1100, name="next", type=EntityType.DATA, size=4)
+        batch.set(ImageId.RECOMP, 7000, name="next", type=EntityType.DATA, size=4)
+        batch.match(1100, 7000)
+
+    orig_lookup = create_candidate_lookup(db, ImageId.ORIG)
+    recomp_lookup = create_candidate_lookup(db, ImageId.RECOMP)
+
+    assert {(1000, 100), (1100, 0)} <= orig_lookup(1100)
+
+    # The recomp layout separates the entities, so only the table
+    # interpretation appears... and the intersection decides.
+    assert (1000, 100) in recomp_lookup(5100)
+    assert orig_lookup(1100) & recomp_lookup(5100) == {(1000, 100)}
+    # ...while the recomp address of "next" only matches the exact
+    # interpretation.
+    assert orig_lookup(1100) & recomp_lookup(7000) == {(1100, 0)}
+
+
+def test_small_entity_one_past_end(db: EntityDb):
+    """One-past-the-end candidates apply to entities of any size.
+    (Unlike name replacement, which requires an array-sized entity:
+    a candidate by itself proves nothing until the other side shares it.)"""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 1000, name="Hello", type=EntityType.DATA, size=4)
+        batch.set(ImageId.RECOMP, 5000, name="Hello", type=EntityType.DATA, size=4)
+        batch.match(1000, 5000)
+
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+    assert (1000, 4) in lookup(1004)
+
+
+def test_function_interior(db: EntityDb):
+    """A function can anchor references into its own body (e.g. its jump
+    tables)."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 0x1000, name="fn", type=EntityType.FUNCTION)
+        batch.set(
+            ImageId.RECOMP, 0x5000, name="fn", type=EntityType.FUNCTION, size=0x500
+        )
+        batch.match(0x1000, 0x5000)
+
+    # n.b. Function entities usually have no orig size; the recomp size
+    # is used as a stand-in.
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+    assert (0x1000, 0x123) in lookup(0x1123)
+
+    # Code entities are units: unlike variables, a reference just before
+    # or just past a function does not relate to it.
+    assert not lookup(0x1000 - 4)
+    assert not lookup(0x1000 + 0x500)
+
+
+def test_excluded_types(db: EntityDb):
+    """Entities that do not occupy bytes of their own cannot anchor
+    a reference."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 1000, name="line", type=EntityType.LINE)
+        batch.set(ImageId.RECOMP, 5000, name="line", type=EntityType.LINE)
+        batch.match(1000, 5000)
+        batch.set(ImageId.ORIG, 2000, name="import", type=EntityType.IMPORT, size=4)
+        batch.set(ImageId.RECOMP, 6000, name="import", type=EntityType.IMPORT, size=4)
+        batch.match(2000, 6000)
+
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+    assert not lookup(1002)
+    assert not lookup(2002)
+
+
+def test_string_interior(db: EntityDb):
+    """Strings occupy bytes and can anchor nearby references, e.g. when
+    an unannotated variable follows a string in both images."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 1000, name='"str"', type=EntityType.STRING, size=6)
+        batch.set(ImageId.RECOMP, 5000, name='"str"', type=EntityType.STRING, size=6)
+        batch.match(1000, 5000)
+
+    lookup = create_candidate_lookup(db, ImageId.ORIG)
+    assert (1000, 4) in lookup(1004)
+    assert (1000, -16) in lookup(984)

--- a/tests/test_instgen.py
+++ b/tests/test_instgen.py
@@ -262,3 +262,64 @@ def test_movzx_data_table():
         SectionType.ADDR_TAB,
         SectionType.DATA_TAB,
     ]
+
+
+# Synthetic function with a jump table that comes BEFORE the instruction
+# that reads it, at 0x1004:
+#   0x1000: jmp 0x1014            (over the table)
+#   0x1002: nop / nop             (padding)
+#   0x1004: jump table            (4 entries, all 0x1014)
+#   0x1014: mov eax, 5
+#   0x1019: jmp [eax*4 + 0x1004]  (the table read)
+#   0x1020: ret
+BACKWARD_TABLE = (
+    b"\xeb\x12\x90\x90"
+    b"\x14\x10\x00\x00\x14\x10\x00\x00\x14\x10\x00\x00\x14\x10\x00\x00"
+    b"\xb8\x05\x00\x00\x00"
+    b"\xff\x24\x85\x04\x10\x00\x00"
+    b"\xc3"
+)
+
+
+def test_backward_table():
+    """A jump table that comes before the JMP into it is detected too
+    late: we have already disassembled the table bytes as code. We only
+    get the (junk) code sections, but the confirmed address of the table
+    must be reported so that another run can be seeded with it."""
+    ig = InstructGen(BACKWARD_TABLE, 0x1000)
+    assert all(section.type == SectionType.CODE for section in ig.sections)
+    assert ig.confirmed_addrs.get(0x1004) == SectionType.ADDR_TAB
+
+
+def test_backward_table_seeded():
+    """Given the location of the jump table up front, the sections can be
+    split correctly even though the JMP into the table comes after it."""
+    ig = InstructGen(BACKWARD_TABLE, 0x1000, seeds={0x1004: SectionType.ADDR_TAB})
+
+    assert [section.type for section in ig.sections] == [
+        SectionType.CODE,
+        SectionType.ADDR_TAB,
+        SectionType.CODE,
+    ]
+
+    # The code before the table: jmp and two nops.
+    assert len(ig.sections[0].contents) == 3
+
+    # All four table entries.
+    assert ig.sections[1].contents == [
+        (0x1004, 0x1014),
+        (0x1008, 0x1014),
+        (0x100C, 0x1014),
+        (0x1010, 0x1014),
+    ]
+
+    # The code after the table, starting at the table target.
+    assert ig.sections[2].contents[0][0] == 0x1014
+    assert len(ig.sections[2].contents) == 3
+
+
+def test_seeds_do_not_affect_normal_functions():
+    """Out-of-range seeds are ignored."""
+    ig = InstructGen(b"\x33\xc0\xc3", 0x1000, seeds={0x5000: SectionType.ADDR_TAB})
+    assert len(ig.sections) == 1
+    assert len(ig.sections[0].contents) == 2

--- a/tests/test_name_replacement.py
+++ b/tests/test_name_replacement.py
@@ -86,8 +86,77 @@ def test_offset_name(db: EntityDb, entity_type: EntityType):
     assert lookup(100) is not None
     assert lookup(101) is not None
 
+    # One-past-the-end of an array-sized entity resolves to 'name+size'.
+    # (A common compiler idiom for the end bound of an array.)
+    assert lookup(110) == "Hello+10 (OFFSET)"
+
     # Outside the range = no name
-    assert lookup(110) is None
+    assert lookup(111) is None
+
+
+def test_one_past_end_prefers_existing_entity(db: EntityDb):
+    """A one-past-the-end name is a fallback: when an entity starts exactly at
+    the end-bound address, its own name wins."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA, size=10)
+        batch.set(ImageId.ORIG, 110, name="Neighbor", type=EntityType.DATA, size=4)
+
+    lookup = create_lookup(db)
+
+    name = lookup(110)
+    assert name is not None
+    assert "Neighbor" in name
+    assert "Hello" not in name
+
+
+def test_one_past_end_small_entity(db: EntityDb):
+    """Without type information, do not use the one-past-the-end name for a
+    small (scalar sized) entity. An address just past a small entity is more
+    likely to be an unrelated (unannotated) neighbor variable."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, name="Hello", type=EntityType.DATA, size=4)
+
+    lookup = create_lookup(db)
+
+    assert lookup(103) is not None
+    assert lookup(104) is None
+
+
+def test_one_past_end_scalar_type(db: EntityDb):
+    """A known scalar never gets a one-past-the-end name, regardless of size.
+    (T_REAL64 is 8 bytes and would pass a pure size heuristic.)"""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Hello",
+            type=EntityType.DATA,
+            size=8,
+            data_type=0x0041,
+        )
+
+    lookup = create_lookup(db)
+
+    assert lookup(107) is not None
+    assert lookup(108) is None
+
+
+def test_one_past_end_aggregate_type(db: EntityDb):
+    """A known array or struct admits the one-past-the-end name even when it
+    is smaller than the fallback size heuristic."""
+    with db.batch() as batch:
+        batch.set(
+            ImageId.ORIG,
+            100,
+            name="Hello",
+            type=EntityType.DATA,
+            size=4,
+            data_type=0x1004,
+        )
+
+    lookup = create_lookup(db)
+
+    assert lookup(104) == "Hello+4 (OFFSET)"
 
 
 def test_offset_name_non_variables(db):

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -1,0 +1,437 @@
+"""Tests for cross-side operand equivalence refinement.
+Mismatching diff line pairs that differ only in structurally equivalent
+address operands are turned into matches. See OperandRefiner."""
+
+import pytest
+from reccmp.difflib import DiffOpcode
+from reccmp.compare.asm.parse import AsmExcerpt
+from reccmp.compare.asm.refine import (
+    ANCHOR_DELTA_LIMIT,
+    OperandRefiner,
+    _split_replace_block,
+    instruction_skeleton,
+)
+
+
+def make_refiner(
+    orig_candidates=None,
+    recomp_candidates=None,
+    orig_start=0x1000,
+    recomp_start=0x5000,
+    self_reach=0x100,
+) -> OperandRefiner:
+    empty: frozenset[tuple[int, int]] = frozenset()
+
+    return OperandRefiner(
+        orig_candidates=lambda addr: frozenset(
+            (orig_candidates or {}).get(addr, empty)
+        ),
+        recomp_candidates=lambda addr: frozenset(
+            (recomp_candidates or {}).get(addr, empty)
+        ),
+        orig_start=orig_start,
+        recomp_start=recomp_start,
+        self_reach=self_reach,
+    )
+
+
+####
+
+
+def test_skeleton():
+    """The skeleton is the instruction text with the address operands
+    masked out. Instructions that differ only in address operands have
+    the same skeleton."""
+    a = instruction_skeleton(
+        ("cmp eax, _array+8 (OFFSET)", ((0x2008, "_array+8 (OFFSET)", False),))
+    )
+    b = instruction_skeleton(
+        ("cmp eax, _next (DATA)", ((0x3000, "_next (DATA)", False),))
+    )
+    assert a is not None
+    assert a == b
+
+    # Different structure = different skeleton
+    c = instruction_skeleton(
+        ("mov eax, _next (DATA)", ((0x3000, "_next (DATA)", False),))
+    )
+    assert a != c
+
+    # Bogus record: replacement text does not appear in the line.
+    assert (
+        instruction_skeleton(("cmp eax, ebx", ((0x2008, "<OFFSET1>", False),))) is None
+    )
+
+
+def test_skeleton_multiple_operands():
+    """Each operand is masked with its position so that shapes align."""
+    rec = (
+        "mov dword ptr [<OFFSET1>], <OFFSET2>",
+        ((0x2000, "<OFFSET1>", False), (0x3000, "<OFFSET2>", False)),
+    )
+    skeleton = instruction_skeleton(rec)
+    assert skeleton is not None
+    assert "<OFFSET1>" not in skeleton and "<OFFSET2>" not in skeleton
+
+
+def _refine_single(
+    refiner: OperandRefiner,
+    orig_line: tuple[int, str],
+    recomp_line: tuple[int, str],
+    orig_ops,
+    recomp_ops,
+    *,
+    equal_lines=(),
+):
+    """Helper: run refine() on a diff with one mismatching line pair,
+    plus optional equal lines that can provide anchors. Each equal line
+    is (orig line addr, text, recomp line addr, orig op, recomp op)
+    where the ops are the operand values behind the shared text.
+    Returns the RefinedDiff or None."""
+    orig: AsmExcerpt = [*[(line[0], line[1]) for line in equal_lines], orig_line]
+    recomp: AsmExcerpt = [*[(line[2], line[1]) for line in equal_lines], recomp_line]
+    n = len(equal_lines)
+    opcodes: list[DiffOpcode] = []
+    if n:
+        opcodes.append(("equal", 0, n, 0, n))
+    opcodes.append(("replace", n, n + 1, n, n + 1))
+
+    orig_records = {orig_line[0]: (orig_line[1], tuple(orig_ops))}
+    recomp_records = {recomp_line[0]: (recomp_line[1], tuple(recomp_ops))}
+    for line_addr, text, line_addr2, op_value, op_value2 in equal_lines:
+        # Anchor lines: same replacement text, one address operand each.
+        orig_records[line_addr] = (text, ((op_value, text.split()[-1], False),))
+        recomp_records[line_addr2] = (text, ((op_value2, text.split()[-1], False),))
+
+    return refiner.refine(orig, recomp, opcodes, orig_records, recomp_records)
+
+
+def test_refine_by_shared_candidate():
+    """Both sides interpret their operand as the same matched entity at
+    the same delta: the pair matches."""
+    refiner = make_refiner(
+        orig_candidates={0x2064: {(0x2000, 100), (0x2064, 0)}},
+        recomp_candidates={0x6064: {(0x2000, 100)}},
+    )
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, _next (DATA)"),
+        (0x5010, "cmp eax, _table+100 (OFFSET)"),
+        [(0x2064, "_next (DATA)", False)],
+        [(0x6064, "_table+100 (OFFSET)", False)],
+    )
+    assert result is not None
+    # The recomp line was rewritten to the orig text...
+    assert result.recomp[-1] == (0x5010, "cmp eax, _next (DATA)")
+    # ...and the pair is now scored as a match.
+    assert ("equal", 0, 1, 0, 1) in result.opcodes
+
+
+def test_refine_no_shared_candidate():
+    """Different interpretations on each side: no match."""
+    refiner = make_refiner(
+        orig_candidates={0x2064: {(0x2064, 0)}},
+        recomp_candidates={0x6064: {(0x2000, 100)}},
+    )
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, _next (DATA)"),
+        (0x5010, "cmp eax, _table+100 (OFFSET)"),
+        [(0x2064, "_next (DATA)", False)],
+        [(0x6064, "_table+100 (OFFSET)", False)],
+    )
+    assert result is None
+
+
+def test_refine_by_function_interior():
+    """References into the function's own body at the same relative
+    offset (e.g. its own jump tables)."""
+    refiner = make_refiner(orig_start=0x1000, recomp_start=0x5000, self_reach=0x100)
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "jmp dword ptr [ecx*4 + <OFFSET1>]"),
+        (0x5010, "jmp dword ptr [ecx*4 + <OFFSET2>]"),
+        [(0x1050, "<OFFSET1>", False)],
+        [(0x5050, "<OFFSET2>", False)],
+    )
+    assert result is not None
+
+    # Not within the function body in both images: no match.
+    assert (
+        _refine_single(
+            refiner,
+            (0x1010, "jmp dword ptr [ecx*4 + <OFFSET1>]"),
+            (0x5010, "jmp dword ptr [ecx*4 + <OFFSET2>]"),
+            [(0x1200, "<OFFSET1>", False)],
+            [(0x5200, "<OFFSET2>", False)],
+        )
+        is None
+    )
+
+
+def test_refine_by_anchor():
+    """References into an unannotated object can be equated if some other
+    reference to the object was already matched up: both operands then
+    show the same delta from the matching pair."""
+    refiner = make_refiner()
+
+    # The equal line pins (0x102000 <-> 0x106000) as the same object.
+    # The mismatching operands are at delta 0x174 from that pair.
+    result = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, <OFFSET9>"),
+        (0x5010, "cmp eax, <OFFSET7>"),
+        [(0x102174, "<OFFSET9>", False)],
+        [(0x106174, "<OFFSET7>", False)],
+        equal_lines=[(0x2000, "mov eax, <OFFSET2>", 0x6000, 0x102000, 0x106000)],
+    )
+    assert result is not None
+
+    # Different deltas: no match.
+    assert (
+        _refine_single(
+            refiner,
+            (0x1010, "cmp eax, <OFFSET9>"),
+            (0x5010, "cmp eax, <OFFSET7>"),
+            [(0x102174, "<OFFSET9>", False)],
+            [(0x106170, "<OFFSET7>", False)],
+            equal_lines=[(0x2000, "mov eax, <OFFSET2>", 0x6000, 0x102000, 0x106000)],
+        )
+        is None
+    )
+
+
+def test_refine_strict_operands():
+    """A call target refers to the exact start of an entity. If a matched
+    entity claims either address exactly, the other side must be the
+    matched counterpart."""
+    # orig 0x2000 <-> recomp 0x6000 is a matched function.
+    # recomp 0x6005 is the start of another matched function whose orig
+    # address is elsewhere.
+    orig_candidates = {0x2000: {(0x2000, 0)}}
+    recomp_candidates = {0x6000: {(0x2000, 0)}, 0x6005: {(0x2F00, 0)}}
+    refiner = make_refiner(orig_candidates, recomp_candidates)
+
+    # Same matched entity: ok. (would normally already match by name,
+    # unless the entity has no name)
+    result = _refine_single(
+        refiner,
+        (0x1010, "call <OFFSET1>"),
+        (0x5010, "call <OFFSET2>"),
+        [(0x2000, "<OFFSET1>", True)],
+        [(0x6000, "<OFFSET2>", True)],
+    )
+    assert result is not None
+
+    # 0x6005 is the start of a different matched entity, even though the
+    # deltas from the anchor pair (provided by the equal line) agree.
+    # A slack interpretation must never override an exact one.
+    assert (
+        _refine_single(
+            refiner,
+            (0x1010, "call <OFFSET5>"),
+            (0x5010, "call Thunk of 'foo' (THUNK)"),
+            [(0x2005, "<OFFSET5>", True)],
+            [(0x6005, "Thunk of 'foo' (THUNK)", True)],
+            equal_lines=[(0x2000, "call <OFFSET2>", 0x6000, 0x2000, 0x6000)],
+        )
+        is None
+    )
+
+
+def test_refine_strict_unannotated_by_anchor():
+    """A call to a function that no annotation covers (e.g. a static
+    function that is invisible in the PDB) can still be equated by its
+    position relative to an anchor pair."""
+    refiner = make_refiner()
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "call _write_multi_char (FUNCTION)"),
+        (0x5010, "call <OFFSET3>"),
+        [(0x2300, "_write_multi_char (FUNCTION)", True)],
+        [(0x6300, "<OFFSET3>", True)],
+        equal_lines=[(0x2000, "call _write_char (FUNCTION)", 0x6000, 0x2000, 0x6000)],
+    )
+    assert result is not None
+
+
+def test_refine_different_shape():
+    """Lines with different instruction structure never match."""
+    refiner = make_refiner(
+        orig_candidates={0x2064: {(0x2000, 100)}},
+        recomp_candidates={0x6064: {(0x2000, 100)}},
+    )
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, _next (DATA)"),
+        (0x5010, "mov eax, _table+100 (OFFSET)"),
+        [(0x2064, "_next (DATA)", False)],
+        [(0x6064, "_table+100 (OFFSET)", False)],
+    )
+    assert result is None
+
+
+def test_refine_stale_record():
+    """If the line text changed after sanitization (e.g. assert_fixup),
+    the operand record no longer applies: no match."""
+    refiner = make_refiner(
+        orig_candidates={0x2064: {(0x2000, 100)}},
+        recomp_candidates={0x6064: {(0x2000, 100)}},
+    )
+
+    orig: AsmExcerpt = [(0x1010, "cmp eax, _next (DATA) MODIFIED")]
+    recomp: AsmExcerpt = [(0x5010, "cmp eax, _table+100 (OFFSET)")]
+    opcodes: list[DiffOpcode] = [("replace", 0, 1, 0, 1)]
+    orig_records = {
+        0x1010: ("cmp eax, _next (DATA)", ((0x2064, "_next (DATA)", False),))
+    }
+    recomp_records = {
+        0x5010: (
+            "cmp eax, _table+100 (OFFSET)",
+            ((0x6064, "_table+100 (OFFSET)", False),),
+        )
+    }
+
+    assert refiner.refine(orig, recomp, opcodes, orig_records, recomp_records) is None
+
+
+def test_refine_patches_locally():
+    """The diff opcodes are patched in place: refined pairs become equal,
+    everything else keeps its position. A replace block is split as
+    needed and leftover lines stay mismatched."""
+    refiner = make_refiner(
+        orig_candidates={0x2064: {(0x2000, 100)}},
+        recomp_candidates={0x6064: {(0x2000, 100)}},
+    )
+
+    orig: AsmExcerpt = [
+        (0x1000, "push ebx"),
+        (0x1001, "cmp eax, _next (DATA)"),
+        (0x1007, "xor eax, eax"),
+        (0x1009, "ret"),
+    ]
+    recomp: AsmExcerpt = [
+        (0x5000, "push ebx"),
+        (0x5001, "cmp eax, _table+100 (OFFSET)"),
+        (0x5007, "sub eax, eax"),
+    ]
+    opcodes: list[DiffOpcode] = [
+        ("equal", 0, 1, 0, 1),
+        ("replace", 1, 4, 1, 3),
+    ]
+    orig_records = {
+        0x1001: ("cmp eax, _next (DATA)", ((0x2064, "_next (DATA)", False),))
+    }
+    recomp_records = {
+        0x5001: (
+            "cmp eax, _table+100 (OFFSET)",
+            ((0x6064, "_table+100 (OFFSET)", False),),
+        )
+    }
+
+    result = refiner.refine(orig, recomp, opcodes, orig_records, recomp_records)
+    assert result is not None
+    assert result.recomp[1] == (0x5001, "cmp eax, _next (DATA)")
+    # The refined pair joins the preceding equal block; the rest of the
+    # replace block (including the leftover orig line) stays.
+    assert result.opcodes == [
+        ("equal", 0, 2, 0, 2),
+        ("replace", 2, 4, 2, 3),
+    ]
+
+
+@pytest.mark.parametrize(
+    "refined,expected",
+    (
+        # Trailing unrefined run absorbs the leftover lines.
+        (
+            [True, False],
+            [("equal", 10, 11, 20, 21), ("replace", 11, 14, 21, 22)],
+        ),
+        # Trailing refined run: leftover orig lines are a deletion.
+        (
+            [False, True],
+            [
+                ("replace", 10, 11, 20, 21),
+                ("equal", 11, 12, 21, 22),
+                ("delete", 12, 14, 22, 22),
+            ],
+        ),
+    ),
+)
+def test_split_replace_block(refined, expected):
+    # pylint: disable=protected-access
+    assert _split_replace_block(("replace", 10, 14, 20, 22), refined) == expected
+
+
+def test_refine_conflicting_exact_candidates():
+    """Both operands sit exactly on different matched entities: an
+    agreeing anchor may not override the annotations."""
+    refiner = make_refiner(
+        orig_candidates={0x102174: {(0x102174, 0)}},
+        recomp_candidates={0x106174: {(0x2F00, 0)}},
+    )
+
+    result = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, _alpha (DATA)"),
+        (0x5010, "cmp eax, _beta (DATA)"),
+        [(0x102174, "_alpha (DATA)", False)],
+        [(0x106174, "_beta (DATA)", False)],
+        equal_lines=[(0x2000, "mov eax, <OFFSET2>", 0x6000, 0x102000, 0x106000)],
+    )
+    assert result is None
+
+
+def test_refine_anchor_delta_boundary():
+    """The anchor rule accepts a delta of exactly ANCHOR_DELTA_LIMIT and
+    rejects one byte more."""
+    refiner = make_refiner()
+
+    at_limit = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, <OFFSET9>"),
+        (0x5010, "cmp eax, <OFFSET7>"),
+        [(0x102000 + ANCHOR_DELTA_LIMIT, "<OFFSET9>", False)],
+        [(0x106000 + ANCHOR_DELTA_LIMIT, "<OFFSET7>", False)],
+        equal_lines=[(0x2000, "mov eax, <OFFSET2>", 0x6000, 0x102000, 0x106000)],
+    )
+    assert at_limit is not None
+
+    past_limit = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, <OFFSET9>"),
+        (0x5010, "cmp eax, <OFFSET7>"),
+        [(0x102001 + ANCHOR_DELTA_LIMIT, "<OFFSET9>", False)],
+        [(0x106001 + ANCHOR_DELTA_LIMIT, "<OFFSET7>", False)],
+        equal_lines=[(0x2000, "mov eax, <OFFSET2>", 0x6000, 0x102000, 0x106000)],
+    )
+    assert past_limit is None
+
+
+def test_refine_self_reach_boundary():
+    """A reference into the function's own body must be strictly interior."""
+    refiner = make_refiner(orig_start=0x1000, recomp_start=0x5000, self_reach=0x100)
+
+    interior = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, <OFFSET9>"),
+        (0x5010, "cmp eax, <OFFSET7>"),
+        [(0x10FF, "<OFFSET9>", False)],
+        [(0x50FF, "<OFFSET7>", False)],
+    )
+    assert interior is not None
+
+    past_end = _refine_single(
+        refiner,
+        (0x1010, "cmp eax, <OFFSET9>"),
+        (0x5010, "cmp eax, <OFFSET7>"),
+        [(0x1100, "<OFFSET9>", False)],
+        [(0x5100, "<OFFSET7>", False)],
+    )
+    assert past_end is None


### PR DESCRIPTION
> [!NOTE]
> Stacked on #523 (its commit is included here); please review only the second commit.

Two operands that point at the same thing can compare unequal today when their addresses displace differently in each image:

- one-past-the-end of an array that coincides with the start of the next variable in one image but not the other (`__dosmaperr`, `__spawnve`)
- references biased slightly before/past a variable, e.g. an array base folded with the first index, or a walking-pointer end bound anchored on a struct member (`MxSoundManager::GetAttenuation`, `Act3Cop::ParseAction`)
- references into the function's own body, e.g. its jump tables, when the function links at a different address (Smacker blob)
- calls to functions no symbol covers, e.g. statics invisible in the PDB (`__output` -> `_write_multi_char`/`_write_string`)

After the initial diff, mismatching line pairs are re-examined: if two lines differ only in address operands and every operand pair shares an interpretation — the same matched entity at the same delta, or the same delta from an operand pair that already compares equal — the pair is scored as a match. The design is deliberately fail-closed: equivalence is strictly symmetric (a one-sided fuzzy resolution is never accepted); call targets and indirect slots only accept exact-entity or position-based interpretations that no annotation contradicts; and the diff opcodes are patched locally, so the ratio can only increase and rewritten lines cannot re-pair with unrelated lines.

This also shares detected jump/data table locations (function-relative) between the two disassemblies when their section layouts disagree. A table sitting before the instruction that reads it was previously disassembled as junk code with image-specific relocated bytes, or cut the disassembly short at an undecodable byte; both Smacker `DoFrame` functions were affected (0.10 -> 1.0). The re-parse is kept only if both sides converge on the same layout.

Validation on the LEGO Island project (zero regressed rows on any target): on a rebuild whose binaries are byte-identical to retail, this plus #523 and #525 takes every remaining sub-100% row to 100% (previously 198 LEGO1 / 1 ISLE / 2 CONFIG rows scored below 100% despite identical bytes). An earlier validation against non-identical builds showed 9 improved + 7 new 100% on LEGO1 and 116 improved + 22 new 100% on BETA10. New coverage in `tests/test_refine.py`, `tests/test_candidate_lookup.py`, `tests/test_instgen.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P88DB9e4CuwhuVz46toNb