### PR TITLE
Ghidra import: testing various inheritance patterns

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -44,7 +44,7 @@ jobs:
             '# codespell:ignore-begin.*?codespell:ignore-end *\n' \
           --ignore-regex remote-checkin-comment \
           -L SEH \
-          -S ./tests/cvdump_sample/*.txt \
+          -S "./tests/cvdump_sample/*.txt" \
           ./reccmp ./tests
 
   js-format:

--- a/reccmp/ghidra/importer/type_importer.py
+++ b/reccmp/ghidra/importer/type_importer.py
@@ -238,8 +238,15 @@ class PdbTypeImporter:
 
         class_size: int = type_in_pdb["size"]
         raw_name: str = type_in_pdb["name"]
-        # Only a class with a virtual base of its own needs the slim treatment.
-        # A sibling base class without one fits at the offset given for it.
+        # Virtual inheritance requires that struct members are arranged in this order:
+        #
+        # 1. Members from non-virtual base classes.
+        # 2. Members from the derived class.
+        # 3. Members from virtual base classes.
+        #
+        # If this class has a direct virtual base class and we are creating it as the base for something else
+        # (i.e. if `as_base_class` is True) then we need to create a "slim" copy that contains only the
+        # non-virtual base classes and its own members.
         make_slim = as_base_class and "vbase" in field_list
         if make_slim:
             raw_name += "_vbase_slim"

--- a/reccmp/ghidra/importer/type_importer.py
+++ b/reccmp/ghidra/importer/type_importer.py
@@ -306,8 +306,6 @@ class PdbTypeImporter:
         components.sort(key=lambda c: c.offset)
 
         if make_slim:
-            # Make a "slim" version: shrink the size to the fields that are actually present.
-            # This makes a difference when the current class uses virtual inheritance
             assert (
                 len(components) > 0
             ), f"Error: {sanitized_name} should not be empty. There must be at least one direct or indirect vbase pointer."

--- a/reccmp/ghidra/importer/type_importer.py
+++ b/reccmp/ghidra/importer/type_importer.py
@@ -80,7 +80,7 @@ class PdbTypeImporter:
         return self.extraction.compare.types
 
     def import_pdb_type_into_ghidra(
-        self, type_index: CvdumpTypeKey, as_base_class: bool = False
+        self, type_index: CvdumpTypeKey, *, as_base_class: bool = False
     ) -> DataType:
         """
         Recursively imports a type from the PDB into Ghidra.
@@ -171,7 +171,9 @@ class PdbTypeImporter:
             type_index,
             referenced_type,
         )
-        return self.import_pdb_type_into_ghidra(referenced_type, as_base_class)
+        return self.import_pdb_type_into_ghidra(
+            referenced_type, as_base_class=as_base_class
+        )
 
     def _import_array(self, type_pdb: CvdumpParsedType) -> DataType:
         inner_type = self.import_pdb_type_into_ghidra(type_pdb["array_type"])

--- a/reccmp/ghidra/importer/type_importer.py
+++ b/reccmp/ghidra/importer/type_importer.py
@@ -80,18 +80,18 @@ class PdbTypeImporter:
         return self.extraction.compare.types
 
     def import_pdb_type_into_ghidra(
-        self, type_index: CvdumpTypeKey, slim_for_vbase: bool = False
+        self, type_index: CvdumpTypeKey, as_base_class: bool = False
     ) -> DataType:
         """
         Recursively imports a type from the PDB into Ghidra.
         @param type_index Either a scalar type like `T_INT4(...)` or a PDB reference like `0x10ba`
-        @param slim_for_vbase If `True`, the current invocation
-            imports a superclass of some class where virtual inheritance is involved (directly or indirectly).
-            This case requires special handling: Let's say we have `class C: B` and `class B: virtual A`. Then cvdump
+        @param as_base_class If `True`, the current invocation
+            imports a superclass to be embedded in some derived class. Virtual inheritance may
+            be involved: Let's say we have `class C: B` and `class B: virtual A`. Then cvdump
             reports a size for B that includes both B's fields as well as the A contained at an offset within B,
             which is not the correct structure to be contained in C. Therefore, we need to create a "slim" version of B
             that fits inside C.
-            This value should always be `False` when the referenced type is not (a pointer to) a class.
+            This value should always be `False` when the referenced type is not a class.
         """
         if type_index.is_scalar():
             return self._import_scalar_type(type_index)
@@ -107,17 +107,20 @@ class PdbTypeImporter:
 
         # follow forward reference (class, struct, union)
         if type_pdb.get("is_forward_ref", False):
-            return self._import_forward_ref_type(type_index, type_pdb, slim_for_vbase)
+            return self._import_forward_ref_type(type_index, type_pdb, as_base_class)
+
+        if type_category in ["LF_CLASS", "LF_STRUCTURE"]:
+            return self._import_class_or_struct(type_pdb, as_base_class)
+
+        assert (
+            not as_base_class
+        ), f"Tried to import {type_index} ({type_category}) as base class"
 
         if type_category == "LF_POINTER":
             return get_or_add_pointer_type(
                 self.api,
-                self.import_pdb_type_into_ghidra(
-                    type_pdb["element_type"], slim_for_vbase
-                ),
+                self.import_pdb_type_into_ghidra(type_pdb["element_type"]),
             )
-        elif type_category in ["LF_CLASS", "LF_STRUCTURE"]:
-            return self._import_class_or_struct(type_pdb, slim_for_vbase)
         elif type_category == "LF_ARRAY":
             return self._import_array(type_pdb)
         elif type_category == "LF_ENUM":
@@ -150,7 +153,7 @@ class PdbTypeImporter:
         self,
         type_index: CvdumpTypeKey,
         type_pdb: CvdumpParsedType,
-        slim_for_vbase: bool = False,
+        as_base_class: bool = False,
     ) -> DataType:
         referenced_type = type_pdb.get("udt") or type_pdb.get("modifies")
         if referenced_type is None:
@@ -168,7 +171,7 @@ class PdbTypeImporter:
             type_index,
             referenced_type,
         )
-        return self.import_pdb_type_into_ghidra(referenced_type, slim_for_vbase)
+        return self.import_pdb_type_into_ghidra(referenced_type, as_base_class)
 
     def _import_array(self, type_pdb: CvdumpParsedType) -> DataType:
         inner_type = self.import_pdb_type_into_ghidra(type_pdb["array_type"])
@@ -226,14 +229,17 @@ class PdbTypeImporter:
     def _import_class_or_struct(
         self,
         type_in_pdb: CvdumpParsedType,
-        slim_for_vbase: bool = False,
+        as_base_class: bool = False,
     ) -> DataType:
         field_list_type = type_in_pdb["field_list_type"]
         field_list = self.types.from_key(field_list_type)
 
         class_size: int = type_in_pdb["size"]
         raw_name: str = type_in_pdb["name"]
-        if slim_for_vbase:
+        # Only a class with a virtual base of its own needs the slim treatment.
+        # A sibling base class without one fits at the offset given for it.
+        make_slim = as_base_class and "vbase" in field_list
+        if make_slim:
             raw_name += "_vbase_slim"
         sanitized_name = sanitize_name(raw_name)
 
@@ -299,7 +305,7 @@ class PdbTypeImporter:
 
         components.sort(key=lambda c: c.offset)
 
-        if slim_for_vbase:
+        if make_slim:
             # Make a "slim" version: shrink the size to the fields that are actually present.
             # This makes a difference when the current class uses virtual inheritance
             assert (
@@ -325,11 +331,8 @@ class PdbTypeImporter:
         non_virtual_base_classes: dict[CvdumpTypeKey, int] = field_list.get("super", {})
 
         for super_type, offset in non_virtual_base_classes.items():
-            # If we have virtual inheritance _and_ a non-virtual base class here, we play safe and import slim version.
-            # This is technically not needed if only one of the superclasses uses virtual inheritance, but I am not aware of any instance.
-            import_slim_vbase_version_of_superclass = "vbase" in field_list
             ghidra_type = self.import_pdb_type_into_ghidra(
-                super_type, slim_for_vbase=import_slim_vbase_version_of_superclass
+                super_type, as_base_class=True
             )
 
             yield GhidraFieldListItem(

--- a/tests/cvdump_sample/base-padding.txt
+++ b/tests/cvdump_sample/base-padding.txt
@@ -1,0 +1,72 @@
+class-d 0x1006
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100c)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100a)
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001008)
+
+0x1005 : Length = 54, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 4
+	list[2] = LF_BCLASS, public, type = 0x1004, offset = 16
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 24
+		member name = 'm_d0'
+
+0x1006 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1005, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = D, UDT(0x00001006)
+
+0x1007 : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_REAL64(0041), offset = 0
+		member name = 'm_c0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = C, UDT(0x00001008)
+
+0x1009 : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_b0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b1'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = B, UDT(0x0000100a)
+
+0x100b : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 0
+		member name = 'm_a0'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 1, class name = A, UDT(0x0000100c)
+

--- a/tests/cvdump_sample/cpp/base_padding.cpp
+++ b/tests/cvdump_sample/cpp/base_padding.cpp
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	char m_a0;
+};
+
+class B
+{
+public:
+	int m_b0;
+	int m_b1;
+};
+
+class C
+{
+public:
+	double m_c0;
+};
+
+class D : public A, public B, public C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(b, m_b1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(d, m_b1));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/diamond_duplicate.cpp
+++ b/tests/cvdump_sample/cpp/diamond_duplicate.cpp
@@ -1,0 +1,65 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+// Offset of a member inherited through `base`, measured from the start of obj.
+#define OFFSET_VIA(base, obj, member) \
+	(int)((char*)&((base*)&(obj))->member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public A
+{
+public:
+	int m_b0;
+};
+
+class C : public A
+{
+public:
+	int m_c0;
+};
+
+class D : public B, public C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  B::A::m_a0 +%d\n", OFFSET_VIA(B, d, m_a0));
+	printf("  B::A::m_a1 +%d\n", OFFSET_VIA(B, d, m_a1));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  C::A::m_a0 +%d\n", OFFSET_VIA(C, d, m_a0));
+	printf("  C::A::m_a1 +%d\n", OFFSET_VIA(C, d, m_a1));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/diamond_virtual.cpp
+++ b/tests/cvdump_sample/cpp/diamond_virtual.cpp
@@ -1,0 +1,59 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	int m_b0;
+};
+
+class C : public virtual A
+{
+public:
+	int m_c0;
+};
+
+class D : public B, public C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(d, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/multiple_inheritance.cpp
+++ b/tests/cvdump_sample/cpp/multiple_inheritance.cpp
@@ -1,0 +1,53 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+	int m_a2;
+};
+
+class B
+{
+public:
+	int m_b0;
+	int m_b1;
+	int m_b2;
+};
+
+class C : public A, public B
+{
+public:
+	int m_c0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+	printf("  A::m_a2    +%d\n", OFFSET_OF(a, m_a2));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(b, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(b, m_b2));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+	printf("  A::m_a2    +%d\n", OFFSET_OF(c, m_a2));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(c, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(c, m_b2));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/multiple_inheritance_virtual_functions.cpp
+++ b/tests/cvdump_sample/cpp/multiple_inheritance_virtual_functions.cpp
@@ -1,0 +1,66 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	virtual void Update();
+	int m_a0;
+	int m_a1;
+};
+
+class B
+{
+public:
+	virtual void Reset();
+	int m_b0;
+};
+
+class C : public A, public B
+{
+public:
+	virtual void Stop();
+	int m_c0;
+};
+
+void A::Update()
+{
+	m_a0 = 0;
+}
+
+void B::Reset()
+{
+	m_b0 = 0;
+}
+
+void C::Stop()
+{
+	m_c0 = 0;
+}
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+
+	c.Update();
+	c.Reset();
+	c.Stop();
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_after_base.cpp
+++ b/tests/cvdump_sample/cpp/vbase_after_base.cpp
@@ -1,0 +1,50 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B
+{
+public:
+	int m_b0;
+	int m_b1;
+	int m_b2;
+};
+
+class C : public B, public virtual A
+{
+public:
+	int m_c0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(b, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(b, m_b2));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(c, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(c, m_b2));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_alignment.cpp
+++ b/tests/cvdump_sample/cpp/vbase_alignment.cpp
@@ -1,0 +1,49 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	double m_a0;
+	char m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	int m_b0;
+	char m_b1;
+};
+
+class C : public B
+{
+public:
+	char m_c0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(b, m_b1));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(c, m_b1));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_chain.cpp
+++ b/tests/cvdump_sample/cpp/vbase_chain.cpp
@@ -1,0 +1,60 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	int m_b0;
+};
+
+class C : public virtual B
+{
+public:
+	int m_c0;
+};
+
+class D : public virtual C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(d, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_first_base.cpp
+++ b/tests/cvdump_sample/cpp/vbase_first_base.cpp
@@ -1,0 +1,63 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	int m_b0;
+};
+
+class C
+{
+public:
+	int m_c0;
+	int m_c1;
+	int m_c2;
+};
+
+class D : public B, public C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  C::m_c1    +%d\n", OFFSET_OF(c, m_c1));
+	printf("  C::m_c2    +%d\n", OFFSET_OF(c, m_c2));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  C::m_c1    +%d\n", OFFSET_OF(d, m_c1));
+	printf("  C::m_c2    +%d\n", OFFSET_OF(d, m_c2));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(d, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_padding.cpp
+++ b/tests/cvdump_sample/cpp/vbase_padding.cpp
@@ -1,0 +1,53 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	double m_a0;
+};
+
+class B
+{
+public:
+	char m_b0;
+};
+
+class C : public virtual A, public virtual B
+{
+public:
+	double m_c0;
+};
+
+class D : public virtual B, public virtual A
+{
+public:
+	double m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_padding_packed.cpp
+++ b/tests/cvdump_sample/cpp/vbase_padding_packed.cpp
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+#pragma pack(1)
+
+class A
+{
+public:
+	double m_a0;
+};
+
+class B
+{
+public:
+	char m_b0;
+};
+
+class C : public virtual A, public virtual B
+{
+public:
+	double m_c0;
+};
+
+class D : public virtual B, public virtual A
+{
+public:
+	double m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_second_base.cpp
+++ b/tests/cvdump_sample/cpp/vbase_second_base.cpp
@@ -1,0 +1,63 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B
+{
+public:
+	int m_b0;
+	int m_b1;
+	int m_b2;
+};
+
+class C : public virtual A
+{
+public:
+	int m_c0;
+};
+
+class D : public B, public C
+{
+public:
+	int m_d0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+	D d;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(b, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(b, m_b2));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	printf("D            size %d\n", (int)sizeof(D));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(d, m_b0));
+	printf("  B::m_b1    +%d\n", OFFSET_OF(d, m_b1));
+	printf("  B::m_b2    +%d\n", OFFSET_OF(d, m_b2));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(d, m_c0));
+	printf("  D::m_d0    +%d\n", OFFSET_OF(d, m_d0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(d, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(d, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_simple.cpp
+++ b/tests/cvdump_sample/cpp/vbase_simple.cpp
@@ -1,0 +1,46 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	int m_b0;
+};
+
+class C : public B
+{
+public:
+	int m_c0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_two.cpp
+++ b/tests/cvdump_sample/cpp/vbase_two.cpp
@@ -1,0 +1,44 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B
+{
+public:
+	int m_b0;
+};
+
+class C : public virtual A, public virtual B
+{
+public:
+	int m_c0;
+};
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+
+	return 0;
+}

--- a/tests/cvdump_sample/cpp/vbase_vftable.cpp
+++ b/tests/cvdump_sample/cpp/vbase_vftable.cpp
@@ -1,0 +1,54 @@
+#include <stdio.h>
+
+#define OFFSET_OF(obj, member) (int)((char*)&(obj).member - (char*)&(obj))
+
+class A
+{
+public:
+	int m_a0;
+	int m_a1;
+};
+
+class B : public virtual A
+{
+public:
+	virtual void Update();
+	int m_b0;
+};
+
+class C : public B
+{
+public:
+	int m_c0;
+};
+
+void B::Update()
+{
+	m_b0 = 0;
+}
+
+int main()
+{
+	A a;
+	B b;
+	C c;
+
+	printf("A            size %d\n", (int)sizeof(A));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(a, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(a, m_a1));
+
+	printf("B            size %d\n", (int)sizeof(B));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(b, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(b, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(b, m_a1));
+
+	printf("C            size %d\n", (int)sizeof(C));
+	printf("  C::m_c0    +%d\n", OFFSET_OF(c, m_c0));
+	printf("  B::m_b0    +%d\n", OFFSET_OF(c, m_b0));
+	printf("  A::m_a0    +%d\n", OFFSET_OF(c, m_a0));
+	printf("  A::m_a1    +%d\n", OFFSET_OF(c, m_a1));
+
+	c.Update();
+
+	return 0;
+}

--- a/tests/cvdump_sample/diamond-duplicate.txt
+++ b/tests/cvdump_sample/diamond-duplicate.txt
@@ -1,0 +1,73 @@
+class-d 0x1005
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100a)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001008)
+
+0x1004 : Length = 42, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 12
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 24
+		member name = 'm_d0'
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1004, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 28, class name = D, UDT(0x00001005)
+
+0x1006 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100c)
+
+0x1007 : Length = 30, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1006, offset = 0
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_c0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = C, UDT(0x00001008)
+
+0x1009 : Length = 30, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1006, offset = 0
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b0'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = B, UDT(0x0000100a)
+
+0x100b : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100c)
+

--- a/tests/cvdump_sample/diamond-virtual.txt
+++ b/tests/cvdump_sample/diamond-virtual.txt
@@ -1,0 +1,104 @@
+class-d 0x1008
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100c)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100a)
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100e)
+
+0x1005 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1006 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1005
+
+0x1007 : Length = 58, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 8
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 16
+		member name = 'm_d0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 28, class name = D, UDT(0x00001008)
+
+0x1009 : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_c0'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = C, UDT(0x0000100a)
+
+0x100b : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = B, UDT(0x0000100c)
+
+0x100d : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100d, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100e)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1002
+
+0x1010 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1011 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001008)
+
+0x1012 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1011
+

--- a/tests/cvdump_sample/multiple-inheritance-virtual-functions.txt
+++ b/tests/cvdump_sample/multiple-inheritance-virtual-functions.txt
@@ -1,0 +1,110 @@
+class-c 0x100D
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x00001013)
+
+0x1001 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1000
+
+0x1002 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1003 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1000, This type = 0x1001, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001011)
+
+0x1005 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1004
+
+0x1006 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1004, This type = 0x1005, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100d)
+
+0x1008 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1007
+
+0x1009 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1007, This type = 0x1008, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x100a : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1002
+
+0x100b : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1000, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1004, offset = 12
+	list[2] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1009, 
+		vfptr offset = 4, name = 'Stop'
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 20
+		member name = 'm_c0'
+
+0x100c : Length = 6, Leaf = 0x000a LF_VTSHAPE
+	Number of entries : 2
+		[0]: NEAR32
+		[1]: NEAR32
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x100c
+	Size = 24, class name = C, UDT(0x0000100d)
+
+0x100e : Length = 6, Leaf = 0x000a LF_VTSHAPE
+	Number of entries : 1
+		[0]: NEAR
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x100E
+
+0x1010 : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VFUNCTAB, type = 0x100F
+	list[1] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1006, 
+		vfptr offset = 0, name = 'Reset'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+
+0x1011 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1010, 
+	Derivation list type 0x0000, VT shape type 0x100e
+	Size = 8, class name = B, UDT(0x00001011)
+
+0x1012 : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VFUNCTAB, type = 0x100F
+	list[1] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1003, 
+		vfptr offset = 0, name = 'Update'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a0'
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_a1'
+
+0x1013 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1012, 
+	Derivation list type 0x0000, VT shape type 0x100e
+	Size = 12, class name = A, UDT(0x00001013)
+

--- a/tests/cvdump_sample/multiple-inheritance.txt
+++ b/tests/cvdump_sample/multiple-inheritance.txt
@@ -1,0 +1,63 @@
+class-c 0x1005
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x00001009)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001007)
+
+0x1004 : Length = 42, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 12
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 24
+		member name = 'm_c0'
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1004, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 28, class name = C, UDT(0x00001005)
+
+0x1006 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_b0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b1'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b2'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = B, UDT(0x00001007)
+
+0x1008 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_a2'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = A, UDT(0x00001009)
+

--- a/tests/cvdump_sample/vbase-after-base.txt
+++ b/tests/cvdump_sample/vbase-after-base.txt
@@ -1,0 +1,81 @@
+class-c 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001009)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100b)
+
+0x1004 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1005 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1004
+
+0x1006 : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_VBCLASS, public, direct base type = 0x1003
+		virtual base ptr = 0x1005, vbpoff = 12, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 16
+		member name = 'm_c0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 28, class name = C, UDT(0x00001007)
+
+0x1008 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_b0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b1'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b2'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = B, UDT(0x00001009)
+
+0x100a : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100b)
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001007)
+
+0x100d : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100C
+

--- a/tests/cvdump_sample/vbase-alignment.txt
+++ b/tests/cvdump_sample/vbase-alignment.txt
@@ -1,0 +1,85 @@
+class-c 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001009)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100b)
+
+0x1004 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1005 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1004
+
+0x1006 : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1003
+		virtual base ptr = 0x1005, vbpoff = 0, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 12
+		member name = 'm_c0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = C, UDT(0x00001007)
+
+0x1008 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1003
+		virtual base ptr = 0x1005, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+	list[2] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 8
+		member name = 'm_b1'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = B, UDT(0x00001009)
+
+0x100a : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_REAL64(0041), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 8
+		member name = 'm_a1'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = A, UDT(0x0000100b)
+
+0x100c : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1002
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001007)
+
+0x100e : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100D
+

--- a/tests/cvdump_sample/vbase-chain.txt
+++ b/tests/cvdump_sample/vbase-chain.txt
@@ -1,0 +1,108 @@
+class-d 0x1008
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100a)
+
+0x1003 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1004 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100e)
+
+0x1006 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100c)
+
+0x1007 : Length = 66, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 3
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1006
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_d0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = D, UDT(0x00001008)
+
+0x1009 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1006
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_c0'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 24, class name = C, UDT(0x0000100a)
+
+0x100b : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = B, UDT(0x0000100c)
+
+0x100d : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100d, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100e)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1006
+
+0x1010 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1002
+
+0x1011 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001008)
+
+0x1012 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1011
+

--- a/tests/cvdump_sample/vbase-first-base.txt
+++ b/tests/cvdump_sample/vbase-first-base.txt
@@ -1,0 +1,102 @@
+class-d 0x1008
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100c)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100a)
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100e)
+
+0x1005 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1006 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1005
+
+0x1007 : Length = 58, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 8
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 20
+		member name = 'm_d0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = D, UDT(0x00001008)
+
+0x1009 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_c0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_c1'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_c2'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = C, UDT(0x0000100a)
+
+0x100b : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = B, UDT(0x0000100c)
+
+0x100d : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100d, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100e)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1002
+
+0x1010 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001008)
+
+0x1011 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1010
+

--- a/tests/cvdump_sample/vbase-padding-packed.txt
+++ b/tests/cvdump_sample/vbase-padding-packed.txt
@@ -1,0 +1,98 @@
+class-d 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100b)
+
+0x1003 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1004 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100d)
+
+0x1006 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[2] = LF_MEMBER, public, type = T_REAL64(0041), offset = 4
+		member name = 'm_d0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, PACKED, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 21, class name = D, UDT(0x00001007)
+
+0x1008 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[2] = LF_MEMBER, public, type = T_REAL64(0041), offset = 4
+		member name = 'm_c0'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, PACKED, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 21, class name = C, UDT(0x00001009)
+
+0x100a : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 0
+		member name = 'm_b0'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x100a, PACKED, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 1, class name = B, UDT(0x0000100b)
+
+0x100c : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_REAL64(0041), offset = 0
+		member name = 'm_a0'
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x100c, PACKED, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100d)
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001009)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100E
+
+0x1010 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001007)
+
+0x1011 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1010
+

--- a/tests/cvdump_sample/vbase-padding.txt
+++ b/tests/cvdump_sample/vbase-padding.txt
@@ -1,0 +1,98 @@
+class-d 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100b)
+
+0x1003 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1004 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100d)
+
+0x1006 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[2] = LF_MEMBER, public, type = T_REAL64(0041), offset = 8
+		member name = 'm_d0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = D, UDT(0x00001007)
+
+0x1008 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[2] = LF_MEMBER, public, type = T_REAL64(0041), offset = 8
+		member name = 'm_c0'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 25, class name = C, UDT(0x00001009)
+
+0x100a : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_RCHAR(0070), offset = 0
+		member name = 'm_b0'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 1, class name = B, UDT(0x0000100b)
+
+0x100c : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_REAL64(0041), offset = 0
+		member name = 'm_a0'
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x100c, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100d)
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001009)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100E
+
+0x1010 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001007)
+
+0x1011 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1010
+

--- a/tests/cvdump_sample/vbase-second-base.txt
+++ b/tests/cvdump_sample/vbase-second-base.txt
@@ -1,0 +1,102 @@
+class-d 0x1008
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100c)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100a)
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100e)
+
+0x1005 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1006 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1005
+
+0x1007 : Length = 58, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_BCLASS, public, type = 0x1003, offset = 12
+	list[2] = LF_IVBCLASS, public, indirect base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 12, vbind = 1
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 20
+		member name = 'm_d0'
+
+0x1008 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1007, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 32, class name = D, UDT(0x00001008)
+
+0x1009 : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1004
+		virtual base ptr = 0x1006, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_c0'
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1009, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = C, UDT(0x0000100a)
+
+0x100b : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_b0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b1'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b2'
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x100b, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 12, class name = B, UDT(0x0000100c)
+
+0x100d : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100e : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100d, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100e)
+
+0x100f : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1010 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = D, UDT(0x00001008)
+
+0x1011 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1010
+

--- a/tests/cvdump_sample/vbase-simple.txt
+++ b/tests/cvdump_sample/vbase-simple.txt
@@ -1,0 +1,84 @@
+class-b 0x1009
+class-c 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001009)
+
+0x1003 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100b)
+
+0x1004 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1005 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1004
+
+0x1006 : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1002, offset = 0
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1003
+		virtual base ptr = 0x1005, vbpoff = 0, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_c0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 20, class name = C, UDT(0x00001007)
+
+0x1008 : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1003
+		virtual base ptr = 0x1005, vbpoff = 0, vbind = 1
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_b0'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 16, class name = B, UDT(0x00001009)
+
+0x100a : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100b)
+
+0x100c : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1002
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001007)
+
+0x100e : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100D
+

--- a/tests/cvdump_sample/vbase-two.txt
+++ b/tests/cvdump_sample/vbase-two.txt
@@ -1,0 +1,78 @@
+class-c 0x1007
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1001 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1000
+
+0x1002 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100b)
+
+0x1003 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1004 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1003
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x00001009)
+
+0x1006 : Length = 50, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1002
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 1
+	list[1] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1004, vbpoff = 0, vbind = 2
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_c0'
+
+0x1007 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1006, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 20, class name = C, UDT(0x00001007)
+
+0x1008 : Length = 18, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_b0'
+
+0x1009 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 1,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 4, class name = B, UDT(0x00001009)
+
+0x100a : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100b : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100b)
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x00001007)
+
+0x100d : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x100C
+

--- a/tests/cvdump_sample/vbase-vftable.txt
+++ b/tests/cvdump_sample/vbase-vftable.txt
@@ -1,0 +1,99 @@
+class-c 0x100A
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100d)
+
+0x1001 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1000
+
+0x1002 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1003 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1000, This type = 0x1001, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x1004 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1002
+
+0x1005 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x0000100f)
+
+0x1006 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1007 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1006
+
+0x1008 : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1000, offset = 0
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1005
+		virtual base ptr = 0x1007, vbpoff = 4, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 12
+		member name = 'm_c0'
+
+0x1009 : Length = 6, Leaf = 0x000a LF_VTSHAPE
+	Number of entries : 1
+		[0]: NEAR
+
+0x100a : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x1008, 
+	Derivation list type 0x0000, VT shape type 0x1009
+	Size = 24, class name = C, UDT(0x0000100a)
+
+0x100b : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1009
+
+0x100c : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1005
+		virtual base ptr = 0x1007, vbpoff = 4, vbind = 1
+	list[1] = LF_VFUNCTAB, type = 0x100B
+	list[2] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1003, 
+		vfptr offset = 0, name = 'Update'
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b0'
+
+0x100d : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x100c, 
+	Derivation list type 0x0000, VT shape type 0x1009
+	Size = 20, class name = B, UDT(0x0000100d)
+
+0x100e : Length = 34, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_MEMBER, public, type = T_INT4(0074), offset = 0
+		member name = 'm_a0'
+	list[1] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a1'
+
+0x100f : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 2,  field list type 0x100e, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 8, class name = A, UDT(0x0000100f)
+
+0x1010 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100a)
+
+0x1011 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1010
+

--- a/tests/cvdump_sample/vbase-virtual-function.txt
+++ b/tests/cvdump_sample/vbase-virtual-function.txt
@@ -1,0 +1,111 @@
+class-c 0x100C
+
+Microsoft (R) Debugging Information Dumper  Version 14.00.23611
+Copyright (C) Microsoft Corporation.  All rights reserved.
+
+
+
+*** Converting 16-bit types to 32-bit equivalents
+
+0x1000 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = A, UDT(0x00001011)
+
+0x1001 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1000
+
+0x1002 : Length = 6, Leaf = 0x1201 LF_ARGLIST argument count = 0
+
+0x1003 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1000, This type = 0x1001, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x1004 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = B, UDT(0x0000100f)
+
+0x1005 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1004
+
+0x1006 : Length = 26, Leaf = 0x1009 LF_MFUNCTION
+	Return type = T_VOID(0003), Class type = 0x1004, This type = 0x1005, 
+	Call type = ThisCall, Func attr = none
+	Parms = 0, Arg list type = 0x1002, This adjust = 0
+
+0x1007 : Length = 14, Leaf = 0x1008 LF_PROCEDURE
+	Return type = T_INT4(0074), Call type = C Near
+	Func attr = none
+	# Parms = 0, Arg list type = 0x1002
+
+0x1008 : Length = 14, Leaf = 0x1503 LF_ARRAY
+	Element type = T_INT4(0074)
+	Index type = T_SHORT(0011)
+	length = 0
+	Name = 
+
+0x1009 : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x1008
+
+0x100a : Length = 46, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_BCLASS, public, type = 0x1004, offset = 0
+	list[1] = LF_IVBCLASS, public, indirect base type = 0x1000
+		virtual base ptr = 0x1009, vbpoff = 4, vbind = 1
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 12
+		member name = 'm_c0'
+
+0x100b : Length = 6, Leaf = 0x000a LF_VTSHAPE
+	Number of entries : 1
+		[0]: NEAR
+
+0x100c : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 3,  field list type 0x100a, 
+	Derivation list type 0x0000, VT shape type 0x100b
+	Size = 28, class name = C, UDT(0x0000100c)
+
+0x100d : Length = 10, Leaf = 0x1002 LF_POINTER
+	Pointer (NEAR32), Size: 0
+	Element type : 0x100B
+
+0x100e : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VBCLASS, public, direct base type = 0x1000
+		virtual base ptr = 0x1009, vbpoff = 4, vbind = 1
+	list[1] = LF_VFUNCTAB, type = 0x100D
+	list[2] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1006, 
+		vfptr offset = 0, name = 'Reset'
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_b0'
+
+0x100f : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x100e, 
+	Derivation list type 0x0000, VT shape type 0x100b
+	Size = 24, class name = B, UDT(0x0000100f)
+
+0x1010 : Length = 62, Leaf = 0x1203 LF_FIELDLIST
+	list[0] = LF_VFUNCTAB, type = 0x100D
+	list[1] = LF_ONEMETHOD, public, INTRODUCING VIRTUAL, index = 0x1003, 
+		vfptr offset = 0, name = 'Update'
+	list[2] = LF_MEMBER, public, type = T_INT4(0074), offset = 4
+		member name = 'm_a0'
+	list[3] = LF_MEMBER, public, type = T_INT4(0074), offset = 8
+		member name = 'm_a1'
+
+0x1011 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 4,  field list type 0x1010, 
+	Derivation list type 0x0000, VT shape type 0x100b
+	Size = 12, class name = A, UDT(0x00001011)
+
+0x1012 : Length = 22, Leaf = 0x1504 LF_CLASS
+	# members = 0,  field list type 0x0000, FORWARD REF, 
+	Derivation list type 0x0000, VT shape type 0x0000
+	Size = 0, class name = C, UDT(0x0000100c)
+
+0x1013 : Length = 10, Leaf = 0x1002 LF_POINTER
+	const Pointer (NEAR32), Size: 0
+	Element type : 0x1012
+

--- a/tests/ghidra_helpers.py
+++ b/tests/ghidra_helpers.py
@@ -1,0 +1,47 @@
+"""Helper functions for interacting with the Ghidra API in tests."""
+
+from typing import TYPE_CHECKING
+
+from .helpers import assert_instance
+
+# Suppress linter warnings related to the fact that the header support for Ghidra is limited
+# and that we cannot import Ghidra classes before Ghidra has been loaded
+
+# pylint: disable=import-outside-toplevel
+# pyright: reportMissingModuleSource=false
+
+if TYPE_CHECKING:
+    from ghidra.program.model.data import DataType, Structure
+
+
+def as_structure(data_type: "DataType") -> "Structure":
+    from ghidra.program.model.data import Structure
+
+    return assert_instance(data_type, Structure)
+
+
+def components_of(data_type: "DataType") -> list[tuple[int, str, str]]:
+    """Returns (offset, field name, type name) for each defined component.
+    This should make the tests more idiomatic because it excludes the
+    `undefined` filler components.
+    """
+    return [
+        (c.getOffset(), c.getFieldName(), c.getDataType().getName())
+        for c in as_structure(data_type).getDefinedComponents()
+    ]
+
+
+def component(data_type: "DataType", offset: int) -> "DataType":
+    """Access the Ghidra DataType for the struct member at the given offset."""
+    for comp in as_structure(data_type).getDefinedComponents():
+        if comp.getOffset() == offset:
+            return comp.getDataType()
+
+    raise ValueError(f"No component at offset {offset} in '{data_type.getName()}'")
+
+
+def dereference(data_type: "DataType") -> "DataType":
+    from ghidra.program.model.data import Pointer
+
+    assert isinstance(data_type, Pointer)
+    return data_type.getDataType()

--- a/tests/ghidra_integration_test_setup.py
+++ b/tests/ghidra_integration_test_setup.py
@@ -10,6 +10,7 @@ from reccmp.compare.core import Compare
 from reccmp.compare.ingest import load_cvdump_types
 from reccmp.cvdump.analysis import CvdumpAnalysis
 from reccmp.cvdump.parser import CvdumpParser
+from .helpers import assert_instance
 from .raw_image import RawImage
 
 # Suppress linter warnings related to the fact that the header support for Ghidra is limited
@@ -19,6 +20,7 @@ from .raw_image import RawImage
 # pyright: reportMissingModuleSource=false
 
 if TYPE_CHECKING:
+    from ghidra.program.model.data import DataType, Structure
     from ghidra.program.model.listing import Program
     from ghidra.program.flatapi import FlatProgramAPI
     from reccmp.ghidra.importer.type_importer import PdbTypeImporter
@@ -166,6 +168,39 @@ class GhidraTypeTestHelper:
         parser.read_section("TYPES", cvdump_types)
         analysis = CvdumpAnalysis(parser)
         load_cvdump_types(analysis, self.compare.types)
+
+
+def as_structure(data_type: "DataType") -> "Structure":
+    from ghidra.program.model.data import Structure
+
+    return assert_instance(data_type, Structure)
+
+
+def components_of(data_type: "DataType") -> list[tuple[int, str, str]]:
+    """Returns (offset, field name, type name) for each defined component.
+    This should make the tests more idiomatic because it excludes the
+    `undefined` filler components.
+    """
+    return [
+        (c.getOffset(), c.getFieldName(), c.getDataType().getName())
+        for c in as_structure(data_type).getDefinedComponents()
+    ]
+
+
+def component(data_type: "DataType", offset: int) -> "DataType":
+    """Access the Ghidra DataType for the struct member at the given offset."""
+    for comp in as_structure(data_type).getDefinedComponents():
+        if comp.getOffset() == offset:
+            return comp.getDataType()
+
+    raise ValueError(f"No component at offset {offset} in '{data_type.getName()}'")
+
+
+def dereference(data_type: "DataType") -> "DataType":
+    from ghidra.program.model.data import Pointer
+
+    assert isinstance(data_type, Pointer)
+    return data_type.getDataType()
 
 
 class GhidraFunctionTestHelper:

--- a/tests/ghidra_integration_test_setup.py
+++ b/tests/ghidra_integration_test_setup.py
@@ -10,7 +10,6 @@ from reccmp.compare.core import Compare
 from reccmp.compare.ingest import load_cvdump_types
 from reccmp.cvdump.analysis import CvdumpAnalysis
 from reccmp.cvdump.parser import CvdumpParser
-from .helpers import assert_instance
 from .raw_image import RawImage
 
 # Suppress linter warnings related to the fact that the header support for Ghidra is limited
@@ -20,7 +19,6 @@ from .raw_image import RawImage
 # pyright: reportMissingModuleSource=false
 
 if TYPE_CHECKING:
-    from ghidra.program.model.data import DataType, Structure
     from ghidra.program.model.listing import Program
     from ghidra.program.flatapi import FlatProgramAPI
     from reccmp.ghidra.importer.type_importer import PdbTypeImporter
@@ -168,39 +166,6 @@ class GhidraTypeTestHelper:
         parser.read_section("TYPES", cvdump_types)
         analysis = CvdumpAnalysis(parser)
         load_cvdump_types(analysis, self.compare.types)
-
-
-def as_structure(data_type: "DataType") -> "Structure":
-    from ghidra.program.model.data import Structure
-
-    return assert_instance(data_type, Structure)
-
-
-def components_of(data_type: "DataType") -> list[tuple[int, str, str]]:
-    """Returns (offset, field name, type name) for each defined component.
-    This should make the tests more idiomatic because it excludes the
-    `undefined` filler components.
-    """
-    return [
-        (c.getOffset(), c.getFieldName(), c.getDataType().getName())
-        for c in as_structure(data_type).getDefinedComponents()
-    ]
-
-
-def component(data_type: "DataType", offset: int) -> "DataType":
-    """Access the Ghidra DataType for the struct member at the given offset."""
-    for comp in as_structure(data_type).getDefinedComponents():
-        if comp.getOffset() == offset:
-            return comp.getDataType()
-
-    raise ValueError(f"No component at offset {offset} in '{data_type.getName()}'")
-
-
-def dereference(data_type: "DataType") -> "DataType":
-    from ghidra.program.model.data import Pointer
-
-    assert isinstance(data_type, Pointer)
-    return data_type.getDataType()
 
 
 class GhidraFunctionTestHelper:

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -1,26 +1,37 @@
 """Tests for importing classes with various inheritance patterns.
 
-Parent classes are embedded in the struct for the derived class instead of
-copying their members instead.
+By convention, the `vftable` pointer appears at offset 0 of a class with virtual functions.
 
-Vftable pointers are set to offset 0 of the class with virtual functions.
+To represent inheritance, we create the base class struct (or use one created earlier in the run)
+and set its position to the offset given in the PDB fieldlist. The other option is to copy members
+from the base classes with new offsets, but we don't do it this way.
 
-Classes with a direct virtual base class have an added VBasePtr* member
-that points to the static Vbtable struct. This contains a list of offsets
-from the derived class to each direct or indirect virtual base class.
+Virtual inheritance presents a challenge because offsets for virtually-inherited members do not
+appear in the fieldlist. Any class with a direct or indirect virtual base class has its members
+arranged in this order:
 
-To import classes with a parent that uses virtual inheritance, we need to
-create a "slim" version of the base that includes only its "owned" members.
+1. Members from non-virtual base classes.
+2. Members from the derived class.
+3. Members from virtual base classes.
 
-The classic example is: `C extends B`, `B virtually extends A`.
-The expected layout for C is:
+Consider the example: `C extends B`, `B virtually extends A`.
 
-- Members introduced by B
-- Members introduced by C
-- Members introduced by A
+In B, the members of B appear first, followed by the virtual members from A.
 
-We cannot reliably set offsets for A or its members without reading the vbtable
-for B. This data is not currently available in the type importer.
+In C, we cannot reference B, because the members of indirect virtual base class A must appear last.
+The order is: members from B, members from C, members from A.
+
+To import C correctly, we need to create a "slim" copy of B that contains only its non-virtually inherited members
+and any derived members.
+
+To make this work at runtime, the compiler creates a `vbtable` for each class with a direct virtual base in each
+inheritance scenario where it is used. Meaning: the `vbtable` for B alone is different from the one created for
+B as a parent of C. Each class with a direct virtual base includes a `VBasePtr*` member that points to the `vbtable`.
+
+The `vbtable` structure contains a list of offsets from the `VBasePtr*` member to each direct or indirect virtual base class.
+
+We do not currently have access to `vbtable` offsets, so we do not set the position of any direct or indirect
+virtual base class when creating Ghidra structs.
 """
 
 import pytest
@@ -81,14 +92,20 @@ def test_duplicate_base_appears_twice(type_helper: GhidraTypeTestHelper):
         (24, "m_d0", "int"),
     ]
 
-    assert components_of(component(class_d, 0)) == [
+    class_b = component(class_d, 0)
+    assert components_of(class_b) == [
         (0, "base", "A"),
         (8, "m_b0", "int"),
     ]
-    assert components_of(component(class_d, 12)) == [
+
+    class_c = component(class_d, 12)
+    assert components_of(class_c) == [
         (0, "base", "A"),
         (8, "m_c0", "int"),
     ]
+
+    # B and C point to the same A.
+    assert component(class_b, 0) == component(class_c, 0)
 
 
 def test_base_offsets_are_not_a_sum_of_sizes(type_helper: GhidraTypeTestHelper):
@@ -130,9 +147,10 @@ def test_slim_vbase_at_offset_zero(type_helper: GhidraTypeTestHelper):
         B : virtual A    size 16
         C : B            size 20
 
-    B is 16 bytes because it contains its own members (8 bytes) followed by A.
-    The field list for C places C's first member at offset 8. Therefore, the
-    full-sized B will not fit and we need to create a "slim" copy.
+    Should create B with its `VBasePtr*` member according to the vbpoff in the fieldlist.
+    B has no other base classes, so the pointer is at offset 0 in B and C.
+    When we import C, we cannot use the full-sized B because its virtually-inherited members
+    must appear last. Thus we create the "slim" copy of B without the virtual members.
     """
     sample = load_cvdump_sample("vbase-simple")
     type_helper.set_up_cvdump_types(sample.text)
@@ -178,9 +196,8 @@ def test_slim_vbase_as_first_base(type_helper: GhidraTypeTestHelper):
         C                size 12
         D : B, C         size 32
 
-    B needs a slim copy because it has a virtual base.
-    C has no virtual base, so the full-sized C fits at offset 8 in D.
-    D has no direct virtual base, so it does not get a vbase pointer.
+    Should position the two base classes of D correctly.
+    Here the class with virtual inheritance (B) is first.
     """
     sample = load_cvdump_sample("vbase-first-base")
     type_helper.set_up_cvdump_types(sample.text)
@@ -201,6 +218,7 @@ def test_slim_vbase_as_first_base(type_helper: GhidraTypeTestHelper):
     assert components_of(slim_b) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_b0", "int"),
+        # A?
     ]
 
     class_c = component(class_d, 8)
@@ -212,7 +230,7 @@ def test_slim_vbase_as_first_base(type_helper: GhidraTypeTestHelper):
     ]
 
 
-def test_slim_vbase_at_nonzero_offset(type_helper: GhidraTypeTestHelper):
+def test_slim_vbase_as_second_base(type_helper: GhidraTypeTestHelper):
     """cvdump_sample/cpp/vbase_second_base.cpp
 
         A                size 8
@@ -220,10 +238,9 @@ def test_slim_vbase_at_nonzero_offset(type_helper: GhidraTypeTestHelper):
         C : virtual A    size 16
         D : B, C         size 32
 
-    C needs a slim copy because it has a virtual base. The copy is at offset 12
-    because B occupies the first 12 bytes.
-    B has no virtual base, so the full-sized B fits at offset 0 in D.
-    D has no direct virtual base, so it does not get a vbase pointer.
+
+    Should position the two base classes of D correctly.
+    Here the class with virtual inheritance (C) is second.
     """
     sample = load_cvdump_sample("vbase-second-base")
     type_helper.set_up_cvdump_types(sample.text)
@@ -263,8 +280,9 @@ def test_slim_base_ends_at_last_member(type_helper: GhidraTypeTestHelper):
         B : virtual A    size 32
         C : B            size 32
 
-    In C, there is padding between the slim copy of B and the first C member.
-    The slim copy of B does not contain this padding.
+    There is padding between the non-virtual and derived members from B
+    and the first member in C. Make sure the padding is represented as a gap in C
+    rather than expanding the slim copy of B to fit.
     """
     sample = load_cvdump_sample("vbase-alignment")
     type_helper.set_up_cvdump_types(sample.text)
@@ -299,7 +317,7 @@ def test_diamond_shares_one_virtual_base(type_helper: GhidraTypeTestHelper):
 
     Diamond inheritance pattern with virtual inheritance.
     D contains only one copy of A: B and C point to the single A
-    using their vbtables.
+    using their vbtables. Notably, `sizeof(D) < sizeof(B) + sizeof(C)`.
     """
     sample = load_cvdump_sample("diamond-virtual")
     type_helper.set_up_cvdump_types(sample.text)
@@ -349,9 +367,9 @@ def test_direct_virtual_base_at_nonzero_vbpoff(type_helper: GhidraTypeTestHelper
         B                   size 12
         C : B, virtual A    size 28
 
-    We cannot naively assume that any class with a direct virtual base has
-    vbpoff at offset zero. Here, C's non-virtual base class B is first.
-    B has no virtual base of its own, so the full-sized B fits at offset 0.
+    We need to create a `VBasePtr*` in C to use with its direct virtual base A.
+    Make sure we follow the `vbpoff` value from the fieldlist rather than assume
+    it can be created at offset 0 in C.
     """
     sample = load_cvdump_sample("vbase-after-base")
     type_helper.set_up_cvdump_types(sample.text)
@@ -382,7 +400,9 @@ def test_vbaseptr_slots_for_two_virtual_bases(type_helper: GhidraTypeTestHelper)
         B                           size 4
         C : virtual A, virtual B    size 20
 
-    The vbtable for C has two entries, one for each virtual base.
+    C has two direct virtual base classes. We only need one `VBasePtr*` member.
+    (i.e. do not create a member for each virtual base class. Obey the fieldlist.)
+    We also show the `vbtable` structure with one entry for each virtual base.
     """
     sample = load_cvdump_sample("vbase-two")
     type_helper.set_up_cvdump_types(sample.text)
@@ -415,7 +435,7 @@ def test_chained_virtual_bases(type_helper: GhidraTypeTestHelper):
         D : virtual C    size 32
 
     The vbtable for D has three entries. The order must match the vbind index
-    values for each virtual base, not the order they appear in the field list.
+    values for each virtual base, not the order they appear in the fieldlist.
     """
     sample = load_cvdump_sample("vbase-chain")
     type_helper.set_up_cvdump_types(sample.text)
@@ -483,9 +503,10 @@ def test_multiple_inheritance_with_virtual_functions(
         B           size 8
         C : A, B    size 24
 
-    A, B, and C each introduce a virtual function.
-    C's virtual function is combined in A's vtable at offset 0 in C.
-    The vtable for B's functions is at offset 12 in C.
+    A, B, and C each introduce a virtual function. Where do we create the `vftable` member?
+    According to the PDB, only the fieldlists for B and C have a VFUNCTAB leaf, so only their
+    structs get the member. The effect is that C's virtual function is "merged" into A's vtable.
+    (This may or may not be correct and we should revisit when we create a vtable struct during import.)
     """
     sample = load_cvdump_sample("multiple-inheritance-virtual-functions")
     type_helper.set_up_cvdump_types(sample.text)

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -426,15 +426,9 @@ def test_slim_vbase_with_vftable(type_helper: GhidraTypeTestHelper):
         B : virtual A    size 20
         C : B            size 24
 
-    B declares both a virtual function and a virtual base, so it carries a
-    vftable pointer and a vbase pointer. LF_VFUNCTAB has no offset, so we place
-    the vftable pointer at 0 by assumption. The field list gives vbpoff = 4,
-    which is where the vbase pointer lands once the vftable takes the first four
-    bytes. This is the only sample where the assumed offset and an offset we
-    read could collide.
-
-    B's slim copy keeps both pointers, so it is 12 bytes rather than 8, and C's
-    own member starts at 12.
+    The slim copy of B should contain the vftable and vbaseptr.
+    By convention the vftable appears at offset 0. The field list for B
+    specifies vbpoff 4, so we know there is a gap where the vftable can fit.
     """
     sample = load_cvdump_sample("vbase-vftable")
     type_helper.set_up_cvdump_types(sample.text)
@@ -444,6 +438,7 @@ def test_slim_vbase_with_vftable(type_helper: GhidraTypeTestHelper):
     assert components_of(leaf) == [
         (0, "base", "B_vbase_slim"),
         (12, "m_c0", "int"),
+        # A?
     ]
 
     slim = component(leaf, 0)

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -62,7 +62,7 @@ def test_duplicate_base_appears_twice(type_helper: GhidraTypeTestHelper):
         C : A       size 12
         D : B, C    size 28
 
-    Diamond inheritance pattern.
+    Diamond inheritance pattern without virtual inheritance.
     B and C each have their own copy of parent A. D extends both B and C, and
     so it has two copies of A.
     """

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -505,7 +505,7 @@ def test_padding_between_two_virtual_bases(type_helper: GhidraTypeTestHelper):
     Note the difference in size between C and D, which extend A and B in
     different orders. In the case of D, there is padding between B and A.
     We cannot set the correct offsets by simply adding the size of B and A.
-    We could guess the default byte alignmen but a `#pragma pack` directive
+    We could guess the default byte alignment but a `#pragma pack` directive
     will change this without any indication that this has happened.
     """
     sample = load_cvdump_sample("vbase-padding")

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -1,0 +1,548 @@
+"""Tests for importing classes with various inheritance patterns.
+
+Parent classes are embedded in the struct for the derived class instead of
+copying their members instead.
+
+Vftable pointers are set to offset 0 of the class with virtual functions.
+
+Classes with a direct virtual base class have an added VBasePtr* member
+that points to the static Vbtable struct. This contains a list of offsets
+from the derived class to each direct or indirect virtual base class.
+
+To import classes with a parent that uses virtual inheritance, we need to
+create a "slim" version of the base that includes only its "owned" members.
+
+The classic example is: `C extends B`, `B virtually extends A`.
+The expected layout for C is:
+
+- Members introduced by B
+- Members introduced by C
+- Members introduced by A
+
+We cannot reliably set offsets for A or its members without reading the vbtable
+for B. This data is not currently available in the type importer.
+"""
+
+import pytest
+from .cvdump_sample import load_cvdump_sample
+from .ghidra_integration_test_setup import (
+    GhidraTypeTestHelper,
+    component,
+    components_of,
+    dereference,
+)
+
+
+def test_multiple_inheritance_base_offsets(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/multiple_inheritance.cpp
+
+        A           size 12
+        B           size 12
+        C : A, B    size 28
+
+    Should create full-sized structs for A and B when creating C.
+    """
+    sample = load_cvdump_sample("multiple-inheritance")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 28
+    assert components_of(leaf) == [
+        (0, "base", "A"),
+        (12, "base_B", "B"),
+        (24, "m_c0", "int"),
+    ]
+
+
+def test_duplicate_base_appears_twice(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/diamond_duplicate.cpp
+
+        A           size 8
+        B : A       size 12
+        C : A       size 12
+        D : B, C    size 28
+
+    Diamond inheritance pattern.
+    B and C each have their own copy of parent A. D extends both B and C, and
+    so it has two copies of A.
+    """
+    sample = load_cvdump_sample("diamond-duplicate")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 28
+    assert components_of(leaf) == [
+        (0, "base", "B"),
+        (12, "base_C", "C"),
+        (24, "m_d0", "int"),
+    ]
+
+    assert components_of(component(leaf, 0)) == [
+        (0, "base", "A"),
+        (8, "m_b0", "int"),
+    ]
+    assert components_of(component(leaf, 12)) == [
+        (0, "base", "A"),
+        (8, "m_c0", "int"),
+    ]
+
+
+def test_base_offsets_are_not_a_sum_of_sizes(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/base_padding.cpp
+
+        A              size 1
+        B              size 8
+        C              size 8
+        D : A, B, C    size 32
+
+    Use the offsets given in the field list for D when setting the position for
+    base classes. This is most important for A, because of the padding between
+    A and its sibling B. The struct for A does not include this padding.
+    """
+    sample = load_cvdump_sample("base-padding")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "base", "A"),
+        (4, "base_B", "B"),
+        (16, "base_C", "C"),
+        (24, "m_d0", "int"),
+    ]
+
+    # Structs created for each parent do not include padding.
+    assert component(leaf, 0).getLength() == 1
+    assert component(leaf, 4).getLength() == 8
+    assert component(leaf, 16).getLength() == 8
+
+
+def test_slim_vbase_at_offset_zero(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_simple.cpp
+
+        A                size 8
+        B : virtual A    size 16
+        C : B            size 20
+
+    B is 16 bytes because it contains its own members (8 bytes) followed by A.
+    The field list for C places C's first member at offset 8. Therefore, the
+    full-sized B will not fit and we need to create a "slim" copy.
+    """
+    sample = load_cvdump_sample("vbase-simple")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 20
+    assert components_of(leaf) == [
+        (0, "base", "B_vbase_slim"),
+        (8, "m_c0", "int"),
+        # A?
+    ]
+
+    slim = component(leaf, 0)
+    assert slim.getLength() == 8
+    assert components_of(slim) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_b0", "int"),
+    ]
+
+    class_b = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-b")
+    )
+
+    # Although they have the same members, the full-size B and the slim B are different types.
+    # (Full-size B should have members from A, but does not due to the acknowledged vbtable limitation.)
+    assert class_b != slim
+
+    assert class_b.getLength() == 16
+    assert components_of(class_b) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_b0", "int"),
+        # A?
+    ]
+
+
+def test_slim_vbase_as_first_base(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_first_base.cpp
+
+        A                size 8
+        B : virtual A    size 16
+        C                size 12
+        D : B, C         size 32
+
+    B needs a slim copy because it has a virtual base.
+    C has no virtual base, so the full-sized C fits at offset 8 in D.
+    D has no direct virtual base, so it does not get a vbase pointer.
+    """
+    sample = load_cvdump_sample("vbase-first-base")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "base", "B_vbase_slim"),
+        (8, "base_C", "C"),
+        (20, "m_d0", "int"),
+        # A?
+    ]
+
+    slim_b = component(leaf, 0)
+    assert slim_b.getLength() == 8
+    assert components_of(slim_b) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_b0", "int"),
+    ]
+
+    class_c = component(leaf, 8)
+    assert class_c.getLength() == 12
+    assert components_of(class_c) == [
+        (0, "m_c0", "int"),
+        (4, "m_c1", "int"),
+        (8, "m_c2", "int"),
+    ]
+
+
+def test_slim_vbase_at_nonzero_offset(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_second_base.cpp
+
+        A                size 8
+        B                size 12
+        C : virtual A    size 16
+        D : B, C         size 32
+
+    C needs a slim copy because it has a virtual base. The copy is at offset 12
+    because B occupies the first 12 bytes.
+    B has no virtual base, so the full-sized B fits at offset 0 in D.
+    D has no direct virtual base, so it does not get a vbase pointer.
+    """
+    sample = load_cvdump_sample("vbase-second-base")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "base", "B"),
+        (12, "base_C_vbase_slim", "C_vbase_slim"),
+        (20, "m_d0", "int"),
+        # A?
+    ]
+
+    class_b = component(leaf, 0)
+    assert class_b.getLength() == 12
+    assert components_of(class_b) == [
+        (0, "m_b0", "int"),
+        (4, "m_b1", "int"),
+        (8, "m_b2", "int"),
+    ]
+
+    slim_c = component(leaf, 12)
+    assert slim_c.getLength() == 8
+    assert components_of(slim_c) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_c0", "int"),
+        # A?
+    ]
+
+
+def test_slim_base_ends_at_last_member(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_alignment.cpp
+
+        A                size 16
+        B : virtual A    size 32
+        C : B            size 32
+
+    In C, there is padding between the slim copy of B and the first C member.
+    The slim copy of B does not contain this padding.
+    """
+    sample = load_cvdump_sample("vbase-alignment")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert components_of(leaf) == [
+        (0, "base", "B_vbase_slim"),
+        (12, "m_c0", "char"),
+        # A?
+    ]
+
+    assert leaf.getLength() == 32
+
+    slim = component(leaf, 0)
+    assert components_of(slim) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_b0", "int"),
+        (8, "m_b1", "char"),
+    ]
+    assert slim.getLength() == 9
+
+
+def test_diamond_shares_one_virtual_base(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/diamond_virtual.cpp
+
+        A                size 8
+        B : virtual A    size 16
+        C : virtual A    size 16
+        D : B, C         size 28
+
+    Diamond inheritance pattern with virtual inheritance.
+    D contains only one copy of A: B and C point to the single A
+    using their vbtables.
+    """
+    sample = load_cvdump_sample("diamond-virtual")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 28
+    assert components_of(leaf) == [
+        (0, "base", "B_vbase_slim"),
+        (8, "base_C_vbase_slim", "C_vbase_slim"),
+        (16, "m_d0", "int"),
+    ]
+
+    slim_b = component(leaf, 0)
+    assert components_of(slim_b) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_b0", "int"),
+    ]
+
+    slim_c = component(leaf, 8)
+    assert components_of(slim_c) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_c0", "int"),
+    ]
+
+    vbase_ptr_b = dereference(component(slim_b, 0))
+    vbase_ptr_c = dereference(component(slim_c, 0))
+
+    # Despite the name, these are not the same `VBasePtr`.
+    assert vbase_ptr_b != vbase_ptr_c
+
+    assert components_of(vbase_ptr_b) == [
+        (0, "o_self", "B_vbase_slim *"),
+        (4, "o_A", "APtrOffset"),
+    ]
+    assert components_of(vbase_ptr_c) == [
+        (0, "o_self", "C_vbase_slim *"),
+        (4, "o_A", "APtrOffset"),
+    ]
+
+
+def test_direct_virtual_base_at_nonzero_vbpoff(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_after_base.cpp
+
+        A                   size 8
+        B                   size 12
+        C : B, virtual A    size 28
+
+    We cannot naively assume that any class with a direct virtual base has
+    vbpoff at offset zero. Here, C's non-virtual base class B is first.
+    B has no virtual base of its own, so the full-sized B fits at offset 0.
+    """
+    sample = load_cvdump_sample("vbase-after-base")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 28
+    assert components_of(leaf) == [
+        (0, "base", "B"),
+        (12, "vbase_offset", "VBasePtr *"),
+        (16, "m_c0", "int"),
+    ]
+
+    assert component(leaf, 0).getLength() == 12
+
+    vbase_ptr = dereference(component(leaf, 12))
+    assert components_of(vbase_ptr) == [
+        (0, "o_self", "C *"),
+        (4, "o_A", "APtrOffset"),
+    ]
+
+
+def test_vbaseptr_slots_for_two_virtual_bases(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_two.cpp
+
+        A                           size 8
+        B                           size 4
+        C : virtual A, virtual B    size 20
+
+    The vbtable for C has two entries, one for each virtual base.
+    """
+    sample = load_cvdump_sample("vbase-two")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 20
+    assert components_of(leaf) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_c0", "int"),
+        # A?
+        # B?
+    ]
+
+    vbase_ptr = dereference(component(leaf, 0))
+    assert components_of(vbase_ptr) == [
+        (0, "o_self", "C *"),
+        (4, "o_A", "APtrOffset"),
+        (8, "o_B", "BPtrOffset"),
+    ]
+
+
+def test_chained_virtual_bases(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_chain.cpp
+
+        A                size 8
+        B : virtual A    size 16
+        C : virtual B    size 24
+        D : virtual C    size 32
+
+    The vbtable for D has three entries. The order must match the vbind index
+    values for each virtual base, not the order they appear in the field list.
+    """
+    sample = load_cvdump_sample("vbase-chain")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (4, "m_d0", "int"),
+        # A?
+        # B?
+        # C?
+    ]
+
+    vbase_ptr = dereference(component(leaf, 0))
+    assert components_of(vbase_ptr) == [
+        (0, "o_self", "D *"),
+        (4, "o_A", "APtrOffset"),
+        (8, "o_B", "BPtrOffset"),
+        (12, "o_C", "CPtrOffset"),
+    ]
+
+
+def test_slim_vbase_with_vftable(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_vftable.cpp
+
+        A                size 8
+        B : virtual A    size 20
+        C : B            size 24
+
+    B declares both a virtual function and a virtual base, so it carries a
+    vftable pointer and a vbase pointer. LF_VFUNCTAB has no offset, so we place
+    the vftable pointer at 0 by assumption. The field list gives vbpoff = 4,
+    which is where the vbase pointer lands once the vftable takes the first four
+    bytes. This is the only sample where the assumed offset and an offset we
+    read could collide.
+
+    B's slim copy keeps both pointers, so it is 12 bytes rather than 8, and C's
+    own member starts at 12.
+    """
+    sample = load_cvdump_sample("vbase-vftable")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 24
+    assert components_of(leaf) == [
+        (0, "base", "B_vbase_slim"),
+        (12, "m_c0", "int"),
+    ]
+
+    slim = component(leaf, 0)
+    assert slim.getLength() == 12
+    assert components_of(slim) == [
+        (0, "vftable", "void *"),
+        (4, "vbase_offset", "VBasePtr *"),
+        (8, "m_b0", "int"),
+    ]
+
+
+def test_multiple_inheritance_with_virtual_functions(
+    type_helper: GhidraTypeTestHelper,
+):
+    """cvdump_sample/cpp/multiple_inheritance_virtual_functions.cpp
+
+        A           size 12
+        B           size 8
+        C : A, B    size 24
+
+    A, B, and C each introduce a virtual function.
+    C's virtual function is combined in A's vtable at offset 0 in C.
+    The vtable for B's functions is at offset 12 in C.
+    """
+    sample = load_cvdump_sample("multiple-inheritance-virtual-functions")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+
+    assert leaf.getLength() == 24
+    assert components_of(leaf) == [
+        (0, "base", "A"),
+        (12, "base_B", "B"),
+        (20, "m_c0", "int"),
+    ]
+
+    assert components_of(component(leaf, 0)) == [
+        (0, "vftable", "void *"),
+        (4, "m_a0", "int"),
+        (8, "m_a1", "int"),
+    ]
+    assert components_of(component(leaf, 12)) == [
+        (0, "vftable", "void *"),
+        (4, "m_b0", "int"),
+    ]
+
+
+@pytest.mark.xfail(reason="The importer does not place virtual base classes yet")
+def test_padding_between_two_virtual_bases(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_padding.cpp
+
+        A                           size 8
+        B                           size 1
+        C : virtual A, virtual B    size 25
+        D : virtual B, virtual A    size 32
+
+    The importer does not currently set the offset of a virtual base class.
+    The offsets are not given in any of the PDB data. We would need to read the
+    static vbtable (referenced by VBasePtr*) to position a base accurately.
+    Note the difference in size between C and D, which extend A and B in
+    different orders. In the case of D, there is padding between B and A.
+    We cannot set the correct offsets by simply adding the size of B and A.
+    We could guess the default byte alignmen but a `#pragma pack` directive
+    will change this without any indication that this has happened.
+    """
+    sample = load_cvdump_sample("vbase-padding")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (8, "m_d0", "double"),
+        (16, "vbase_B", "B"),
+        (24, "vbase_A", "A"),
+    ]
+
+
+@pytest.mark.xfail(reason="The importer does not place virtual base classes yet")
+def test_no_padding_between_two_virtual_bases(type_helper: GhidraTypeTestHelper):
+    """cvdump_sample/cpp/vbase_padding_packed.cpp
+
+        A                           size 8
+        B                           size 1
+        C : virtual A, virtual B    size 25
+        D : virtual B, virtual A    size 25
+
+    These are the same classes as `vbase_padding.cpp`, but wrapped with
+    `#pragma pack(1)`. This causes the `PACKED` attribute to appear in each
+    LF_CLASS. In this case, we could place the virtual bases reliably because
+    simply adding the struct size would be correct.
+    """
+    sample = load_cvdump_sample("vbase-padding-packed")
+    type_helper.set_up_cvdump_types(sample.text)
+    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+
+    assert leaf.getLength() == 32
+    assert components_of(leaf) == [
+        (0, "vbase_offset", "VBasePtr *"),
+        (8, "m_d0", "double"),
+        (16, "vbase_B", "B"),
+        (17, "vbase_A", "A"),
+    ]

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -44,10 +44,12 @@ def test_multiple_inheritance_base_offsets(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("multiple-inheritance")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 28
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 28
+    assert components_of(class_c) == [
         (0, "base", "A"),
         (12, "base_B", "B"),
         (24, "m_c0", "int"),
@@ -68,20 +70,22 @@ def test_duplicate_base_appears_twice(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("diamond-duplicate")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 28
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 28
+    assert components_of(class_d) == [
         (0, "base", "B"),
         (12, "base_C", "C"),
         (24, "m_d0", "int"),
     ]
 
-    assert components_of(component(leaf, 0)) == [
+    assert components_of(component(class_d, 0)) == [
         (0, "base", "A"),
         (8, "m_b0", "int"),
     ]
-    assert components_of(component(leaf, 12)) == [
+    assert components_of(component(class_d, 12)) == [
         (0, "base", "A"),
         (8, "m_c0", "int"),
     ]
@@ -101,10 +105,12 @@ def test_base_offsets_are_not_a_sum_of_sizes(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("base-padding")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "base", "A"),
         (4, "base_B", "B"),
         (16, "base_C", "C"),
@@ -112,9 +118,9 @@ def test_base_offsets_are_not_a_sum_of_sizes(type_helper: GhidraTypeTestHelper):
     ]
 
     # Structs created for each parent do not include padding.
-    assert component(leaf, 0).getLength() == 1
-    assert component(leaf, 4).getLength() == 8
-    assert component(leaf, 16).getLength() == 8
+    assert component(class_d, 0).getLength() == 1
+    assert component(class_d, 4).getLength() == 8
+    assert component(class_d, 16).getLength() == 8
 
 
 def test_slim_vbase_at_offset_zero(type_helper: GhidraTypeTestHelper):
@@ -130,18 +136,20 @@ def test_slim_vbase_at_offset_zero(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-simple")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 20
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 20
+    assert components_of(class_c) == [
         (0, "base", "B_vbase_slim"),
         (8, "m_c0", "int"),
         # A?
     ]
 
-    slim = component(leaf, 0)
-    assert slim.getLength() == 8
-    assert components_of(slim) == [
+    slim_b = component(class_c, 0)
+    assert slim_b.getLength() == 8
+    assert components_of(slim_b) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_b0", "int"),
     ]
@@ -152,7 +160,7 @@ def test_slim_vbase_at_offset_zero(type_helper: GhidraTypeTestHelper):
 
     # Although they have the same members, the full-size B and the slim B are different types.
     # (Full-size B should have members from A, but does not due to the acknowledged vbtable limitation.)
-    assert class_b != slim
+    assert class_b != slim_b
 
     assert class_b.getLength() == 16
     assert components_of(class_b) == [
@@ -176,24 +184,26 @@ def test_slim_vbase_as_first_base(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-first-base")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "base", "B_vbase_slim"),
         (8, "base_C", "C"),
         (20, "m_d0", "int"),
         # A?
     ]
 
-    slim_b = component(leaf, 0)
+    slim_b = component(class_d, 0)
     assert slim_b.getLength() == 8
     assert components_of(slim_b) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_b0", "int"),
     ]
 
-    class_c = component(leaf, 8)
+    class_c = component(class_d, 8)
     assert class_c.getLength() == 12
     assert components_of(class_c) == [
         (0, "m_c0", "int"),
@@ -217,17 +227,19 @@ def test_slim_vbase_at_nonzero_offset(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-second-base")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "base", "B"),
         (12, "base_C_vbase_slim", "C_vbase_slim"),
         (20, "m_d0", "int"),
         # A?
     ]
 
-    class_b = component(leaf, 0)
+    class_b = component(class_d, 0)
     assert class_b.getLength() == 12
     assert components_of(class_b) == [
         (0, "m_b0", "int"),
@@ -235,7 +247,7 @@ def test_slim_vbase_at_nonzero_offset(type_helper: GhidraTypeTestHelper):
         (8, "m_b2", "int"),
     ]
 
-    slim_c = component(leaf, 12)
+    slim_c = component(class_d, 12)
     assert slim_c.getLength() == 8
     assert components_of(slim_c) == [
         (0, "vbase_offset", "VBasePtr *"),
@@ -256,23 +268,25 @@ def test_slim_base_ends_at_last_member(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-alignment")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert components_of(leaf) == [
+    assert components_of(class_c) == [
         (0, "base", "B_vbase_slim"),
         (12, "m_c0", "char"),
         # A?
     ]
 
-    assert leaf.getLength() == 32
+    assert class_c.getLength() == 32
 
-    slim = component(leaf, 0)
-    assert components_of(slim) == [
+    slim_b = component(class_c, 0)
+    assert components_of(slim_b) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_b0", "int"),
         (8, "m_b1", "char"),
     ]
-    assert slim.getLength() == 9
+    assert slim_b.getLength() == 9
 
 
 def test_diamond_shares_one_virtual_base(type_helper: GhidraTypeTestHelper):
@@ -289,22 +303,24 @@ def test_diamond_shares_one_virtual_base(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("diamond-virtual")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 28
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 28
+    assert components_of(class_d) == [
         (0, "base", "B_vbase_slim"),
         (8, "base_C_vbase_slim", "C_vbase_slim"),
         (16, "m_d0", "int"),
     ]
 
-    slim_b = component(leaf, 0)
+    slim_b = component(class_d, 0)
     assert components_of(slim_b) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_b0", "int"),
     ]
 
-    slim_c = component(leaf, 8)
+    slim_c = component(class_d, 8)
     assert components_of(slim_c) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_c0", "int"),
@@ -339,18 +355,20 @@ def test_direct_virtual_base_at_nonzero_vbpoff(type_helper: GhidraTypeTestHelper
     """
     sample = load_cvdump_sample("vbase-after-base")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 28
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 28
+    assert components_of(class_c) == [
         (0, "base", "B"),
         (12, "vbase_offset", "VBasePtr *"),
         (16, "m_c0", "int"),
     ]
 
-    assert component(leaf, 0).getLength() == 12
+    assert component(class_c, 0).getLength() == 12
 
-    vbase_ptr = dereference(component(leaf, 12))
+    vbase_ptr = dereference(component(class_c, 12))
     assert components_of(vbase_ptr) == [
         (0, "o_self", "C *"),
         (4, "o_A", "APtrOffset"),
@@ -368,17 +386,19 @@ def test_vbaseptr_slots_for_two_virtual_bases(type_helper: GhidraTypeTestHelper)
     """
     sample = load_cvdump_sample("vbase-two")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 20
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 20
+    assert components_of(class_c) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_c0", "int"),
         # A?
         # B?
     ]
 
-    vbase_ptr = dereference(component(leaf, 0))
+    vbase_ptr = dereference(component(class_c, 0))
     assert components_of(vbase_ptr) == [
         (0, "o_self", "C *"),
         (4, "o_A", "APtrOffset"),
@@ -399,10 +419,12 @@ def test_chained_virtual_bases(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-chain")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "vbase_offset", "VBasePtr *"),
         (4, "m_d0", "int"),
         # A?
@@ -410,7 +432,7 @@ def test_chained_virtual_bases(type_helper: GhidraTypeTestHelper):
         # C?
     ]
 
-    vbase_ptr = dereference(component(leaf, 0))
+    vbase_ptr = dereference(component(class_d, 0))
     assert components_of(vbase_ptr) == [
         (0, "o_self", "D *"),
         (4, "o_A", "APtrOffset"),
@@ -432,18 +454,20 @@ def test_slim_vbase_with_vftable(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-vftable")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 24
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 24
+    assert components_of(class_c) == [
         (0, "base", "B_vbase_slim"),
         (12, "m_c0", "int"),
         # A?
     ]
 
-    slim = component(leaf, 0)
-    assert slim.getLength() == 12
-    assert components_of(slim) == [
+    slim_b = component(class_c, 0)
+    assert slim_b.getLength() == 12
+    assert components_of(slim_b) == [
         (0, "vftable", "void *"),
         (4, "vbase_offset", "VBasePtr *"),
         (8, "m_b0", "int"),
@@ -465,21 +489,23 @@ def test_multiple_inheritance_with_virtual_functions(
     """
     sample = load_cvdump_sample("multiple-inheritance-virtual-functions")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-c"))
+    class_c = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-c")
+    )
 
-    assert leaf.getLength() == 24
-    assert components_of(leaf) == [
+    assert class_c.getLength() == 24
+    assert components_of(class_c) == [
         (0, "base", "A"),
         (12, "base_B", "B"),
         (20, "m_c0", "int"),
     ]
 
-    assert components_of(component(leaf, 0)) == [
+    assert components_of(component(class_c, 0)) == [
         (0, "vftable", "void *"),
         (4, "m_a0", "int"),
         (8, "m_a1", "int"),
     ]
-    assert components_of(component(leaf, 12)) == [
+    assert components_of(component(class_c, 12)) == [
         (0, "vftable", "void *"),
         (4, "m_b0", "int"),
     ]
@@ -505,10 +531,12 @@ def test_padding_between_two_virtual_bases(type_helper: GhidraTypeTestHelper):
     """
     sample = load_cvdump_sample("vbase-padding")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "vbase_offset", "VBasePtr *"),
         (8, "m_d0", "double"),
         (16, "vbase_B", "B"),
@@ -532,10 +560,12 @@ def test_no_padding_between_two_virtual_bases(type_helper: GhidraTypeTestHelper)
     """
     sample = load_cvdump_sample("vbase-padding-packed")
     type_helper.set_up_cvdump_types(sample.text)
-    leaf = type_helper.type_importer.import_pdb_type_into_ghidra(sample.key("class-d"))
+    class_d = type_helper.type_importer.import_pdb_type_into_ghidra(
+        sample.key("class-d")
+    )
 
-    assert leaf.getLength() == 32
-    assert components_of(leaf) == [
+    assert class_d.getLength() == 32
+    assert components_of(class_d) == [
         (0, "vbase_offset", "VBasePtr *"),
         (8, "m_d0", "double"),
         (16, "vbase_B", "B"),

--- a/tests/test_ghidra_integration_inheritance.py
+++ b/tests/test_ghidra_integration_inheritance.py
@@ -38,6 +38,8 @@ import pytest
 from .cvdump_sample import load_cvdump_sample
 from .ghidra_integration_test_setup import (
     GhidraTypeTestHelper,
+)
+from .ghidra_helpers import (
     component,
     components_of,
     dereference,


### PR DESCRIPTION
Part of #106. The Ghidra importer uses the structures from the types db directly. I want to push these behind an API so we can swap out the mechanism that loads debug artifacts. But we need more tests first.

Claude created these sample .cpp files with various inheritance patterns. I compiled each one and generated the cvdump `TYPES` output with both MSVC 4.2 and 6. (They were identical.) The docstrings and comments are all mine. One of my goals for doing this was to understand how this works and why we can't assume the location of the indirect virtual base class without reading the `vbtable`. (Certainly doable in a follow-up.)

This corrects an "issue" where we created slim copies of base classes where this was not necessary. (I say "issue" because there was not an observable difference.) For example: if class D has base classes B and C, but only B uses virtual inheritance, we do not need a slim copy of C.