### PR TITLE
Read section names from string table if needed

### DIFF
--- a/reccmp/formats/pe.py
+++ b/reccmp/formats/pe.py
@@ -22,6 +22,20 @@ from .mz import ImageDosHeader
 # pylint: disable=too-many-lines
 
 
+PE_COFF_SYMBOL_SIZE = 18
+
+
+def extract_strz(data: bytes, offset: int) -> str:
+    if offset >= len(data):
+        raise IndexError
+    end = data.find(b"\x00", offset)
+    if end == -1:
+        name_bytes = data[offset:]
+    else:
+        name_bytes = data[offset:end]
+    return name_bytes.decode("ascii")
+
+
 class PEHeaderNotFoundError(ValueError):
     """PE magic string not found."""
 
@@ -307,6 +321,16 @@ class PESectionFlags(IntFlag):
     IMAGE_SCN_MEM_WRITE = 0x80000000
 
 
+def lookup_section_name(name: str, *, data: bytes, offset_names_table: int) -> str:
+    if name.startswith("/"):
+        try:
+            name_offset = int(name[1:])
+            name = extract_strz(data, offset_names_table + name_offset)
+        except (IndexError, ValueError):
+            pass
+    return name
+
+
 @dataclasses.dataclass(frozen=True)
 class PEImageSectionHeader:
     name: str
@@ -322,13 +346,17 @@ class PEImageSectionHeader:
 
     @classmethod
     def from_memory(
-        cls, data: bytes, offset: int, count: int
+        cls, data: bytes, offset: int, count: int, offset_names_table: int
     ) -> tuple[tuple["PEImageSectionHeader", ...], int]:
         struct_fmt = "<8s6I2HI"
         s_size = struct.calcsize(struct_fmt)
         items = tuple(
             cls(
-                members[0].decode("ascii").rstrip("\x00"),
+                lookup_section_name(
+                    members[0].decode("ascii").rstrip("\x00"),
+                    data=data,
+                    offset_names_table=offset_names_table,
+                ),
                 *members[1:-1],
                 PESectionFlags(members[-1]),
             )
@@ -496,8 +524,15 @@ class PEImage(Image):
         optional_header, offset_sections = PEImageOptionalHeader.from_memory(
             data, offset=offset_optional
         )
+        offset_names_table = (
+            header.pointer_to_symbol_table
+            + header.number_of_symbols * PE_COFF_SYMBOL_SIZE
+        )
         section_headers, _ = PEImageSectionHeader.from_memory(
-            data, count=header.number_of_sections, offset=offset_sections
+            data,
+            count=header.number_of_sections,
+            offset=offset_sections,
+            offset_names_table=offset_names_table,
         )
         sections = tuple(
             get_pe_sections(section_headers, optional_header.image_base, view)


### PR DESCRIPTION
The debug sections of MinGW executables are longer than 8 characters and are stored in the string table.
In the same way as is done in PE/COFF object files, this table is stored after the symbol table.

On a dummy MinGW executables, this changes the output of the following small program:
```python
import reccmp.formats

# /tmp/a.exe is a minimal MinGW executable
image = reccmp.formats.detect.detect_image("/tmp/a.exe")

for section in image.sections:
    print(
        f"{section.name:20} 0x{section.virtual_range.start:08x} 0x{section.virtual_range.stop-section.virtual_range.start:08x}"
    )
```

From:
```
.text                0x00401000 0x00001710
.data                0x00403000 0x00000034
.rdata               0x00404000 0x000009f0
/4                   0x00405000 0x000007f0
.bss                 0x00406000 0x000000b0
.idata               0x00407000 0x00000444
.tls                 0x00408000 0x00000008
.reloc               0x00409000 0x0000023c
/14                  0x0040a000 0x00000360
/29                  0x0040b000 0x0000b575
/41                  0x00417000 0x00001e0c
/55                  0x00419000 0x00001d15
/67                  0x0041b000 0x00000038
/80                  0x0041c000 0x0000035b
/91                  0x0041d000 0x00002141
/107                 0x00420000 0x00000b1d
/123                 0x00421000 0x00000185
```

To:
```
.text                0x00401000 0x00001710
.data                0x00403000 0x00000034
.rdata               0x00404000 0x000009f0
.eh_frame            0x00405000 0x000007f0
.bss                 0x00406000 0x000000b0
.idata               0x00407000 0x00000444
.tls                 0x00408000 0x00000008
.reloc               0x00409000 0x0000023c
.debug_aranges       0x0040a000 0x00000360
.debug_info          0x0040b000 0x0000b575
.debug_abbrev        0x00417000 0x00001e0c
.debug_line          0x00419000 0x00001d15
.debug_frame         0x0041b000 0x00000038
.debug_str           0x0041c000 0x0000035b
.debug_line_str      0x0041d000 0x00002141
.debug_loclists      0x00420000 0x00000b1d
.debug_rnglists      0x00421000 0x00000185
```