### PR TITLE
compare: strip trailing nulls when naming a string entity

### DIFF
--- a/reccmp/compare/db.py
+++ b/reccmp/compare/db.py
@@ -10,8 +10,23 @@ from reccmp.types import EntityType, ImageId
 
 def entity_name_from_string(text: str, wide: bool = False) -> str:
     """Create an entity name for the given string by escaping
-    control characters and double quotes, then wrapping in double quotes."""
-    escaped = text.encode("unicode_escape").decode("utf-8").replace('"', '\\"')
+    control characters and double quotes, then wrapping in double quotes.
+
+    TRAILING null characters are stripped first, because the two images do not
+    report string extents the same way. In the recompiled image we know each
+    literal's true extent from its section contribution, so a source literal
+    spelled `"text\\0"` is read back as 'text\\x00'. In the original image there
+    is no such metadata and the reader stops at the first null, giving 'text'.
+    Substituting those two into the disassembly would make an operand pair that
+    refers to identical bytes compare as a difference -- i.e. it would score a
+    CORRECT source lower than an incorrect one. Trailing nulls are storage, not
+    content: a C string's identity for comparison purposes ends at its
+    terminator. Nulls in the INTERIOR are preserved, so the ability to read and
+    match strings containing embedded nulls (the reason the known extent is
+    used in the first place) is unaffected."""
+    escaped = (
+        text.rstrip("\0").encode("unicode_escape").decode("utf-8").replace('"', '\\"')
+    )
     return f'{"L" if wide else ""}"{escaped}"'
 
 

--- a/tests/test_compare_analyze.py
+++ b/tests/test_compare_analyze.py
@@ -314,6 +314,31 @@ def test_complete_partial_strings_with_nulls(db: EntityDb):
     assert e.name == '"\\x00test"'
 
 
+def test_complete_partial_strings_trailing_null_spelling(db: EntityDb):
+    """A literal spelled "text\0" stores one more byte, which only the sized
+    (section contribution) reader can see; the unsized reader stops at the
+    first null. Both must produce the same name for the same bytes."""
+    binfile = Mock(spec=[])
+    binfile.read = Mock(return_value=b"text\x00\x00")
+    binfile.read_string = Mock(return_value=b"text")
+
+    with db.batch() as batch:
+        # Contribution-sized, like a recomp string from the PDB.
+        batch.set(ImageId.ORIG, 100, type=EntityType.STRING, size=6)
+        # No size metadata, like an orig string.
+        batch.set(ImageId.ORIG, 200, type=EntityType.STRING)
+
+    complete_partial_strings(db, ImageId.ORIG, binfile)
+
+    sized = db.get(ImageId.ORIG, 100)
+    unsized = db.get(ImageId.ORIG, 200)
+    assert sized is not None and unsized is not None
+    # Trailing nulls are storage, not content: the names agree.
+    assert sized.name == unsized.name == '"text"'
+    # The true extent stays on the sized entity.
+    assert sized.any_size() == 6
+
+
 def test_complete_partial_strings_widechar(db: EntityDb):
     """Should read data for a partially-initialized widechar entity."""
     binfile = Mock(spec=[])

--- a/tests/test_entity_obj.py
+++ b/tests/test_entity_obj.py
@@ -60,6 +60,16 @@ def test_entity_name_from_string():
     # Escaping double quotes (not part of unicode_escape conversion)
     assert entity_name_from_string('"quotes"') == '"\\"quotes\\""'
 
+    # Trailing nulls are storage, not content: the recomp reader knows each
+    # literal's true extent and includes the terminator, the orig reader stops
+    # at the first null. Strip them so both sides produce the same name.
+    assert entity_name_from_string("text\x00") == '"text"'
+    assert entity_name_from_string("text\x00", wide=True) == 'L"text"'
+    assert entity_name_from_string("\x00\x00") == '""'
+    # Interior nulls are content (embedded-null matching) and are preserved.
+    assert entity_name_from_string("a\x00b") == '"a\\x00b"'
+    assert entity_name_from_string("a\x00b\x00") == '"a\\x00b"'
+
     # Escaping extended ASCII (Latin1) character
     assert entity_name_from_string("®") == '"\\xae"'
     assert entity_name_from_string("®", wide=True) == 'L"\\xae"'


### PR DESCRIPTION
The two images do not report string extents the same way, and the asymmetry makes a *correct* source score lower than an incorrect one.

In the recompiled image each literal's true extent is known from its section contribution, and `create_recomp_strings` deliberately uses it so strings containing embedded nulls can be read at all. In the original image there is no such metadata, so the reader stops at the first null. A source literal spelled `"Action not supported.\0"` therefore becomes entity name `"Action not supported.\x00"` on the recomp side but `"Action not supported."` on the orig side; both names are substituted into the disassembly, so an instruction pair referring to byte-identical data compares as a difference.

That is not hypothetical: the LEGO Island DirectDraw error tables are provably spelled with the trailing `\0` in the shipped 1997 source (each of those literals occupies `round_up(strlen+2, 4)` in `.data` while every other literal in the same object occupies `round_up(strlen+1, 4)`). Restoring that spelling reproduces all 91 string addresses exactly, yet dropped `MxDirectDraw::ErrorToString` and `MxDeviceEnumerate::EnumerateErrorToString` from 1.0 to 0.79.

Trailing nulls are storage, not content: a C string's identity for comparison ends at its terminator. Interior nulls are preserved, so the embedded-null matching that motivates using the known extent is unaffected. New cases in `tests/test_entity_obj.py` cover trailing, interior, and all-null strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P88DB9e4CuwhuVz46toNb