### PR TITLE
Bugfix: L-strings in code get `WIDECHAR` type

### DIFF
--- a/reccmp/compare/ingest.py
+++ b/reccmp/compare/ingest.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from reccmp.formats.exceptions import (
     InvalidStringError,
 )
-from reccmp.formats import PEImage, TextFile
+from reccmp.formats import Image, PEImage, TextFile
 from reccmp.cvdump import CvdumpTypesParser, CvdumpAnalysis
 from reccmp.parser import DecompCodebase
 from reccmp.parser.marker import ProjectAliases
@@ -148,7 +148,7 @@ def load_cvdump_lines(
 def load_markers(
     code_files: Sequence[TextFile],
     lines_db: LinesDb,
-    orig_bin: PEImage,
+    orig_bin: Image,
     target_id: str,
     db: EntityDb,
     encoding: str = "latin1",
@@ -288,7 +288,7 @@ def load_markers(
                 ImageId.ORIG,
                 string.offset,
                 name=entity_name_from_string(string.name, wide=string.is_widechar),
-                type=EntityType.STRING,
+                type=EntityType.WIDECHAR if string.is_widechar else EntityType.STRING,
                 size=string_size,
                 verified=True,
             )

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -434,13 +434,13 @@ def test_load_code_widechar_with_trailing_nulls(db: EntityDb, lines_db: LinesDb)
 
 def test_load_code_string_with_internal_nulls(db: EntityDb, lines_db: LinesDb):
     """Should read a string with nulls included."""
-    image = RawImage.from_memory(b"Te\x00st\x00", base_addr=0x10000000)
+    image = RawImage.from_memory(b"aa\x00bb\x00", base_addr=0x10000000)
     files = (
         TextFile(
             PurePath("test.cpp"),
             dedent("""\
                 // STRING: TEST 0x10000000
-                char* nullstr = "Te\\0st";
+                char* nullstr = "aa\\0bb";
                 """),
         ),
     )
@@ -450,20 +450,20 @@ def test_load_code_string_with_internal_nulls(db: EntityDb, lines_db: LinesDb):
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
     assert entity.any_size() == 6
-    assert entity.get("name") == '"Te\\x00st"'
+    assert entity.get("name") == '"aa\\x00bb"'
 
 
 def test_load_code_widechar_with_internal_nulls(db: EntityDb, lines_db: LinesDb):
     """Should read a widechar string with nulls included."""
     image = RawImage.from_memory(
-        "Te\x00st".encode("utf-16-le") + b"\x00\x00", base_addr=0x10000000
+        "aa\x00bb".encode("utf-16-le") + b"\x00\x00", base_addr=0x10000000
     )
     files = (
         TextFile(
             PurePath("test.cpp"),
             dedent("""\
                 // STRING: TEST 0x10000000
-                char* nullstr = L"Te\\0st";
+                char* nullstr = L"aa\\0bb";
                 """),
         ),
     )
@@ -473,7 +473,7 @@ def test_load_code_widechar_with_internal_nulls(db: EntityDb, lines_db: LinesDb)
     assert entity is not None
     assert entity.get("type") == EntityType.WIDECHAR
     assert entity.any_size() == 12
-    assert entity.get("name") == 'L"Te\\x00st"'
+    assert entity.get("name") == 'L"aa\\x00bb"'
 
 
 def test_load_code_widechar_invalid(db: EntityDb, lines_db: LinesDb, binfile: PEImage):

--- a/tests/test_compare_ingest_code.py
+++ b/tests/test_compare_ingest_code.py
@@ -9,6 +9,7 @@ from reccmp.formats import PEImage, TextFile
 from reccmp.compare.ingest import load_markers
 from reccmp.compare.db import EntityDb
 from reccmp.compare.lines import LinesDb
+from .raw_image import RawImage
 
 
 @pytest.fixture(name="db")
@@ -352,7 +353,7 @@ def test_load_code_widechar(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
 
     entity = db.get(ImageId.ORIG, 0x100DAAA0)
     assert entity is not None
-    assert entity.get("type") == EntityType.STRING
+    assert entity.get("type") == EntityType.WIDECHAR
     assert entity.any_size() == 14
     assert entity.get("name") == 'L"(null)"'
 
@@ -387,25 +388,92 @@ def test_read_gb2312_string(db: EntityDb, lines_db: LinesDb):
     assert entity.name == f'"{string_text}"'.encode("unicode_escape").decode()
 
 
-def test_load_code_string_with_nulls(db: EntityDb, lines_db: LinesDb, binfile: PEImage):
-    """Should read string with nulls included.
-    Using the unicode string '(null)' from the above example."""
+def test_load_code_string_with_trailing_nulls(db: EntityDb, lines_db: LinesDb):
+    """Should read string with trailing nulls and report its exact length."""
+    image = RawImage.from_memory(b"Test\x00\x00", base_addr=0x10000000)
     files = (
         TextFile(
             PurePath("test.cpp"),
             dedent("""\
-                // STRING: TEST 0x100daaa0
-                char* nullstr = "(\\x00n\\x00u\\x00l\\x00l\\x00)";
+                // STRING: TEST 0x10000000
+                char* test = "Test\\0";
                 """),
         ),
     )
-    load_markers(files, lines_db, binfile, "TEST", db)
+    load_markers(files, lines_db, image, "TEST", db)
 
-    entity = db.get(ImageId.ORIG, 0x100DAAA0)
+    entity = db.get(ImageId.ORIG, 0x10000000)
     assert entity is not None
     assert entity.get("type") == EntityType.STRING
+    assert entity.any_size() == 6
+    assert entity.get("name") == '"Test\\x00"'
+
+
+def test_load_code_widechar_with_trailing_nulls(db: EntityDb, lines_db: LinesDb):
+    """Should read widechar string with trailing nulls and report its exact length."""
+    image = RawImage.from_memory(
+        "Test".encode("utf-16-le") + b"\x00\x00\x00\x00", base_addr=0x10000000
+    )
+    files = (
+        TextFile(
+            PurePath("test.cpp"),
+            dedent("""\
+                // STRING: TEST 0x10000000
+                wchar_t* test = L"Test\\0";
+                """),
+        ),
+    )
+    load_markers(files, lines_db, image, "TEST", db)
+
+    entity = db.get(ImageId.ORIG, 0x10000000)
+    assert entity is not None
+    assert entity.get("type") == EntityType.WIDECHAR
     assert entity.any_size() == 12
-    assert entity.get("name") == '"(\\x00n\\x00u\\x00l\\x00l\\x00)"'
+    assert entity.get("name") == 'L"Test\\x00"'
+
+
+def test_load_code_string_with_internal_nulls(db: EntityDb, lines_db: LinesDb):
+    """Should read a string with nulls included."""
+    image = RawImage.from_memory(b"Te\x00st\x00", base_addr=0x10000000)
+    files = (
+        TextFile(
+            PurePath("test.cpp"),
+            dedent("""\
+                // STRING: TEST 0x10000000
+                char* nullstr = "Te\\0st";
+                """),
+        ),
+    )
+    load_markers(files, lines_db, image, "TEST", db)
+
+    entity = db.get(ImageId.ORIG, 0x10000000)
+    assert entity is not None
+    assert entity.get("type") == EntityType.STRING
+    assert entity.any_size() == 6
+    assert entity.get("name") == '"Te\\x00st"'
+
+
+def test_load_code_widechar_with_internal_nulls(db: EntityDb, lines_db: LinesDb):
+    """Should read a widechar string with nulls included."""
+    image = RawImage.from_memory(
+        "Te\x00st".encode("utf-16-le") + b"\x00\x00", base_addr=0x10000000
+    )
+    files = (
+        TextFile(
+            PurePath("test.cpp"),
+            dedent("""\
+                // STRING: TEST 0x10000000
+                char* nullstr = L"Te\\0st";
+                """),
+        ),
+    )
+    load_markers(files, lines_db, image, "TEST", db)
+
+    entity = db.get(ImageId.ORIG, 0x10000000)
+    assert entity is not None
+    assert entity.get("type") == EntityType.WIDECHAR
+    assert entity.any_size() == 12
+    assert entity.get("name") == 'L"Te\\x00st"'
 
 
 def test_load_code_widechar_invalid(db: EntityDb, lines_db: LinesDb, binfile: PEImage):


### PR DESCRIPTION
My intent in #264 was for `L""` code strings to get the `EntityType.WIDECHAR`. We assigned the `STRING` type instead.

This may not have presented as a bug in any way because `match_strings` doesn't use the type. It only looks at the entity name, which _was_ created correctly with the `L` prefix for widechars in `entity_name_from_string`. So we were still able to match widechar strings marked in code, and nothing should have been matched incorrectly.

While we are here: add more tests to confirm that a string with explicit `\0` nulls has its entity size and name set correctly. (from review of #525.)

Rather than try to find bytes in `LEGO1.DLL` that will work for the new tests, I used `RawImage`. (See #519.)

