### PR TITLE
Fix Ghidra tests: install python3-dev package

### DIFF
--- a/.github/workflows/unittest-ghidra.yml
+++ b/.github/workflows/unittest-ghidra.yml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
       run: |
         apt-get update
-        apt-get -y install python3 python3-pip python3-venv build-essential
+        apt-get -y install python3 python3-pip python3-venv python3-dev build-essential
         python3 -m venv .venv
 
     - name: Install python libraries


### PR DESCRIPTION
The error is:
```
2026-09-02T01:21:11.0999253Z       In file included from native/common/include/jpype.h:178,
2026-09-02T01:21:11.0999925Z                        from native/common/jp_array.cpp:16:
2026-09-02T01:21:11.1001050Z       native/python/include/jp_pythontypes.h:18:10: fatal error: Python.h: No such file or directory
2026-09-02T01:21:11.1001915Z          18 | #include <Python.h>
2026-09-02T01:21:11.1002357Z             |          ^~~~~~~~~~
2026-09-02T01:21:11.1002798Z       compilation terminated.
```
with the hint earlier in the run:
```
2026-09-02T01:20:51.5227283Z Recommended packages:
2026-09-02T01:20:51.5227511Z   python3-dev
```
so presumably something changed again in the container. (See also #351)