### PR TITLE
compare: anchor annotated statics inside preserved spans

### DIFF
--- a/reccmp/compare/core.py
+++ b/reccmp/compare/core.py
@@ -61,6 +61,7 @@ from .mutate import (
     name_thunks,
     unique_names_for_overloaded_functions,
     match_crt_startup,
+    match_span_anchored_functions,
     set_max_size,
 )
 from .verify import (
@@ -192,6 +193,7 @@ class Compare:
             set_max_size(self._db, img_id)
 
         match_crt_startup(self._db, self.orig_bin, self.recomp_bin)
+        match_span_anchored_functions(self._db)
         check_vtables(self._db)
         match_ref(self._db, self.report)
         unique_names_for_overloaded_functions(self._db)

--- a/reccmp/compare/mutate.py
+++ b/reccmp/compare/mutate.py
@@ -13,7 +13,7 @@ from reccmp.cvdump.demangler import (
 )
 from reccmp.formats import PEImage
 from reccmp.types import EntityType, ImageId
-from .db import EntityDb
+from .db import EntityDb, ReccmpEntity
 from .queries import get_overloaded_functions, get_named_thunks
 
 logger = logging.getLogger(__name__)
@@ -58,6 +58,74 @@ def set_max_size(db: EntityDb, image_id: ImageId):
             # Measured against the end of the section/image.
             if last_addr is not None:
                 batch.set(image_id, last_addr, max_size=range_.stop - last_addr)
+
+
+def match_span_anchored_functions(db: EntityDb):
+    """Match annotated functions that no symbol can reach by anchoring them
+    inside a preserved span between matched neighbors.
+
+    A static function (e.g. a CRT-internal helper like _write_multi_char) is
+    invisible in the PDB, so an annotation for it can never be matched by
+    name. Its address is still fully determined by its object's section
+    contribution: it keeps its offset relative to the surrounding, matchable
+    functions as long as that span is reproduced. For each unmatched annotated
+    FUNCTION entity that lies between two matched functions whose span has the
+    same length in both images, match it at the same offset in the recompiled
+    image. The regular function comparison still scores the new match, so a
+    wrong anchor shows up as a mismatch instead of passing silently.
+
+    A candidate is skipped when any entity already exists at the anchored
+    recomp address: a known entity there means the symbol table disagrees
+    with the anchoring, and the annotation should then only match by name."""
+
+    anchor: ReccmpEntity | None = None
+    pending: list[ReccmpEntity] = []
+
+    with db.batch() as batch:
+        for ent in db.all(ImageId.ORIG):
+            if ent.entity_type != EntityType.FUNCTION:
+                continue
+
+            if not ent.matched:
+                if anchor is not None and not ent.get("stub", False):
+                    pending.append(ent)
+                continue
+
+            # A matched function closes the current span.
+            if pending:
+                assert anchor is not None
+                anchor_orig = anchor.addr(ImageId.ORIG)
+                anchor_recomp = anchor.addr(ImageId.RECOMP)
+                close_orig = ent.addr(ImageId.ORIG)
+                close_recomp = ent.addr(ImageId.RECOMP)
+                assert anchor_orig is not None and anchor_recomp is not None
+                assert close_orig is not None and close_recomp is not None
+
+                if close_orig - anchor_orig == close_recomp - anchor_recomp:
+                    # Each static extends at most to the next function in the
+                    # span (finally, the closing anchor).
+                    bounds = [s.addr(ImageId.ORIG) for s in pending[1:]]
+                    bounds.append(close_orig)
+
+                    for static, bound in zip(pending, bounds):
+                        static_orig = static.addr(ImageId.ORIG)
+                        assert static_orig is not None and bound is not None
+                        candidate = anchor_recomp + (static_orig - anchor_orig)
+                        if db.get(ImageId.RECOMP, candidate) is not None:
+                            continue
+
+                        batch.match(static_orig, candidate)
+                        # Without any size the match cannot be compared (and
+                        # would silently disappear from the report). The span
+                        # is preserved, so the orig-side extent bound applies
+                        # to the recomp side as well.
+                        if static.size(ImageId.RECOMP) is None:
+                            batch.set(
+                                ImageId.RECOMP, candidate, size=bound - static_orig
+                            )
+
+            anchor = ent
+            pending.clear()
 
 
 def name_thunks(db: EntityDb):

--- a/tests/test_compare_mutate.py
+++ b/tests/test_compare_mutate.py
@@ -1,5 +1,6 @@
 import pytest
 from reccmp.compare.mutate import (
+    match_span_anchored_functions,
     name_thunks,
     set_max_size,
 )
@@ -383,3 +384,122 @@ def test_set_max_size_section_boundaries(db: EntityDb, image_id: ImageId):
     ent = db.get(image_id, 500)
     assert ent is not None
     assert ent.max_size(image_id) == 100
+
+
+def _span_db(db: EntityDb, *, close_recomp: int = 1200) -> EntityDb:
+    """Two matched functions at (100, 1100) and (200, close_recomp) with an
+    unmatched annotated static function at 150 between them."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION, name="alpha")
+        batch.match(100, 1100)
+        batch.set(ImageId.ORIG, 150, type=EntityType.FUNCTION, name="static_helper")
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION, name="omega")
+        batch.match(200, close_recomp)
+
+    return db
+
+
+def test_span_anchor_matches_static(db: EntityDb):
+    """An unmatched function between two matched functions whose span is
+    preserved is matched at the same offset in the recomp image."""
+    match_span_anchored_functions(_span_db(db))
+
+    ent = db.get(ImageId.ORIG, 150)
+    assert ent is not None
+    assert ent.matched
+    assert ent.addr(ImageId.RECOMP) == 1150
+
+
+def test_span_anchor_requires_preserved_span(db: EntityDb):
+    """No match when the span between the anchors differs."""
+    match_span_anchored_functions(_span_db(db, close_recomp=1210))
+
+    ent = db.get(ImageId.ORIG, 150)
+    assert ent is not None
+    assert not ent.matched
+
+
+def test_span_anchor_requires_vacant_recomp_addr(db: EntityDb):
+    """No match when any entity already exists at the anchored address.
+    The symbol table disagrees with the anchoring in that case."""
+    _span_db(db)
+    with db.batch() as batch:
+        batch.set(ImageId.RECOMP, 1150, name="occupied")
+
+    match_span_anchored_functions(db)
+
+    ent = db.get(ImageId.ORIG, 150)
+    assert ent is not None
+    assert not ent.matched
+
+
+def test_span_anchor_requires_both_anchors(db: EntityDb):
+    """No match without a matched function on both sides of the static."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION, name="alpha")
+        batch.match(100, 1100)
+        batch.set(ImageId.ORIG, 150, type=EntityType.FUNCTION, name="static_helper")
+
+    match_span_anchored_functions(db)
+
+    ent = db.get(ImageId.ORIG, 150)
+    assert ent is not None
+    assert not ent.matched
+
+
+def test_span_anchor_before_first_match(db: EntityDb):
+    """No match for an unmatched function that precedes every matched one."""
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 50, type=EntityType.FUNCTION, name="static_helper")
+        batch.set(ImageId.ORIG, 100, type=EntityType.FUNCTION, name="alpha")
+        batch.match(100, 1100)
+        batch.set(ImageId.ORIG, 200, type=EntityType.FUNCTION, name="omega")
+        batch.match(200, 1200)
+
+    match_span_anchored_functions(db)
+
+    ent = db.get(ImageId.ORIG, 50)
+    assert ent is not None
+    assert not ent.matched
+
+
+def test_span_anchor_skips_stubs(db: EntityDb):
+    """A STUB-annotated function is not eligible for anchoring."""
+    _span_db(db)
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 150, stub=True)
+
+    match_span_anchored_functions(db)
+
+    ent = db.get(ImageId.ORIG, 150)
+    assert ent is not None
+    assert not ent.matched
+
+
+def test_span_anchor_multiple_statics(db: EntityDb):
+    """Each unmatched function in a preserved span is anchored independently."""
+    _span_db(db)
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 170, type=EntityType.FUNCTION, name="static_helper2")
+
+    match_span_anchored_functions(db)
+
+    for orig_addr, recomp_addr in ((150, 1150), (170, 1170)):
+        ent = db.get(ImageId.ORIG, orig_addr)
+        assert ent is not None
+        assert ent.matched
+        assert ent.addr(ImageId.RECOMP) == recomp_addr
+
+
+def test_span_anchor_ignores_non_functions(db: EntityDb):
+    """Only FUNCTION entities participate: an unmatched DATA entity in the
+    span is not anchored, and matched DATA entities are not span anchors."""
+    _span_db(db)
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, 160, type=EntityType.DATA, name="g_value")
+
+    match_span_anchored_functions(db)
+
+    ent = db.get(ImageId.ORIG, 160)
+    assert ent is not None
+    assert not ent.matched


### PR DESCRIPTION
A static function (e.g. a CRT-internal helper like `_write_multi_char`) is invisible in the PDB, so an annotation for it can never be matched by name — it is reported as an unmatched stub forever, even when the rebuilt code is identical.

Its address is still fully determined by its object's section contribution: it keeps its offset relative to the surrounding, matchable functions as long as that span is reproduced. This change matches each unmatched annotated FUNCTION entity that lies between two matched functions whose span has the same length in both images, at the same offset in the recompiled image. Guards:

- the enclosing span must have exactly the same length on both sides (a changed contribution disables the anchoring);
- the anchored recomp address must be vacant — any existing entity there means the symbol table disagrees, and the annotation may then only match by name;
- the regular function comparison still scores the new match, so a wrong anchor shows up as a mismatched row instead of passing silently;
- the recomp side receives the orig-side extent bound as its size so the match is actually comparable (matches without any size are dropped from the report).

On the LEGO Island project this resolves the two remaining ISLE stubs, `_write_multi_char` and `_write_string` (both compare at 100%), with no change to any other row. Eight new cases in `tests/test_compare_mutate.py` cover the span, vacancy, stub, ordering, and multi-static rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P88DB9e4CuwhuVz46toNb