### PR TITLE
Allow LINE markers inside function bodies again

### DIFF
--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -411,6 +411,7 @@ class DecompParser:
         if self.state == ReaderState.IN_FUNC and marker.type not in (
             MarkerType.GLOBAL,
             MarkerType.STRING,
+            MarkerType.LINE,
         ):
             self._syntax_warning(AlertCode.MISSED_END_OF_FUNCTION)
             self._function_done(unexpected=True)

--- a/reccmp/parser/parser.py
+++ b/reccmp/parser/parser.py
@@ -208,6 +208,10 @@ class DecompParser:
     def strings(self) -> list[ParserString]:
         return [s for s in self._symbols if isinstance(s, ParserString)]
 
+    @property
+    def lines(self) -> list[ParserLineSymbol]:
+        return [s for s in self._symbols if isinstance(s, ParserLineSymbol)]
+
     def iter_symbols(self, module: str | None = None) -> Iterator[ParserSymbol]:
         for s in self._symbols:
             if module is None or s.module == module:

--- a/tests/test_parser_line_number.py
+++ b/tests/test_parser_line_number.py
@@ -291,3 +291,4 @@ def test_function_with_line_marker_inside(parser: DecompParser):
     assert len(parser.alerts) == 0
     assert parser.functions[0].line_number == 2
     assert parser.functions[0].end_line == 6
+    assert parser.lines[0].line_number == 4

--- a/tests/test_parser_line_number.py
+++ b/tests/test_parser_line_number.py
@@ -275,3 +275,19 @@ def test_string_line_continuation(parser: DecompParser):
     assert parser.strings[0].line_number == 2
     # TODO: enable when end_line is added
     # assert parser.strings[0].end_line == 3
+
+
+def test_function_with_line_marker_inside(parser: DecompParser):
+    """A LINE marker inside a function body belongs to that function
+    and must not end function tracking or produce a warning."""
+    parser.read(dedent("""\
+        // FUNCTION: TEST 0x1234
+        void test()
+        {
+            // LINE: TEST 0x1250
+            do_the_thing();
+        }
+        """))
+    assert len(parser.alerts) == 0
+    assert parser.functions[0].line_number == 2
+    assert parser.functions[0].end_line == 6


### PR DESCRIPTION
The #510 refactor replaced `marker.allowed_in_func()` with an inline tuple but dropped `MarkerType.LINE` from the set. A `// LINE:` marker inside a function body now raises a spurious `missed_end_of_function` warning and ends function tracking early, truncating the function's `end_line`.

Example from isle (`LEGO1/viewmanager/viewmanager.cpp`), which now fails `reccmp-decomplint --warnfail`:

```
 483 :  warning: missed_end_of_function  // LINE: BETA10 0x10172bbd
```

This restores `LINE` to the allowed set (the pre-#510 behavior) and adds a regression test asserting no alert and an intact `end_line`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015P88DB9e4CuwhuVz46toNb