### PR TITLE
Match CRT functions by a unique call

### DIFF
--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -135,7 +135,7 @@ def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
 
 
 def get_function_fingerprint(
-    db: EntityDb, image_id: ImageId, binfile: PEImage, addr: int
+    db: EntityDb, image_id: ImageId, binfile: Image, addr: int
 ) -> tuple[UsedAddress, ...]:
     """Create lists of addresses written to and read from by this function.
     Filter the addresses that point to a matched variable entity.

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -49,7 +49,7 @@ def get_crt_function_name(type_: CrtStartupArrayType) -> str:
 class UsedHow(enum.Enum):
     READ = enum.auto()
     WRITE = enum.auto()
-    EXEC = enum.auto()
+    CALL = enum.auto()
 
 
 UsedAddress = tuple[int, UsedHow]
@@ -106,7 +106,7 @@ class UsedAddressCollector:
                         continue
 
                     if inst_mnemonic in ("call",):
-                        self._append_addrs(inst_op_str, UsedHow.EXEC)
+                        self._append_addrs(inst_op_str, UsedHow.CALL)
                         # self._append_addrs(inst_op_str, UsedHow.READ)
                     elif inst_mnemonic in ("mov", "fstp"):
                         dst_operand, _, src_operand = inst_op_str.partition(", ")

--- a/reccmp/analysis/crt_startup.py
+++ b/reccmp/analysis/crt_startup.py
@@ -46,7 +46,13 @@ def get_crt_function_name(type_: CrtStartupArrayType) -> str:
     return _CRT_FUNCTION_NAMES[type_]
 
 
-UsedAddress = tuple[int, bool]
+class UsedHow(enum.Enum):
+    READ = enum.auto()
+    WRITE = enum.auto()
+    EXEC = enum.auto()
+
+
+UsedAddress = tuple[int, UsedHow]
 
 
 @dataclass
@@ -80,11 +86,11 @@ class UsedAddressCollector:
         self.is_entity = is_entity
         self.seen_addrs = []
 
-    def _append_addrs(self, text: str, is_write: bool):
+    def _append_addrs(self, text: str, used_how: UsedHow):
         for hex_str in ADDR_REGEX.findall(text):
             addr = int(hex_str, 16)
             if self.is_entity(addr):
-                self.seen_addrs.append((addr, is_write))
+                self.seen_addrs.append((addr, used_how))
 
     def analyze(self, data: Buffer, start_addr: int):
         ig = InstructGen(bytes(data), start_addr, True)
@@ -99,12 +105,15 @@ class UsedAddressCollector:
                     if inst_mnemonic in JUMP_MNEMONICS:
                         continue
 
-                    if inst_mnemonic in ("mov", "fstp"):
+                    if inst_mnemonic in ("call",):
+                        self._append_addrs(inst_op_str, UsedHow.EXEC)
+                        # self._append_addrs(inst_op_str, UsedHow.READ)
+                    elif inst_mnemonic in ("mov", "fstp"):
                         dst_operand, _, src_operand = inst_op_str.partition(", ")
-                        self._append_addrs(dst_operand, True)
-                        self._append_addrs(src_operand, False)
+                        self._append_addrs(dst_operand, UsedHow.WRITE)
+                        self._append_addrs(src_operand, UsedHow.READ)
                     else:
-                        self._append_addrs(inst_op_str, False)
+                        self._append_addrs(inst_op_str, UsedHow.READ)
 
 
 def get_function_sample_size(db: EntityDb, image_id: ImageId, addr: int) -> int:
@@ -139,14 +148,18 @@ def get_function_fingerprint(
     collector.analyze(raw, addr)
 
     normalized_addrs = []
-    for sample_addr, is_write in collector.seen_addrs:
+    for sample_addr, used_how in collector.seen_addrs:
         ent = db.get(image_id, sample_addr)
         # Only matched entities are candidates for the fingerprint
         # because we have an address in both address spaces.
-        if ent and ent.matched and ent.get("type") == EntityType.DATA:
+        if (
+            ent
+            and ent.matched
+            and ent.get("type") in (EntityType.FUNCTION, EntityType.DATA)
+        ):
             normalized_addr = ent.addr(ImageId.ORIG)
             assert isinstance(normalized_addr, int)
-            normalized_addrs.append((normalized_addr, is_write))
+            normalized_addrs.append((normalized_addr, used_how))
 
     return tuple(normalized_addrs)
 

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -8,6 +8,7 @@ from reccmp.analysis.crt_startup import (
     CrtStartupArray,
     create_crt_matches,
     UsedAddressCollector,
+    UsedHow,
     unwrap_jump,
 )
 from reccmp.compare.db import EntityDb
@@ -44,7 +45,7 @@ def test_get_function_fingerprint_matched(binfile: PEImage):
         batch.match(G_MUTEX_ADDR, G_MUTEX_ADDR)
 
     assert get_function_fingerprint(db, ImageId.ORIG, binfile, SET_DO_MUTEX_ADDR) == (
-        (G_MUTEX_ADDR, True),
+        (G_MUTEX_ADDR, UsedHow.WRITE),
     )
 
 
@@ -118,7 +119,7 @@ def test_xca_fingerprints_matched_variable(binfile: PEImage):
 
     array = read_crt_functions(binfile, XCA_XCZ_RANGE)
     fingerprint_crt_functions(db, ImageId.ORIG, binfile, array)
-    assert array.functions[0x1001A6D0] == ((0x10102B28, False),)
+    assert array.functions[0x1001A6D0] == ((0x10102B28, UsedHow.READ),)
 
 
 def test_xca_fingerprints_avoid_crash(binfile: PEImage):
@@ -140,7 +141,7 @@ def test_create_match_baseline():
 
 def test_create_match_single():
     """Should create match for unique fingerprint."""
-    write_sample = (1234, True)
+    write_sample = (1234, UsedHow.WRITE)
     x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={})
     y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={})
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
@@ -148,7 +149,7 @@ def test_create_match_single():
 
 def test_create_match_single_with_thunks_one_sided():
     """Should not add thunk match unless it exists in both arrays."""
-    write_sample = (1234, True)
+    write_sample = (1234, UsedHow.WRITE)
     x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={100: 500})
     y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={})
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
@@ -156,7 +157,7 @@ def test_create_match_single_with_thunks_one_sided():
 
 def test_create_match_single_with_thunks_two_sided():
     """Should match function and thunk."""
-    write_sample = (1234, True)
+    write_sample = (1234, UsedHow.WRITE)
     x_array = CrtStartupArray(functions={100: (write_sample,)}, thunks={100: 500})
     y_array = CrtStartupArray(functions={200: (write_sample,)}, thunks={200: 600})
     assert create_crt_matches(x_array, y_array) == [(100, 200), (500, 600)]
@@ -171,7 +172,7 @@ def test_create_match_blank_fingerprint():
 
 def test_create_match_non_unique_fingerprint():
     """Should not match functions if their fingerprint is not unique."""
-    write_sample = (1234, True)
+    write_sample = (1234, UsedHow.WRITE)
     x_array = CrtStartupArray(
         functions={100: (write_sample,), 200: (write_sample,)}, thunks={}
     )
@@ -183,8 +184,8 @@ def test_create_match_non_unique_fingerprint():
 
 def test_create_match_with_elimination():
     """Can create unique matches by eliminating already-matched functions."""
-    write_sample = (1234, True)
-    read_sample = (5000, False)
+    write_sample = (1234, UsedHow.WRITE)
+    read_sample = (5000, UsedHow.READ)
     # `write_sample` can be used to match uniquely on the first pass.
     # `read_sample` will provide a unique match after deleting the functions that contain `write_sample`.
     x_array = CrtStartupArray(
@@ -216,8 +217,8 @@ def test_collector_small_addrs_ignored():
     collector.analyze(code, 0)
 
     assert collector.seen_addrs == [
-        (0x400000, True),
-        (0x10000000, True),
+        (0x400000, UsedHow.WRITE),
+        (0x10000000, UsedHow.WRITE),
     ]
 
 
@@ -235,9 +236,9 @@ def test_collector_repeated_addrs():
     collector.analyze(code, 0)
 
     assert collector.seen_addrs == [
-        (0x400000, True),
-        (0x400000, True),
-        (0x400000, False),
+        (0x400000, UsedHow.WRITE),
+        (0x400000, UsedHow.WRITE),
+        (0x400000, UsedHow.READ),
     ]
 
 
@@ -255,9 +256,9 @@ def test_collector_classify_float_instructions_as_read_or_write():
     collector.analyze(code, 0)
 
     assert collector.seen_addrs == [
-        (0x401000, False),
-        (0x402000, False),
-        (0x403000, True),
+        (0x401000, UsedHow.READ),
+        (0x402000, UsedHow.READ),
+        (0x403000, UsedHow.WRITE),
     ]
 
 
@@ -272,14 +273,13 @@ def test_collector_not_all_dst_operands_are_writes():
     collector.analyze(code, 0)
 
     assert collector.seen_addrs == [
-        (0x400000, False),
-        (0x410000, False),
+        (0x400000, UsedHow.READ),
+        (0x410000, UsedHow.READ),
     ]
 
 
 def test_collector_calls_and_jumps():
-    """Jumps are ignored. Calls are collected as read addresses.
-    (We may choose to classify them differently in the future.)"""
+    """Jumps are ignored. Calls are collected as exec addresses."""
     code = (
         b"\xe8\xfb\x0f\x00\x00"  # call 0x401000
         b"\xe9\xf6\x1f\x00\x00"  # jmp 0x402000
@@ -291,7 +291,7 @@ def test_collector_calls_and_jumps():
     collector.analyze(code, 0x400000)
 
     assert collector.seen_addrs == [
-        (0x401000, False),
+        (0x401000, UsedHow.EXEC),
     ]
 
 

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -66,7 +66,7 @@ def test_get_function_fingerprint_called_function():
         batch.match(other_addr, other_addr)
 
     assert get_function_fingerprint(db, ImageId.ORIG, binfile, start_addr) == (
-        (other_addr, UsedHow.EXEC),
+        (other_addr, UsedHow.CALL),
     )
 
 
@@ -216,7 +216,7 @@ def test_create_match_single():
 
 def test_create_match_single_call():
     """Should create match for a unique function call."""
-    call_sample = (1234, UsedHow.EXEC)
+    call_sample = (1234, UsedHow.CALL)
     x_array = CrtStartupArray(functions={100: (call_sample,)}, thunks={})
     y_array = CrtStartupArray(functions={200: (call_sample,)}, thunks={})
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
@@ -226,7 +226,7 @@ def test_create_match_call_is_not_a_read():
     """Should not match a function that calls the address with one that
     only reads it. e.g. passing the function pointer as an argument."""
     x_array = CrtStartupArray(functions={100: ((1234, UsedHow.READ),)}, thunks={})
-    y_array = CrtStartupArray(functions={200: ((1234, UsedHow.EXEC),)}, thunks={})
+    y_array = CrtStartupArray(functions={200: ((1234, UsedHow.CALL),)}, thunks={})
     assert not create_crt_matches(x_array, y_array)
 
 
@@ -371,7 +371,7 @@ def test_collector_calls_and_jumps():
     collector.analyze(code, 0x400000)
 
     assert collector.seen_addrs == [
-        (0x401000, UsedHow.EXEC),
+        (0x401000, UsedHow.CALL),
     ]
 
 

--- a/tests/test_analysis_crt_startup.py
+++ b/tests/test_analysis_crt_startup.py
@@ -49,6 +49,73 @@ def test_get_function_fingerprint_matched(binfile: PEImage):
     )
 
 
+def test_get_function_fingerprint_called_function():
+    """Called functions appear as CALLs in the fingerprint list."""
+    start_addr = 0x400000
+    other_addr = 0x401000
+    code = (
+        b"\xe8\xfb\x0f\x00\x00"  # call 0x401000
+        b"\xc3"  # ret
+    )
+    binfile = RawImage.from_memory(code, base_addr=start_addr)
+
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, start_addr, size=len(code))
+        batch.set(ImageId.ORIG, other_addr, name="test", type=EntityType.FUNCTION)
+        batch.match(other_addr, other_addr)
+
+    assert get_function_fingerprint(db, ImageId.ORIG, binfile, start_addr) == (
+        (other_addr, UsedHow.EXEC),
+    )
+
+
+def test_get_function_fingerprint_function_pointer():
+    """Function entities that are not used in a call instruction appear as
+    READ entries in the fingerprint list."""
+    start_addr = 0x400000
+    other_addr = 0x401000
+    code = (
+        b"\x68\x00\x10\x40\x00"  # push 0x401000
+        b"\xc3"  # ret
+    )
+    binfile = RawImage.from_memory(code, base_addr=start_addr)
+
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, start_addr, size=len(code))
+        batch.set(ImageId.ORIG, other_addr, name="test", type=EntityType.FUNCTION)
+        batch.match(other_addr, other_addr)
+
+    assert get_function_fingerprint(db, ImageId.ORIG, binfile, start_addr) == (
+        (other_addr, UsedHow.READ),
+    )
+
+
+@pytest.mark.xfail(reason="Undecided on whether we need this")
+def test_get_function_fingerprint_indirect_call():
+    """Indirect function calls should have their own fingerprint category
+    that is distinct from regular calls."""
+    start_addr = 0x400000
+    other_addr = 0x401000
+    pointer = other_addr.to_bytes(4, "little")
+    code = (
+        b"\xff\x15\x00\x00\x40\x00"  # call dword ptr [0x400000]
+        b"\xc3"  # ret
+    )
+    binfile = RawImage.from_memory(pointer + code, base_addr=start_addr)
+    func_addr = start_addr + len(pointer)
+
+    db = EntityDb()
+    with db.batch() as batch:
+        batch.set(ImageId.ORIG, func_addr, size=len(code))
+        batch.set(ImageId.ORIG, other_addr, name="test", type=EntityType.FUNCTION)
+        batch.match(other_addr, other_addr)
+
+    # TODO: Add the fingerprints here if this feature is added.
+    assert get_function_fingerprint(db, ImageId.ORIG, binfile, func_addr)
+
+
 XCA_XCZ_RANGE = range(0x100F0000, 0x100F0020)
 
 
@@ -147,6 +214,22 @@ def test_create_match_single():
     assert create_crt_matches(x_array, y_array) == [(100, 200)]
 
 
+def test_create_match_single_call():
+    """Should create match for a unique function call."""
+    call_sample = (1234, UsedHow.EXEC)
+    x_array = CrtStartupArray(functions={100: (call_sample,)}, thunks={})
+    y_array = CrtStartupArray(functions={200: (call_sample,)}, thunks={})
+    assert create_crt_matches(x_array, y_array) == [(100, 200)]
+
+
+def test_create_match_call_is_not_a_read():
+    """Should not match a function that calls the address with one that
+    only reads it. e.g. passing the function pointer as an argument."""
+    x_array = CrtStartupArray(functions={100: ((1234, UsedHow.READ),)}, thunks={})
+    y_array = CrtStartupArray(functions={200: ((1234, UsedHow.EXEC),)}, thunks={})
+    assert not create_crt_matches(x_array, y_array)
+
+
 def test_create_match_single_with_thunks_one_sided():
     """Should not add thunk match unless it exists in both arrays."""
     write_sample = (1234, UsedHow.WRITE)
@@ -170,15 +253,12 @@ def test_create_match_blank_fingerprint():
     assert not create_crt_matches(x_array, y_array)
 
 
-def test_create_match_non_unique_fingerprint():
+@pytest.mark.parametrize("used_how", UsedHow)
+def test_create_match_non_unique_fingerprint(used_how: UsedHow):
     """Should not match functions if their fingerprint is not unique."""
-    write_sample = (1234, UsedHow.WRITE)
-    x_array = CrtStartupArray(
-        functions={100: (write_sample,), 200: (write_sample,)}, thunks={}
-    )
-    y_array = CrtStartupArray(
-        functions={200: (write_sample,), 300: (write_sample,)}, thunks={}
-    )
+    sample = (1234, used_how)
+    x_array = CrtStartupArray(functions={100: (sample,), 200: (sample,)}, thunks={})
+    y_array = CrtStartupArray(functions={200: (sample,), 300: (sample,)}, thunks={})
     assert not create_crt_matches(x_array, y_array)
 
 


### PR DESCRIPTION
c.f. #526. Matches the last CRT function in `LEGO1`.

This differentiates calls from reads or writes. A function pointer pushed as an argument won't match with that same function being called in another slot of the CRT array. The function must be used once across the entire CRT array in order to match, so we could not match with a constructor used in multiple spots.

I added an xfail test for indirect calls (i.e. imports) but did not add the feature yet. We also do not match if the calls are to vtordisp or thunk functions, only functions that are `EntityType.FUNCTION`. These are probably fine to add, but were not needed for `LEGO1` so I left them out.